### PR TITLE
fix: [EL-4637] Clicking inline refresh button displays unknown error

### DIFF
--- a/src/hooks/application/useValidateApplicationVersion.js
+++ b/src/hooks/application/useValidateApplicationVersion.js
@@ -25,7 +25,7 @@ const getSubAgentValidationKey = (projectId, tool) => {
 };
 
 const extractValidationInfo = ({ error, toastError, dispatch, applicationId, projectId, versionId }) => {
-  if (error?.status !== 400) {
+  if (error?.status && error.status !== 400) {
     toastError(buildErrorMessage(error));
   }
   dispatch(
@@ -33,7 +33,7 @@ const extractValidationInfo = ({ error, toastError, dispatch, applicationId, pro
       applicationId,
       projectId,
       versionId,
-      validationInfo: error.data?.toolkit_errors || [],
+      validationInfo: error?.data?.toolkit_errors || [],
     }),
   );
 };
@@ -64,10 +64,26 @@ export default function useValidateApplicationVersion({
   }, [isError, error, toastError, dispatch, applicationId, projectId, versionId]);
 }
 
-export const useManualValidateApplicationVersion = ({ applicationId, projectId, versionId } = {}) => {
+export const useManualValidateApplicationVersion = ({
+  applicationId,
+  projectId,
+  versionId,
+  tools,
+  toolId,
+} = {}) => {
   const dispatch = useDispatch();
   const { toastError } = useToast();
   const [validateAppVersion] = useLazyValidateApplicationVersionQuery();
+  const subApplication = useMemo(() => {
+    if (!tools?.length) return undefined;
+    return tools.find(
+      tool =>
+        tool.type === 'application' &&
+        tool.id === toolId &&
+        tool.settings?.application_id &&
+        tool.settings?.application_version_id,
+    );
+  }, [tools, toolId]);
 
   const doValidateVersion = useCallback(async () => {
     try {
@@ -94,7 +110,33 @@ export const useManualValidateApplicationVersion = ({ applicationId, projectId, 
         versionId,
       });
     }
-  }, [validateAppVersion, applicationId, projectId, versionId, toastError, dispatch]);
+    if (subApplication) {
+      try {
+        const result = await validateAppVersion({
+          projectId,
+          applicationId: subApplication.settings.application_id,
+          versionId: subApplication.settings.application_version_id,
+        }).unwrap();
+        extractValidationInfo({
+          error: result.error,
+          toastError,
+          dispatch,
+          projectId,
+          applicationId: subApplication.settings.application_id,
+          versionId: subApplication.settings.application_version_id,
+        });
+      } catch (error) {
+        extractValidationInfo({
+          error,
+          toastError,
+          dispatch,
+          projectId,
+          applicationId: subApplication.settings.application_id,
+          versionId: subApplication.settings.application_version_id,
+        });
+      }
+    }
+  }, [subApplication, validateAppVersion, applicationId, projectId, versionId, toastError, dispatch]);
   return { doValidateVersion };
 };
 

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -108,7 +108,13 @@ const ToolCard = memo(props => {
     toolId: tool.id,
     tool,
   });
-  const { doValidateVersion } = useManualValidateApplicationVersion({ applicationId, projectId, versionId });
+  const { doValidateVersion } = useManualValidateApplicationVersion({
+    applicationId,
+    projectId,
+    versionId,
+    tools: values?.version_details?.tools || [],
+    toolId: tool.id,
+  });
 
   const isAttachmentToolkit = useMemo(
     () => tool.id && values?.version_details?.meta?.attachment_toolkit_id === tool.id,


### PR DESCRIPTION
# Fix: EL-4637 — Clicking inline refresh button displays unknown error

## Root Cause

Two defensive checks were missing in `extractValidationInfo`:

1. `error?.status !== 400` was always truthy when `error.status` was `undefined`, causing a generic toast error to be shown instead of silent handling
2. `error.data?.toolkit_errors` crashed with an uncaught access on `undefined` when `error.data` was absent

## Changes

### `src/hooks/application/useValidateApplicationVersion.js`
- Fixed guard: `error?.status && error.status !== 400` — only show toast if status is present and not 400
- Fixed safe access: `error?.data?.toolkit_errors || []` — prevent crash on missing `data`
- Extended `useManualValidateApplicationVersion` to accept `tools` and `toolId` params
- When the tool being refreshed is a sub-agent (`type === 'application'`), the hook now also validates **that sub-agent's own application version**, surfacing its toolkit errors correctly

### `src/pages/Applications/Components/Tools/ToolCard.jsx`
- Passes `tools` (from `version_details.tools`) and `toolId` into `useManualValidateApplicationVersion` so sub-agent validation can be triggered from the inline refresh button
