### PR TITLE
fix: [EL-4659] False credential change warning when editing non-credential fields in toolkit

### DIFF
--- a/src/[fsd]/entities/credential-warning/helpers/credentialWarning.helpers.js
+++ b/src/[fsd]/entities/credential-warning/helpers/credentialWarning.helpers.js
@@ -7,7 +7,7 @@ export const hasCredentialConfigChanged = (current, original) => {
     const orig = originalSettings[key];
 
     // Check if this is a credential object
-    if (typeof curr === 'object' && curr != null && 'elitea_title' in curr) {
+    if (typeof curr === 'object' && curr != null && 'elitea_title' in curr && orig?.elitea_title) {
       // Check if private flag or credential selection changed
       return curr.private !== orig?.private || curr.elitea_title !== orig?.elitea_title;
     }
@@ -29,7 +29,7 @@ export const revertCredentialFields = (editToolDetail, originalDetails) => {
     const orig = originalSettings[key];
 
     // Check if this is a credential object that has changed
-    if (typeof curr === 'object' && 'elitea_title' in curr) {
+    if (typeof curr === 'object' && 'elitea_title' in curr && orig?.elitea_title) {
       if (curr.private !== orig?.private || curr.elitea_title !== orig?.elitea_title) {
         revertedSettings[key] = orig;
       }


### PR DESCRIPTION
# Fix: False credential change warning when editing non-credential fields in toolkit

## Issue
**Ticket**: EL-4659

When editing toolkit configurations, users were seeing false warnings about credential changes even when they were only modifying non-credential fields. This occurred because the credential detection logic was too broad and would trigger warnings for any field with an `elitea_title` property, even if the original value wasn't empty.

## Root Cause

In `credentialWarning.helpers.js`, the functions `hasCredentialConfigChanged()` and `revertCredentialFields()` were checking if the current field was empty by looking for the `elitea_title` property:

```javascript
if (typeof curr === 'object' && curr != null && 'elitea_title' in curr) {
  // Treat as credential
}
```

However, this check didn't verify whether the **original** value was empty. This caused false positives when:
- The original value was empty
- The system incorrectly flagged it as a credential change

## Solution

Added an additional check to verify that the **original value** also has an `elitea_title` property before treating the field as a credential:

```javascript
if (typeof curr === 'object' && curr != null && 'elitea_title' in curr && orig?.elitea_title) {
  // Now properly identifies actual credentials
}
```

This ensures we only detect credential changes when **both** the current and original values are credential objects.

## Changes

**File Modified**: `src/[fsd]/entities/credential-warning/helpers/credentialWarning.helpers.js`

1. **`hasCredentialConfigChanged()`** (line 10):
   - Added `&& orig?.elitea_title` check
   - Prevents false positives for non-credential field changes

2. **`revertCredentialFields()`** (line 32):
   - Added `&& orig?.elitea_title` check
   - Ensures only actual credential fields are reverted

## Impact

- ✅ Eliminates false warnings when editing non-credential toolkit fields
- ✅ Maintains correct warning behavior for actual credential changes
- ✅ Improves user experience by reducing unnecessary warning dialogs
- ✅ More accurate detection of credential configuration changes

## Testing Scenarios

- [x] Edit non-credential fields → No warning (correct)
- [x] Change credential selection → Warning appears (correct)
- [x] Toggle credential private flag → Warning appears (correct)
- [x] Edit mix of credential and non-credential fields → Warning only for credentials (correct)

## Commit
`35112e8` - fix: [EL-4659] False credential change warning when editing non-credential fields in toolkit
