### PR TITLE
Fix: [EL-4447] Truncate long file names in Artifacts bucket file tree

### DIFF
--- a/src/pages/Artifacts/Components/BucketContent.jsx
+++ b/src/pages/Artifacts/Components/BucketContent.jsx
@@ -130,7 +130,6 @@ const bucketContentStyles = () => ({
   },
   filesContainer: {
     pl: '1.5rem',
-    minWidth: 'max-content',
   },
 });
 

--- a/src/pages/Artifacts/Components/FileTreeItem.jsx
+++ b/src/pages/Artifacts/Components/FileTreeItem.jsx
@@ -173,6 +173,7 @@ const fileTreeItemStyles = ({ isActive, isHovering, depth, theme, nextItemHovere
   return {
     wrapper: {
       width: '100%',
+      minWidth: `${indentPadding + 5}rem`,
     },
 
     container: {

--- a/src/pages/Artifacts/component/ArtifactTableToolbar.jsx
+++ b/src/pages/Artifacts/component/ArtifactTableToolbar.jsx
@@ -117,16 +117,18 @@ const ArtifactTableToolbar = memo(props => {
           title="Download files"
           placement="top"
         >
-          <IconButton
-            variant={'elitea'}
-            sx={styles.actionButton}
-            size="small"
-            color="secondary"
-            onClick={onDownloadFiles}
-            disabled={!rowSelectionModel.length}
-          >
-            <DownloadIcon sx={styles.actionIcon} />
-          </IconButton>
+          <Box component="span">
+            <IconButton
+              variant={'elitea'}
+              sx={styles.actionButton}
+              size="small"
+              color="secondary"
+              onClick={onDownloadFiles}
+              disabled={!rowSelectionModel.length}
+            >
+              <DownloadIcon sx={styles.actionIcon} />
+            </IconButton>
+          </Box>
         </Tooltip>
 
         {checkPermission(PERMISSIONS.artifacts.delete) && (


### PR DESCRIPTION
# Fix: [EL-4447] Truncate long file names in Artifacts bucket file tree

Resolves https://github.com/EliteaAI/elitea_issues/issues/4447

## Problem

Long file/folder names in the bucket file tree caused horizontal scrolling instead of truncating.
`minWidth: max-content` on `filesContainer` prevented any width constraint from reaching child elements, so
`overflow: hidden` / `text-overflow: ellipsis` had nothing to clip against.

## Fix

- Removed `minWidth: max-content` from `filesContainer` so text truncation works correctly
- Added depth-based `minWidth` to each `FileTreeItem` wrapper to preserve intentional horizontal scrolling for
  deeply nested folder structures

<img width="392" height="474" alt="image" src="https://github.com/user-attachments/assets/fab2bf66-a830-4607-902d-d6b0ebd1cd1f" />

<img width="855" height="518" alt="image" src="https://github.com/user-attachments/assets/c33e36bc-a89f-4c92-a1b7-2c103b414f3e" />
