### PR TITLE
fix: [EL-4668] Published version selector not loading correct version in chat Edit

### DIFF
--- a/src/api/applications.js
+++ b/src/api/applications.js
@@ -420,8 +420,11 @@ export const apiSlice = eliteaApi
         },
       }),
       publicApplicationDetails: build.query({
-        query: ({ applicationId }) => {
-          const url = apiSlicePath + '/public_application/prompt_lib/' + applicationId;
+        query: ({ applicationId, versionName }) => {
+          let url = apiSlicePath + '/public_application/prompt_lib/' + applicationId;
+          if (versionName) {
+            url += '/' + versionName;
+          }
           return {
             url,
           };

--- a/src/hooks/chat/useActiveParticipantDetails.js
+++ b/src/hooks/chat/useActiveParticipantDetails.js
@@ -31,7 +31,7 @@ const useActiveParticipantDetails = ({ activeParticipant, skip }) => {
           entity_meta.id,
           entity_settings.version_id,
           entityProjectId,
-          { versionName },
+          versionName,
         );
       }
 

--- a/src/hooks/chat/useActiveParticipantDetails.js
+++ b/src/hooks/chat/useActiveParticipantDetails.js
@@ -25,11 +25,13 @@ const useActiveParticipantDetails = ({ activeParticipant, skip }) => {
         entity_settings.version_id && details.version_details?.id !== entity_settings.version_id;
 
       if (needsVersionFetch) {
+        const versionName = details.versions?.find(v => v.id === entity_settings.version_id)?.name;
         versionDetails = await fetchOriginalVersionDetails(
           entity_name,
           entity_meta.id,
           entity_settings.version_id,
           entityProjectId,
+          { versionName },
         );
       }
 

--- a/src/hooks/chat/useFetchParticipantDetails.js
+++ b/src/hooks/chat/useFetchParticipantDetails.js
@@ -72,7 +72,7 @@ const useFetchParticipantDetails = () => {
   );
 
   const fetchOriginalVersionDetails = useCallback(
-    async (type, id, versionId, projectId, { versionName } = {}) => {
+    async (type, id, versionId, projectId, versionName) => {
       if (!versionId) {
         return {};
       }

--- a/src/hooks/chat/useFetchParticipantDetails.js
+++ b/src/hooks/chat/useFetchParticipantDetails.js
@@ -72,7 +72,7 @@ const useFetchParticipantDetails = () => {
   );
 
   const fetchOriginalVersionDetails = useCallback(
-    async (type, id, versionId, projectId) => {
+    async (type, id, versionId, projectId, { versionName } = {}) => {
       if (!versionId) {
         return {};
       }
@@ -80,8 +80,8 @@ const useFetchParticipantDetails = () => {
         case ChatParticipantType.Pipelines:
         case ChatParticipantType.Applications: {
           if (projectId == PUBLIC_PROJECT_ID) {
-            // Published agents: use public_application endpoint (no project membership required)
-            const result = await getPublicApplicationDetail({ applicationId: id });
+            // Published agents: use public_application endpoint with version name
+            const result = await getPublicApplicationDetail({ applicationId: id, versionName });
             return result?.data?.version_details || {};
           }
           const result = await getApplicationVersion({ projectId, applicationId: id, versionId });

--- a/src/pages/NewChat/AgentEditor.jsx
+++ b/src/pages/NewChat/AgentEditor.jsx
@@ -94,6 +94,7 @@ AgentEditorContent.displayName = 'AgentEditorContent';
 const AgentEditor = memo(
   ({
     agent,
+    versionName,
     onCloseAgentEditor,
     isVisible,
     isCreateMode = false,
@@ -139,7 +140,7 @@ const AgentEditor = memo(
       error: publicError,
       refetch: refetchPublicAppDetails,
     } = usePublicApplicationDetailsQuery(
-      { applicationId: agentId },
+      { applicationId: agentId, versionName },
       { skip: !isVisible || !agentId || !isPublishedAgent || isCreateMode },
     );
     const versionDetails = isPublishedAgent ? publicAppDetails : privateVersionDetails;

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1418,7 +1418,7 @@ const ChatBox = forwardRef((props, boxRef) => {
           activeParticipant?.entity_meta.id,
           activeParticipant?.entity_settings?.version_id,
           activeParticipant?.entity_meta.project_id,
-          { versionName },
+          versionName,
         );
         setOriginalParticipant({
           ...details,
@@ -1485,7 +1485,7 @@ const ChatBox = forwardRef((props, boxRef) => {
         activeParticipant?.entity_meta.id,
         version.id,
         activeParticipant?.entity_meta.project_id,
-        { versionName: version.name },
+        version.name,
       );
 
       onChangeParticipantSettings(

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1410,11 +1410,15 @@ const ChatBox = forwardRef((props, boxRef) => {
         activeParticipant.participantType !== ChatParticipantType.Toolkits &&
         details?.version_details?.name !== LATEST_VERSION_NAME
       ) {
+        const versionName = details.versions?.find(
+          v => v.id === activeParticipant?.entity_settings?.version_id,
+        )?.name;
         const versionDetails = await fetchOriginalVersionDetails(
           activeParticipant?.entity_name,
           activeParticipant?.entity_meta.id,
           activeParticipant?.entity_settings?.version_id,
           activeParticipant?.entity_meta.project_id,
+          { versionName },
         );
         setOriginalParticipant({
           ...details,
@@ -1481,6 +1485,7 @@ const ChatBox = forwardRef((props, boxRef) => {
         activeParticipant?.entity_meta.id,
         version.id,
         activeParticipant?.entity_meta.project_id,
+        { versionName: version.name },
       );
 
       onChangeParticipantSettings(

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -1370,6 +1370,11 @@ const NewChat = props => {
             >
               <AgentEditor
                 agent={editingAgent}
+                versionName={
+                  activeParticipantDetails?.versions?.find(
+                    v => v.id === activeParticipant?.entity_settings?.version_id,
+                  )?.name
+                }
                 onCloseAgentEditor={handleCloseAgentEditor}
                 onAgentCreated={onAgentCreated}
                 onAgentSaved={handleAgentSaved}

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -232,6 +232,13 @@ const NewChat = props => {
     activeParticipant,
   });
 
+  const activeVersionName = useMemo(
+    () =>
+      activeParticipantDetails?.versions?.find(v => v.id === activeParticipant?.entity_settings?.version_id)
+        ?.name,
+    [activeParticipantDetails?.versions, activeParticipant?.entity_settings?.version_id],
+  );
+
   const { handleAttachmentToolChange } = useAttachmentToolChange({
     activeParticipant,
     refetchParticipantDetails,
@@ -1370,11 +1377,7 @@ const NewChat = props => {
             >
               <AgentEditor
                 agent={editingAgent}
-                versionName={
-                  activeParticipantDetails?.versions?.find(
-                    v => v.id === activeParticipant?.entity_settings?.version_id,
-                  )?.name
-                }
+                versionName={activeVersionName}
                 onCloseAgentEditor={handleCloseAgentEditor}
                 onAgentCreated={onAgentCreated}
                 onAgentSaved={handleAgentSaved}

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -457,7 +457,7 @@ const NewConversationView = forwardRef(
           selectedParticipant?.entity_meta?.project_id ||
             selectedParticipant?.project_id ||
             selectedProjectId,
-          { versionName: version.name },
+          version.name,
         );
         const updatedParticipant = {
           ...(selectedParticipant || {}),

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -457,6 +457,7 @@ const NewConversationView = forwardRef(
           selectedParticipant?.entity_meta?.project_id ||
             selectedParticipant?.project_id ||
             selectedProjectId,
+          { versionName: version.name },
         );
         const updatedParticipant = {
           ...(selectedParticipant || {}),


### PR DESCRIPTION
When a published agent with multiple versions is added to a chat conversation, switching to a different version via the version selector dropdown and then clicking the Edit icon opened the agent configuration panel with all fields empty (instructions, LLM settings, tools, etc.).

Root cause: Multiple code paths were fetching published agent details without passing the version name to the public_application API endpoint, which already supports version-specific queries via URL path parameter.

Changes:
- applications.js: publicApplicationDetails query now accepts optional versionName and appends it to the URL path
- useFetchParticipantDetails.js: fetchOriginalVersionDetails accepts versionName option and passes it to the public application API
- useActiveParticipantDetails.js: Resolves versionName from versions list before calling fetchOriginalVersionDetails
- ChatBox.jsx: onSelectVersion and fetchDetails pass versionName for published agents
- NewConversationView.jsx: onSelectVersion passes version.name
- AgentEditor.jsx: Accepts versionName prop and passes it to usePublicApplicationDetailsQuery
- NewChat.jsx: Passes versionName prop to AgentEditor resolved from activeParticipantDetails.versions

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/4668