### PR TITLE
fix: [EL-4524] published agent participant details using wrong project_id and endpoints

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
@@ -24,6 +24,7 @@ const ApplicationTools = memo(props => {
     disabled,
     title = 'Toolkits',
     hidePythonSandbox = false,
+    entityProjectId,
   } = props;
   const sortedToolsRef = useRef(null);
 
@@ -122,6 +123,7 @@ const ApplicationTools = memo(props => {
                   applicationId={applicationId}
                   disabled={disabled}
                   isDuplicate={markedDuplicateTool.isDuplicate}
+                  entityProjectId={entityProjectId}
                 />
               ))}
 

--- a/src/hooks/chat/useFetchParticipantDetails.js
+++ b/src/hooks/chat/useFetchParticipantDetails.js
@@ -79,6 +79,11 @@ const useFetchParticipantDetails = () => {
       switch (type) {
         case ChatParticipantType.Pipelines:
         case ChatParticipantType.Applications: {
+          if (projectId == PUBLIC_PROJECT_ID) {
+            // Published agents: use public_application endpoint (no project membership required)
+            const result = await getPublicApplicationDetail({ applicationId: id });
+            return result?.data?.version_details || {};
+          }
           const result = await getApplicationVersion({ projectId, applicationId: id, versionId });
           return result?.data || {};
         }
@@ -87,7 +92,7 @@ const useFetchParticipantDetails = () => {
       }
       return {};
     },
-    [getApplicationVersion],
+    [getApplicationVersion, getPublicApplicationDetail],
   );
 
   return {

--- a/src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx
@@ -13,7 +13,14 @@ import ApplicationInformation from '@/pages/Applications/Components/Applications
 import ApplicationWelcomeMessage from '@/pages/Applications/Components/Applications/ApplicationWelcomeMessage';
 
 const ApplicationConfigurationForm = memo(props => {
-  const { applicationId, viewMode, containerStyle = {}, isChatView = false, onAttachmentToolChange } = props;
+  const {
+    applicationId,
+    viewMode,
+    containerStyle = {},
+    isChatView = false,
+    onAttachmentToolChange,
+    entityProjectId,
+  } = props;
 
   const isDisabled = useMemo(() => viewMode !== ViewMode.Owner, [viewMode]);
   const styles = useMemo(() => applicationConfigurationFormStyles(isChatView), [isChatView]);
@@ -35,6 +42,7 @@ const ApplicationConfigurationForm = memo(props => {
         applicationId={applicationId}
         disabled={isDisabled}
         onAttachmentToolChange={onAttachmentToolChange}
+        entityProjectId={entityProjectId}
       />
       <ConversationStarters
         disabled={isDisabled}

--- a/src/pages/Applications/Components/Applications/ApplicationValidator.jsx
+++ b/src/pages/Applications/Components/Applications/ApplicationValidator.jsx
@@ -4,6 +4,7 @@ import { useFormikContext } from 'formik';
 import { useDispatch } from 'react-redux';
 
 import { eliteaApi } from '@/api/eliteaApi';
+import { PUBLIC_PROJECT_ID } from '@/common/constants';
 import useValidateApplicationVersion from '@/hooks/application/useValidateApplicationVersion';
 
 /**
@@ -21,7 +22,9 @@ function ApplicationValidator({ agentId, projectId, isCreateMode = false }) {
   const dispatch = useDispatch();
   const prevToolsRef = useRef();
 
+  const isPublished = projectId == PUBLIC_PROJECT_ID;
   const shouldSkip =
+    isPublished ||
     isCreateMode ||
     !agentId ||
     !projectId ||
@@ -56,12 +59,12 @@ function ApplicationValidator({ agentId, projectId, isCreateMode = false }) {
 
   // Collect application-type sub-tools (sub-agents/pipelines used as tools)
   const applicationTools = useMemo(() => {
-    if (!values?.version_details?.tools?.length || isCreateMode) return [];
+    if (!values?.version_details?.tools?.length || isCreateMode || isPublished) return [];
     return values.version_details.tools.filter(
       tool =>
         tool.type === 'application' && tool.settings?.application_id && tool.settings?.application_version_id,
     );
-  }, [values?.version_details?.tools, isCreateMode]);
+  }, [values?.version_details?.tools, isCreateMode, isPublished]);
 
   return (
     <>

--- a/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
@@ -18,6 +18,7 @@ const PipelineConfigurationForm = memo(props => {
     isChatView = false,
     hidePythonSandbox,
     onAttachmentToolChange,
+    entityProjectId,
   } = props;
   const isDisabled = viewMode !== ViewMode.Owner;
 
@@ -33,6 +34,7 @@ const PipelineConfigurationForm = memo(props => {
         disabled={isDisabled}
         hidePythonSandbox={hidePythonSandbox}
         onAttachmentToolChange={onAttachmentToolChange}
+        entityProjectId={entityProjectId}
       />
       {!isDisabled && (
         <>

--- a/src/pages/Applications/Components/Tools/AgentPipelineVersionSelector.jsx
+++ b/src/pages/Applications/Components/Tools/AgentPipelineVersionSelector.jsx
@@ -14,10 +14,12 @@ import {
   TAG_TYPE_APPLICATION_DETAILS,
   useApplicationDetailsQuery,
   useLazyGetApplicationVersionDetailQuery,
+  usePublicApplicationDetailsQuery,
   useUpdateApplicationRelationMutation,
 } from '@/api/applications';
 import { eliteaApi } from '@/api/eliteaApi';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
+import { PUBLIC_PROJECT_ID } from '@/common/constants';
 import { useSetRefetchDetails } from '@/hooks/application/useRefetchAgentDetails';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
@@ -45,11 +47,13 @@ const isRelationAlreadyExistsError = error => {
 /**
  * Component for selecting agent/pipeline versions in the toolkit card according to Figma design
  */
-const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
+const AgentPipelineVersionSelector = memo(({ tool, index, applicationId, disabled, entityProjectId }) => {
   const dispatch = useDispatch();
   const { values, setFieldValue, dirty, resetForm } = useFormikContext();
   const [anchorEl, setAnchorEl] = useState(null);
-  const projectId = useSelectedProjectId();
+  const selectedProjectId = useSelectedProjectId();
+  const projectId = entityProjectId || selectedProjectId;
+  const isPublished = projectId == PUBLIC_PROJECT_ID;
   const [updateApplicationRelation] = useUpdateApplicationRelationMutation();
   const [isUpdating, setIsUpdating] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -59,12 +63,19 @@ const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
   const [getVersionDetail] = useLazyGetApplicationVersionDetailQuery();
   const styles = agentPipelineVersionSelectorStyles();
 
-  // Fetch all versions for this agent/pipeline using applicationDetails
-  const { data: applicationData = { versions: [] }, refetch: refetchApplicationDetails } =
+  // Fetch all versions for this agent/pipeline using the appropriate endpoint
+  const { data: privateAppData = { versions: [] }, refetch: refetchPrivateDetails } =
     useApplicationDetailsQuery(
       { projectId, applicationId: tool.settings?.application_id },
-      { skip: !projectId || !tool.settings?.application_id },
+      { skip: isPublished || !projectId || !tool.settings?.application_id },
     );
+  const { data: publicAppData = { versions: [] }, refetch: refetchPublicDetails } =
+    usePublicApplicationDetailsQuery(
+      { applicationId: tool.settings?.application_id },
+      { skip: !isPublished || !tool.settings?.application_id },
+    );
+  const applicationData = isPublished ? publicAppData : privateAppData;
+  const refetchApplicationDetails = isPublished ? refetchPublicDetails : refetchPrivateDetails;
 
   // Get versions from the API response or fallback to local data, sorted properly
   const versions = useMemo(() => {
@@ -91,15 +102,21 @@ const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
   }, [applicationData]);
 
   // Check if the stored version reference is invalid (version was deleted)
+  // For published agents, the embedded version may not be in the public list - that's expected, not invalid
   const isInvalidVersionReference = useMemo(() => {
+    if (isPublished) return false;
     const storedVersionId = tool.settings?.application_version_id;
     return storedVersionId && versions.length > 0 && !versions.find(v => v.id === storedVersionId);
-  }, [tool.settings?.application_version_id, versions]);
+  }, [tool.settings?.application_version_id, versions, isPublished]);
 
   // Get current selected version or default to latest
   const selectedVersion = useMemo(() => {
-    return versions.find(v => v.id === tool.settings.application_version_id) || versions[0];
-  }, [tool, versions]);
+    const found = versions.find(v => v.id === tool.settings.application_version_id);
+    if (found) return found;
+    // For published agents, the referenced version (e.g. embedded) may not be in the public versions list
+    if (isPublished) return null;
+    return versions[0];
+  }, [tool, versions, isPublished]);
 
   // Helper function to format version display text
   const formatVersionDisplayText = useCallback(version => {
@@ -129,10 +146,14 @@ const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
   // Get display text for the selected version
   const displayText = useMemo(() => {
     if (isInvalidVersionReference) return 'Invalid version';
-    if (!selectedVersion) return LATEST_VERSION_NAME;
+    if (!selectedVersion) {
+      // For published agents, the embedded version is not in the public versions list
+      if (isPublished) return 'embedded';
+      return LATEST_VERSION_NAME;
+    }
 
     return formatVersionDisplayText(selectedVersion);
-  }, [selectedVersion, formatVersionDisplayText, isInvalidVersionReference]);
+  }, [selectedVersion, formatVersionDisplayText, isInvalidVersionReference, isPublished]);
 
   // Helper function to invalidate cache and trigger refetch
   const invalidateCacheAndRefresh = useCallback(
@@ -347,8 +368,8 @@ const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
     <Box sx={styles.contentWrapper}>
       {/* Version Selector Button */}
       <Box
-        sx={styles.selector}
-        onClick={isUpdating ? undefined : handleClick}
+        sx={[styles.selector, disabled && { cursor: 'default', '&:hover': {} }]}
+        onClick={isUpdating || disabled ? undefined : handleClick}
       >
         {isInvalidVersionReference && <WarningAmberIcon sx={styles.warningIcon} />}
         <Typography
@@ -359,13 +380,15 @@ const AgentPipelineVersionSelector = memo(({ tool, index, applicationId }) => {
           {displayText}
         </Typography>
         {isUpdating && <StyledCircleProgress size={16} />}
-        <KeyboardArrowDownIcon
-          className="dropdown-icon"
-          sx={[
-            isInvalidVersionReference ? styles.dropdownIconInvalid : styles.dropdownIcon,
-            { transform: anchorEl ? 'rotate(180deg)' : 'rotate(0deg)' },
-          ]}
-        />
+        {!disabled && (
+          <KeyboardArrowDownIcon
+            className="dropdown-icon"
+            sx={[
+              isInvalidVersionReference ? styles.dropdownIconInvalid : styles.dropdownIcon,
+              { transform: anchorEl ? 'rotate(180deg)' : 'rotate(0deg)' },
+            ]}
+          />
+        )}
       </Box>
 
       {/* Version Selection Dropdown Menu */}

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -45,11 +45,13 @@ import EnhancedCardToolActions from './CardActions/EnhancedCardToolActions.jsx';
 import BaseCardBody from './CardBodies/BaseCardBody.jsx';
 
 const ToolCard = memo(props => {
-  const { tool, index, applicationId, disabled, isDuplicate, onDeleteAttachmentTool } = props;
+  const { tool, index, applicationId, disabled, isDuplicate, onDeleteAttachmentTool, entityProjectId } =
+    props;
   const theme = useTheme();
   const [openAlert, setOpenAlert] = useState(false);
   const { toastError } = useToast();
-  const projectId = useSelectedProjectId();
+  const selectedProjectId = useSelectedProjectId();
+  const projectId = entityProjectId || selectedProjectId;
   const { checkPermission } = useCheckPermission();
   const viewModeFromUrl = useSearchParamValue('ViewMode');
   const [showActions, setShowActions] = useState(false);
@@ -365,6 +367,8 @@ const ToolCard = memo(props => {
                 tool={tool}
                 index={index}
                 applicationId={applicationId}
+                disabled={disabled}
+                entityProjectId={entityProjectId}
               />
             )}
 

--- a/src/pages/NewChat/AgentEditor.jsx
+++ b/src/pages/NewChat/AgentEditor.jsx
@@ -5,7 +5,7 @@ import { useFormikContext } from 'formik';
 import { useTrackEvent } from '@/GA';
 import useRefetchAgentVersionDetailsOnClose from '@/[fsd]/features/chat/lib/hooks/useRefetchAgentVersionDetailsOnClose';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
-import { useGetApplicationVersionDetailQuery } from '@/api/applications';
+import { useGetApplicationVersionDetailQuery, usePublicApplicationDetailsQuery } from '@/api/applications';
 import { ChatParticipantType, PERMISSIONS, PUBLIC_PROJECT_ID, ViewMode } from '@/common/constants.js';
 import useCheckPermission from '@/hooks/useCheckPermission';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
@@ -27,7 +27,16 @@ const getAgentId = agent => {
 };
 
 const AgentEditorContent = memo(
-  ({ agentId, projectId, isCreateMode, canEditIt, viewMode, handleAttachmentToolChange, isPublic }) => {
+  ({
+    agentId,
+    projectId,
+    isCreateMode,
+    canEditIt,
+    viewMode,
+    handleAttachmentToolChange,
+    isPublic,
+    entityProjectId,
+  }) => {
     const { setFieldValue } = useFormikContext();
     const styles = getStyles();
 
@@ -46,7 +55,7 @@ const AgentEditorContent = memo(
       <>
         <ApplicationValidator
           agentId={agentId}
-          projectId={projectId}
+          projectId={entityProjectId || projectId}
           isCreateMode={isCreateMode}
         />
         <ContentContainer height="100%">
@@ -68,6 +77,7 @@ const AgentEditorContent = memo(
               isChatView={true}
               viewMode={viewMode}
               onAttachmentToolChange={handleAttachmentToolChange}
+              entityProjectId={entityProjectId}
             />
           )}
         </ContentContainer>
@@ -109,16 +119,28 @@ const AgentEditor = memo(
     const { initialValues: createInitialValues } = useCreateApplicationInitialValues();
 
     // Only fetch details when the editor is visible and we have required IDs (edit mode only)
+    const isPublishedAgent = agent?.entity_meta?.project_id == PUBLIC_PROJECT_ID;
     const {
-      data: versionDetails,
-      error,
-      refetch: refetchVersionDetails,
+      data: privateVersionDetails,
+      error: privateError,
+      refetch: refetchPrivateVersionDetails,
     } = useGetApplicationVersionDetailQuery(
-      projectId && agentId && versionId && isVisible && !isCreateMode
+      projectId && agentId && versionId && isVisible && !isCreateMode && !isPublishedAgent
         ? { projectId: agent.entity_meta?.project_id || projectId, applicationId: agentId, versionId }
         : { skip: true },
-      { skip: !isVisible || !projectId || !agentId || !versionId || isCreateMode },
+      { skip: !isVisible || !projectId || !agentId || !versionId || isCreateMode || isPublishedAgent },
     );
+    const {
+      data: publicAppDetails,
+      error: publicError,
+      refetch: refetchPublicAppDetails,
+    } = usePublicApplicationDetailsQuery(
+      { applicationId: agentId },
+      { skip: !isVisible || !agentId || !isPublishedAgent || isCreateMode },
+    );
+    const versionDetails = isPublishedAgent ? publicAppDetails : privateVersionDetails;
+    const error = isPublishedAgent ? publicError : privateError;
+    const refetchVersionDetails = isPublishedAgent ? refetchPublicAppDetails : refetchPrivateVersionDetails;
     const { refetchAgentVersionDetailsOnClose } = useRefetchAgentVersionDetailsOnClose({
       refetchVersionDetails,
     });
@@ -284,6 +306,7 @@ const AgentEditor = memo(
             viewMode={viewMode}
             handleAttachmentToolChange={handleAttachmentToolChange}
             isPublic={isPublic}
+            entityProjectId={agent?.entity_meta?.project_id}
           />
         </BaseEditor>
       </FileReaderEnhancerRefContext.Provider>

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -249,30 +249,35 @@ const NewConversationView = forwardRef(
       [activeConversation?.name],
     );
 
+    const selectedParticipantProjectId =
+      selectedParticipant?.entity_meta?.project_id || selectedParticipant?.project_id;
+    const isPublishedParticipant = selectedParticipantProjectId == PUBLIC_PROJECT_ID;
+
     useValidateApplicationVersion(
-      (selectedParticipant?.entity_name === ChatParticipantType.Applications ||
-        selectedParticipant?.entity_name === ChatParticipantType.Pipelines) &&
+      !isPublishedParticipant &&
+        (selectedParticipant?.entity_name === ChatParticipantType.Applications ||
+          selectedParticipant?.entity_name === ChatParticipantType.Pipelines) &&
         selectedParticipant?.version_details?.tools
         ? {
             applicationId: selectedParticipant?.id,
-            projectId: selectedParticipant?.project_id,
+            projectId: selectedParticipantProjectId,
             versionId: selectedParticipant?.entity_settings?.version_id,
           }
         : {},
     );
 
     const { totalValidationInfo } = useToolsValidationInfo({
-      applicationId: selectedParticipant?.id,
-      projectId: selectedParticipant?.project_id,
+      applicationId: isPublishedParticipant ? undefined : selectedParticipant?.id,
+      projectId: selectedParticipantProjectId,
       versionId: selectedParticipant?.entity_settings?.version_id,
-      tools: selectedParticipant?.version_details?.tools || [],
+      tools: isPublishedParticipant ? [] : selectedParticipant?.version_details?.tools || [],
     });
 
     useValidateToolkit(
       selectedParticipant?.entity_name === ChatParticipantType.Toolkits
         ? {
             toolkitId: selectedParticipant?.id,
-            projectId: selectedParticipant?.project_id,
+            projectId: selectedParticipant?.entity_meta?.project_id || selectedParticipant?.project_id,
             forceSkip: selectedParticipant?.entity_name !== ChatParticipantType.Toolkits,
           }
         : {},
@@ -281,7 +286,7 @@ const NewConversationView = forwardRef(
     const { toolkitValidationInfoList } = useToolkitValidationInfo(
       selectedParticipant?.entity_name === ChatParticipantType.Toolkits
         ? {
-            projectId: selectedParticipant?.project_id,
+            projectId: selectedParticipant?.entity_meta?.project_id || selectedParticipant?.project_id,
             toolkitId: selectedParticipant?.id,
           }
         : {},
@@ -449,7 +454,9 @@ const NewConversationView = forwardRef(
           selectedParticipant?.participantType,
           selectedParticipant?.id,
           version.id,
-          selectedParticipant?.project_id || selectedProjectId,
+          selectedParticipant?.entity_meta?.project_id ||
+            selectedParticipant?.project_id ||
+            selectedProjectId,
         );
         const updatedParticipant = {
           ...(selectedParticipant || {}),

--- a/src/pages/NewChat/Participants/ParticipantItem.jsx
+++ b/src/pages/NewChat/Participants/ParticipantItem.jsx
@@ -160,9 +160,12 @@ const ParticipantItem = memo(props => {
     return originalDetails?.name || entity_meta?.name || participantName || 'Participant Name';
   }, [originalDetails?.name, entity_meta?.name, participantName]);
 
+  const isPublishedParticipant = entity_meta?.project_id == PUBLIC_PROJECT_ID;
+
   useValidateApplicationVersion(
-    (participant.entity_name === ChatParticipantType.Applications ||
-      participant.entity_name === ChatParticipantType.Pipelines) &&
+    !isPublishedParticipant &&
+      (participant.entity_name === ChatParticipantType.Applications ||
+        participant.entity_name === ChatParticipantType.Pipelines) &&
       originalDetails?.version_details?.tools
       ? {
           applicationId: entity_meta?.id,
@@ -173,10 +176,10 @@ const ParticipantItem = memo(props => {
   );
 
   const { totalValidationInfo } = useToolsValidationInfo({
-    applicationId: entity_meta?.id,
+    applicationId: isPublishedParticipant ? undefined : entity_meta?.id,
     projectId: entity_meta?.project_id,
     versionId: participant.entity_settings?.version_id,
-    tools: originalDetails?.version_details?.tools || [],
+    tools: isPublishedParticipant ? [] : originalDetails?.version_details?.tools || [],
   });
 
   useValidateToolkit(

--- a/src/pages/NewChat/PipelineEditor.jsx
+++ b/src/pages/NewChat/PipelineEditor.jsx
@@ -21,7 +21,7 @@ import { FlowEditorConstants } from '@/[fsd]/features/pipelines/flow-editor/lib/
 import { LayoutHelpers, ParsePipelineHelpers } from '@/[fsd]/features/pipelines/flow-editor/lib/helpers';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
 import { DEFAULT_REASONING_EFFORT } from '@/[fsd]/shared/lib/constants/llmSettings.constants';
-import { useGetApplicationVersionDetailQuery } from '@/api/applications';
+import { useGetApplicationVersionDetailQuery, usePublicApplicationDetailsQuery } from '@/api/applications';
 import FlowIcon from '@/assets/flow-icon.svg?react';
 import { ChatParticipantType, PERMISSIONS, PUBLIC_PROJECT_ID, ViewMode } from '@/common/constants.js';
 import GearIcon from '@/components/Icons/GearIcon.jsx';
@@ -48,8 +48,16 @@ const getPipelineId = pipeline => {
 };
 
 const PipelineEditorContent = memo(props => {
-  const { isCreateMode, viewMode, canEditIt, isPublic, pipelineId, projectId, handleAttachmentToolChange } =
-    props;
+  const {
+    isCreateMode,
+    viewMode,
+    canEditIt,
+    isPublic,
+    pipelineId,
+    projectId,
+    handleAttachmentToolChange,
+    entityProjectId,
+  } = props;
   const { setFieldValue } = useFormikContext();
   const styles = getStyles();
 
@@ -82,6 +90,7 @@ const PipelineEditorContent = memo(props => {
         containerStyle={styles.configForm}
         hidePythonSandbox
         onAttachmentToolChange={handleAttachmentToolChange}
+        entityProjectId={entityProjectId}
       />
     </ContentContainer>
   );
@@ -183,19 +192,33 @@ const PipelineEditor = forwardRef(
     const { initialValues: createInitialValues } = useCreateApplicationInitialValues(true); // true for pipeline
 
     // Fetch version details in edit mode only
+    const isPublishedPipeline = pipeline?.entity_meta?.project_id == PUBLIC_PROJECT_ID;
     const {
-      data: versionDetails,
-      error,
-      refetch: refetchVersionDetails,
+      data: privateVersionDetails,
+      error: privateError,
+      refetch: refetchPrivateVersionDetails,
     } = useGetApplicationVersionDetailQuery(
-      projectId && pipelineId && versionId && isVisible && !isCreateMode
+      projectId && pipelineId && versionId && isVisible && !isCreateMode && !isPublishedPipeline
         ? { projectId: pipeline.entity_meta?.project_id || projectId, applicationId: pipelineId, versionId }
         : { skip: true },
       {
-        skip: !isVisible || !projectId || !pipelineId || !versionId || isCreateMode,
-        refetchOnMountOrArgChange: true, // Force refetch when arguments change
+        skip: !isVisible || !projectId || !pipelineId || !versionId || isCreateMode || isPublishedPipeline,
+        refetchOnMountOrArgChange: true,
       },
     );
+    const {
+      data: publicAppDetails,
+      error: publicError,
+      refetch: refetchPublicAppDetails,
+    } = usePublicApplicationDetailsQuery(
+      { applicationId: pipelineId },
+      { skip: !isVisible || !pipelineId || !isPublishedPipeline || isCreateMode },
+    );
+    const versionDetails = isPublishedPipeline ? publicAppDetails : privateVersionDetails;
+    const error = isPublishedPipeline ? publicError : privateError;
+    const refetchVersionDetails = isPublishedPipeline
+      ? refetchPublicAppDetails
+      : refetchPrivateVersionDetails;
     const { refetchAgentVersionDetailsOnClose } = useRefetchAgentVersionDetailsOnClose({
       refetchVersionDetails,
     });
@@ -449,7 +472,7 @@ const PipelineEditor = forwardRef(
         >
           <ApplicationValidator
             agentId={pipelineId}
-            projectId={projectId}
+            projectId={pipeline?.entity_meta?.project_id || projectId}
             isCreateMode={isCreateMode}
           />
 
@@ -463,6 +486,7 @@ const PipelineEditor = forwardRef(
               pipelineId={pipelineId}
               projectId={projectId}
               handleAttachmentToolChange={handleAttachmentToolChange}
+              entityProjectId={pipeline?.entity_meta?.project_id}
             />
           )}
 


### PR DESCRIPTION
When clicking on published agent participant details in a conversation, multiple invalid API requests were made with wrong project_id and to endpoints requiring project membership (version/, version_validator/, application/). Regular users don't have membership in the public project for this api

Changes:
- AgentEditor/PipelineEditor: use public_application endpoint instead of version/ for published agents
- NewConversationView: resolve project_id from entity_meta for published participants, skip version validation for published agents
- ParticipantItem: skip validation hooks for published participants
- ApplicationValidator: skip parent and sub-agent validation when published
- AgentPipelineVersionSelector: use public endpoint for version list, disable dropdown for published agents, show 'embedded' version label instead of incorrectly falling back to 'base'
- useFetchParticipantDetails: route version detail fetch through public_application endpoint for published agents
- Thread entityProjectId prop through ApplicationConfigurationForm, PipelineConfigurationForm, ApplicationTools, ToolCard

Fixes: https://github.com/EliteaAI/elitea_issues/issues/4524