### PR TITLE
fix: [EL-4324] Fixed header components ui issues

### DIFF
--- a/src/[fsd]/entities/application-tab-bar/ui/ApplicationControls.jsx
+++ b/src/[fsd]/entities/application-tab-bar/ui/ApplicationControls.jsx
@@ -188,9 +188,18 @@ const ApplicationControls = memo(({ setBlockNav, onSuccess }) => {
     <Box
       sx={{
         display: 'flex',
+        position: 'relative',
         alignItems: 'center',
-        borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
         paddingLeft: '0.5rem',
+
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          left: 0,
+          top: '0.25rem',
+          bottom: '0.25rem',
+          borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
+        },
       }}
     >
       {viewMode === ViewMode.Public && (

--- a/src/[fsd]/entities/import-wizard/ui/ToolbarImportButton.jsx
+++ b/src/[fsd]/entities/import-wizard/ui/ToolbarImportButton.jsx
@@ -2,10 +2,9 @@ import { memo } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { IconButton } from '@mui/material';
-
 import StyledTooltip from '@/ComponentsLib/Tooltip';
 import { useImport } from '@/[fsd]/entities/import-wizard/lib/hooks';
+import BaseBtn from '@/[fsd]/shared/ui/button/BaseBtn';
 import ImportIcon from '@/assets/import-icon.svg?react';
 import { PUBLIC_PROJECT_ID } from '@/common/constants';
 
@@ -23,13 +22,12 @@ const ToolbarImportButton = memo(() => {
       title="Import"
       placement="top"
     >
-      <IconButton
+      <BaseBtn
+        variant="secondary"
         onClick={openFileDialog}
-        size="small"
         sx={styles.importBtn}
-      >
-        <ImportIcon />
-      </IconButton>
+        startIcon={<ImportIcon />}
+      />
     </StyledTooltip>
   );
 });
@@ -38,27 +36,11 @@ ToolbarImportButton.displayName = 'ToolbarImportButton';
 
 /** @type {MuiSx} */
 const importButtonStyles = () => ({
-  importBtn: theme => ({
+  importBtn: {
     ml: 1,
-    padding: '.5rem',
-    borderRadius: '.5rem',
-    backgroundColor: theme.palette.background.button.secondary,
-
-    '&:hover': {
-      backgroundColor: theme.palette.background.button.secondary,
-      opacity: 0.8,
-    },
-
-    svg: {
-      fontSize: '1rem',
-      width: '1rem',
-      height: '1rem',
-
-      path: {
-        fill: theme.palette.icon.fill.secondary,
-      },
-    },
-  }),
+    width: '2rem',
+    height: '2rem',
+  },
 });
 
 export default ToolbarImportButton;

--- a/src/[fsd]/features/credentials/ui/credentials-tab-bar/CredentialsControls.jsx
+++ b/src/[fsd]/features/credentials/ui/credentials-tab-bar/CredentialsControls.jsx
@@ -157,9 +157,18 @@ CredentialsControls.displayName = 'CredentialsControls';
 const credentialsControlsStyles = () => ({
   wrapper: {
     display: 'flex',
+    position: 'relative',
     alignItems: 'center',
-    borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
     paddingLeft: '0.5rem',
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: 0,
+      top: '0.25rem',
+      bottom: '0.25rem',
+      borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
+    },
   },
   deleteIcon: {
     fontSize: '1rem',

--- a/src/[fsd]/features/toolkits/ui/toolkits-tab-bar/ToolkitsControls.jsx
+++ b/src/[fsd]/features/toolkits/ui/toolkits-tab-bar/ToolkitsControls.jsx
@@ -82,9 +82,18 @@ const ToolkitsControls = memo(props => {
     <Box
       sx={{
         display: 'flex',
+        position: 'relative',
         alignItems: 'center',
-        borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
         paddingLeft: '0.5rem',
+
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          left: 0,
+          top: '0.25rem',
+          bottom: '0.25rem',
+          borderLeft: ({ palette }) => `1px solid ${palette.border.lines}`,
+        },
       }}
     >
       {viewMode === ViewMode.Public && (

--- a/src/components/DotMenu.jsx
+++ b/src/components/DotMenu.jsx
@@ -496,6 +496,6 @@ export default function DotMenu({
 const dotMenuStyles = () => ({
   iconButton: ({ palette }) => ({
     marginLeft: 0,
-    '&:hover svg': { fill: palette.icon.fill.secondary },
+    'svg, &:hover svg': { fill: palette.icon.fill.secondary },
   }),
 });

--- a/src/components/StickyTabs.jsx
+++ b/src/components/StickyTabs.jsx
@@ -212,7 +212,7 @@ const StickyTabs = memo(props => {
                 >
                   <Typography
                     component="div"
-                    variant="labelMedium"
+                    variant="headingSmall"
                     color="text.secondary"
                   >
                     {title}

--- a/src/components/StyledTabs.jsx
+++ b/src/components/StyledTabs.jsx
@@ -293,7 +293,6 @@ const styledPureTabsStyles = (componentHeight, shouldShowLabel, tabSX, isCreateP
     marginRight: '2rem',
     minHeight: '2rem',
     fontSize: '0.875rem',
-    fontWeight: '500',
     '& button': {
       minHeight: '1.875rem',
       textTransform: 'capitalize',
@@ -346,6 +345,7 @@ const styledPureTabsStyles = (componentHeight, shouldShowLabel, tabSX, isCreateP
     }),
   },
   tab: ({ palette }) => ({
+    fontWeight: '600',
     ...(isCreatePage && {
       pointerEvents: 'none',
       '&.MuiTab-textColorPrimary': {

--- a/src/pages/Credentials/CreateCredential.jsx
+++ b/src/pages/Credentials/CreateCredential.jsx
@@ -191,7 +191,7 @@ const CreateCredential = memo(
                 <Tooltip.TypographyWithConditionalTooltip
                   title={pageTitle}
                   placement="top"
-                  variant="labelMedium"
+                  variant="headingSmall"
                   sx={styles.pageTitle}
                 >
                   {pageTitle}

--- a/src/pages/Credentials/EditCredential.jsx
+++ b/src/pages/Credentials/EditCredential.jsx
@@ -194,7 +194,7 @@ const EditCredential = memo(({ title, forceShowTitle }) => {
               <Tooltip.TypographyWithConditionalTooltip
                 title={credentialDisplayName}
                 placement="top"
-                variant="labelMedium"
+                variant="headingSmall"
                 sx={styles.credentialTitle}
               >
                 {credentialDisplayName}
@@ -291,7 +291,6 @@ const editCredentialStyles = () => ({
     },
   },
   credentialTitle: {
-    maxWidth: '12.5rem',
     textAlign: 'center',
     textTransform: 'none !important',
   },


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4324

- Changed the font weight to 600 for the headers
- Fixed "Import" button style on Agents and Pipelines (discovery) pages
- Removed Credentials title truncation
- Fixed Menu button style - the icon should be #FFFFFF (white)
- Reduced buttons divider height 

<img width="157" height="79" alt="Screenshot 2026-04-07 121705" src="https://github.com/user-attachments/assets/e05e2347-ff1c-4734-8d1d-e9a98062fe68" />
<img width="854" height="160" alt="Screenshot 2026-04-07 145040" src="https://github.com/user-attachments/assets/37c366ec-a7b5-42ce-905e-e412da57cb7e" />
<img width="194" height="107" alt="Screenshot 2026-04-07 165257" src="https://github.com/user-attachments/assets/9bd47952-8b60-4592-8c98-78b31ecbe6c2" />
<img width="483" height="124" alt="image" src="https://github.com/user-attachments/assets/422367a4-120d-47de-9998-17638f1aa018" />
