### PR TITLE
fix: [EL-4667] SharePoint OAuth authentication fails when triggered from chat  "Authorize" button

### DIFF
--- a/src/[fsd]/features/chat/ui/chat-continue/ChatContinue.jsx
+++ b/src/[fsd]/features/chat/ui/chat-continue/ChatContinue.jsx
@@ -90,6 +90,7 @@ const ChatContinue = memo(props => {
           tokenStorageKey={authRequiredAction.toolOutputs?.server_url}
           mcpAuthMetadata={mcpAuthMetadata}
           projectId={projectId}
+          toolkitId={mcpAuthMetadata?.toolkitId}
           onClose={handleCloseModal}
           onCancel={handleCancelModal}
         />

--- a/src/[fsd]/features/mcp/lib/hooks/useMcpAuthModal.hooks.js
+++ b/src/[fsd]/features/mcp/lib/hooks/useMcpAuthModal.hooks.js
@@ -51,6 +51,8 @@ export const extractMcpAuthMetadata = source => {
     // When present, tokens should be stored under "{configUuid}:{oauth_endpoint}" so that
     // two credentials sharing the same Azure AD tenant stay isolated.
     configurationUuid: resourceMetadata?.configuration_uuid,
+    // Toolkit ID for fetching credentials from database
+    toolkitId: resourceMetadata?.toolkit_id,
   };
 };
 


### PR DESCRIPTION
# SharePoint OAuth Fix (EL-4667) - All 3 Repos

## Problem
SharePoint OAuth failing from chat "Authorize" button with Azure AD error `AADSTS700025: invalid client_secret provided`

## Root Cause

**Security by Design Backfire:**
1. SDK masks `client_secret` as `*****` in `McpAuthorizationRequired` exception (for security - never expose secrets to frontend)
2. Frontend receives masked value and sends it to backend OAuth proxy
3. Backend's check `if not client_secret:` **fails** because `"*****"` is truthy
4. Backend doesn't fetch real secret from database
5. Sends masked `*****` to Azure AD → Rejected

**Additional Complication:**
SharePoint toolkit stores credentials as **configuration reference** (`{"private": true, "elitea_title": "sharepoint-delegated"}`) instead of directly in toolkit settings. Backend needed to:
- Fetch toolkit from DB using `toolkit_id`
- Resolve configuration reference with `expand_configuration()`
- Extract real credentials

---

## Fix Summary

### 1. **elitea_core** (Backend)
**Branch**: `fix/EL-4667/sharepoint-login-issue`  
**Files**: `api/v2/mcp_oauth_proxy.py`, `models/pd/mcp_oauth.py`

**Changes (3-part fix)**:

#### Part 1: Detect Masked Secrets
```python
# Helper function to detect masked secrets (e.g., "*****", "****6afP")
def is_masked_secret(value):
    import re
    return isinstance(value, str) and bool(re.match(r'^\*+', value))

# Treat masked secrets as None so we fetch from database
if is_masked_secret(client_secret):
    log.debug(f"MCP OAuth proxy: detected masked client_secret, will fetch from database")
    client_secret = None
```

#### Part 2: Fetch Toolkit from Database
```python
if data.toolkit_id:
    with db.with_project_schema_session(project_id) as session:
        toolkit = session.query(EliteATool).filter(
            EliteATool.id == data.toolkit_id
        ).first()
        settings = vault_client.unsecret(toolkit.settings or {})
```

#### Part 3: Resolve Configuration References
```python
from ....configurations.utils import expand_configuration

# SharePoint stores credentials as configuration reference
sp_config = settings.get('sharepoint_configuration', {})
config_title = sp_config.get('elitea_title')
if config_title and not sp_config.get('client_id'):
    user_id = auth.current_user().get('id') if sp_config.get('private') else None
    # Resolves {"private": true, "elitea_title": "..."} → actual credentials
    expand_configuration(sp_config, current_project_id=project_id, user_id=user_id, unsecret=True)

# Extract credentials (from direct settings OR resolved reference)
client_id = settings.get('client_id') or sp_config.get('client_id')
client_secret = settings.get('client_secret') or sp_config.get('client_secret')
```

### 2. **elitea-sdk** (SharePoint Toolkit)
**Branch**: `fix/EL-4667/sharepoint-login-issue`  
**File**: `elitea_sdk/tools/sharepoint/__init__.py`

**Changes**:
- Pass `toolkit_id` through `get_tools()` and `get_toolkit()`
- Add `toolkit_id` to `McpAuthorizationRequired` exception metadata
- Backend uses this ID to fetch toolkit from database

```python
def get_toolkit(cls, selected_tools, toolkit_name, toolkit_id=None, **kwargs):
    # ...
    if exc.resource_metadata is not None:
        if toolkit_id is not None:
            exc.resource_metadata['toolkit_id'] = toolkit_id
```

### 3. **EliteaUI** (Frontend)
**Branch**: `fix/EL-4667/sharepoint-login-issue`  
**Files**: `src/[fsd]/features/chat/ui/chat-continue/ChatContinue.jsx`, `src/[fsd]/features/mcp/lib/hooks/useMcpAuthModal.hooks.js`

**Changes**:
- Extract `toolkitId` from MCP exception metadata
- Pass to auth modal
- Modal sends to backend OAuth proxy

```javascript
// Extract from exception
toolkitId: resourceMetadata?.toolkit_id

// Pass to modal
<McpAuthModal toolkitId={mcpAuthMetadata?.toolkitId} ... />
```

---

## How the Fix Works

### Before Fix (Broken Flow)
```
SDK: mask_secret(client_secret) → "*****"
  ↓
Frontend: receives "*****", sends to backend
  ↓
Backend: if not client_secret: ← FAILS (truthy)
  ↓ 
Backend: sends "*****" to Azure AD
  ↓
Azure AD: AADSTS700025 ❌
```

### After Fix (Working Flow)
```
SDK: mask_secret(client_secret) → "*****"
  ↓
SDK: adds toolkit_id to exception metadata
  ↓
Frontend: receives "*****" + toolkit_id, sends both to backend
  ↓
Backend: is_masked_secret("*****") → True
Backend: client_secret = None
  ↓
Backend: fetch toolkit from DB using toolkit_id
Backend: sp_config = {"private": true, "elitea_title": "sharepoint-delegated"}
  ↓
Backend: expand_configuration(sp_config) → resolves to real credentials
  ↓
Backend: extract real client_secret from resolved config
  ↓
Backend: sends real client_secret to Azure AD
  ↓
Azure AD: Success ✓
```

**Result:** OAuth works from chat panel - masked secrets detected, credentials fetched from DB, configuration references resolved.

---

## Commits

- **elitea_core**: `d92075d` - fix: [EL-4667] SharePoint OAuth authentication fails when triggered from chat "Authorize" button
- **elitea-sdk**: `43a10be` - fix: [EL-4667] SharePoint OAuth authentication fails when triggered from chat panel "Authorize" button
- **EliteaUI**: `a9fe63d` - fix: [EL-4667] SharePoint OAuth authentication fails when triggered from chat "Authorize" button

---

**Date**: 2026-04-16  
**Issue**: EL-4667  
**Status**: ✅ Fixed
