### PR TITLE
fix: [EL-4638] Canvas mode does not display agent configuration after misconfigured toolkit is added

### DIFF
--- a/src/api/applications.js
+++ b/src/api/applications.js
@@ -833,6 +833,20 @@ export const apiSlice = eliteaApi
         providesTags: (result, error, { projectId, applicationId, versionId }) => [
           { type: 'ApplicationValidation', id: `${projectId}-${applicationId}-${versionId}` },
         ],
+        onQueryStarted: async (args, { dispatch, queryFulfilled }) => {
+          try {
+            await queryFulfilled;
+          } catch {
+            // When validation fails, invalidate the version details cache
+            // so stale data doesn't persist
+            const { projectId, applicationId, versionId } = args;
+            dispatch(
+              eliteaApi.util.invalidateTags([
+                { type: TAG_TYPE_APPLICATION_DETAILS, id: `${projectId}_${applicationId}_${versionId}` },
+              ]),
+            );
+          }
+        },
       }),
       setAgentAttachmentStorage: build.mutation({
         query: ({ projectId, applicationId, versionId, toolkit_id }) => {


### PR DESCRIPTION
# Cache Invalidation on Validation Error

## Problem

When the application version validation API returns errors, the RTK Query cache for the corresponding application version details was not being invalidated. This caused the UI to potentially display stale cached data even after validation failures.

## Solution

Implemented cache invalidation in the `validateApplicationVersion` query using the `onQueryStarted` lifecycle hook to automatically invalidate the version details cache when validation errors occur.

## Implementation

### File Modified
`EliteaUI/src/api/applications.js`

### Code Changes

```javascript
validateApplicationVersion: build.query({
  query: ({ projectId, applicationId, versionId }) => ({
    url: `${apiSlicePath}/version_validator/prompt_lib/${projectId}/${applicationId}/${versionId}`,
  }),
  providesTags: (result, error, { projectId, applicationId, versionId }) => [
    { type: 'ApplicationValidation', id: `${projectId}-${applicationId}-${versionId}` },
  ],
  onQueryStarted: async (args, { dispatch, queryFulfilled }) => {
    try {
      await queryFulfilled;
    } catch {
      // When validation fails, invalidate the version details cache
      // so stale data doesn't persist
      const { projectId, applicationId, versionId } = args;
      dispatch(
        eliteaApi.util.invalidateTags([
          { type: TAG_TYPE_APPLICATION_DETAILS, id: `${projectId}_${applicationId}_${versionId}` },
        ]),
      );
    }
  },
}),
```

## How It Works

1. **Query Execution**: When `validateApplicationVersion` is called, it initiates the API request
2. **Error Detection**: The `onQueryStarted` hook awaits `queryFulfilled` promise
3. **Cache Invalidation**: If the promise rejects (validation error), the catch block executes:
   - Extracts `projectId`, `applicationId`, and `versionId` from the arguments
   - Dispatches a cache invalidation for the specific version details tag
4. **Automatic Refetch**: Components using `useGetApplicationVersionDetailQuery` will automatically refetch the latest data

## Related Components

### Query Hook Usage
- `useValidateApplicationVersion` (hooks/application/useValidateApplicationVersion.js)
- `useManualValidateApplicationVersion` (hooks/application/useValidateApplicationVersion.js)

### Cache Tags
- **Validation Tag**: `{ type: 'ApplicationValidation', id: '${projectId}-${applicationId}-${versionId}' }`
- **Version Details Tag**: `{ type: TAG_TYPE_APPLICATION_DETAILS, id: '${projectId}_${applicationId}_${versionId}' }`

### Related Queries
- `getApplicationVersionDetail` - Provides the version details that get invalidated
- `validateApplicationVersion` - The validation query with the new invalidation logic

## Benefits

1. **Data Consistency**: Ensures UI always displays up-to-date information after validation failures
2. **Automatic Updates**: No manual cache management needed in components
3. **Better UX**: Users see correct validation state without manual page refreshes
4. **Follows Existing Patterns**: Consistent with other cache management strategies in the codebase (e.g., `deleteApplicationIcon`, `replaceApplicationIcon`)

## Testing Scenarios

To verify this works correctly:

1. **Validation Error Flow**:
   - Open an application version with invalid configuration
   - Trigger validation via `useValidateApplicationVersion`
   - Verify that validation errors appear
   - Check that version details are refetched (no stale cache)

2. **Sub-agent Validation**:
   - Use `useManualValidateApplicationVersion` with tools containing sub-agents
   - Verify both parent and sub-agent validation errors trigger cache invalidation
   - Confirm version details update correctly

3. **Multiple Validations**:
   - Trigger validation multiple times for the same version
   - Verify each validation error properly invalidates the cache
   - Ensure no duplicate refetches occur

## Related Documentation

- [RTK Query - onQueryStarted](https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#onquerystarted)
- [RTK Query - Cache Invalidation](https://redux-toolkit.js.org/rtk-query/usage/automated-refetching)
- Project: `CLAUDE.md` - Frontend development guidelines

## Date
2026-04-15
