### PR TITLE
fix: [EL-4657] Fixed ui issues label for Firefox

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/NameDescriptionInput.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/NameDescriptionInput.jsx
@@ -94,7 +94,7 @@ const NameDescriptionInput = memo(props => {
         <Box sx={styles.descriptionContainer}>
           <Input.StyledInputEnhancer
             autoComplete="off"
-            showexpandicon
+            hasActionsToolBar
             id="tool-description"
             label="Description"
             multiline
@@ -148,7 +148,6 @@ const nameDescriptionInputStyles = () => ({
     display: 'flex',
     flexDirection: 'column',
     position: 'relative',
-    marginTop: '1rem',
   },
   descriptionLengthMessage: {
     textAlign: 'right',

--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -10,7 +10,7 @@ import { ToolkitForm } from '@/[fsd]/features/toolkits/ui';
 import { ArrayFieldInput } from '@/[fsd]/features/toolkits/ui/form/ToolBase';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
-import { Checkbox, Field } from '@/[fsd]/shared/ui';
+import { Checkbox, Field, Input } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
 import { MAX_NAME_LENGTH } from '@/common/constants';
@@ -594,7 +594,7 @@ const ToolBaseProperty = memo(props => {
 
       return (
         <Box sx={styles.nameInputContainer}>
-          <FormInput
+          <Input.StyledInputEnhancer
             key={k}
             required={required}
             label={description ? renderLabelWithHint(required) : label}
@@ -611,15 +611,6 @@ const ToolBaseProperty = memo(props => {
             InputLabelProps={{
               shrink: true,
             }}
-            sx={
-              description
-                ? {
-                    '& .MuiInputLabel-asterisk': {
-                      display: 'none',
-                    },
-                  }
-                : {}
-            }
           />
           {isFocused('label') && MAX_NAME_LENGTH === settings[k]?.length && (
             <Typography

--- a/src/[fsd]/shared/ui/input/InputBase.jsx
+++ b/src/[fsd]/shared/ui/input/InputBase.jsx
@@ -1,9 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 
-import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
-import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import { Box, TextField as MuiTextField } from '@mui/material';
-import IconButton from '@mui/material/IconButton';
 
 import { Label } from '@/[fsd]/shared/ui';
 import useAutoBlur from '@/hooks/useAutoBlur';
@@ -71,7 +68,6 @@ const PROMPT_PAGE_INPUT = {
 const InputBase = memo(props => {
   const {
     variant = INPUT_VARIANTS.standard,
-    showexpandicon = false,
     editswitcher = false,
     editswitchconfig = {},
     onDrop,
@@ -232,28 +228,13 @@ const InputBase = memo(props => {
               sx: styles.inputSlot,
               readOnly: editswitcher,
               onDoubleClick: () => {},
-              endAdornment:
-                showexpandicon && !hasActionsToolBar ? (
-                  <IconButton
-                    size="small"
-                    variant="icon"
-                    color="tertiary"
-                    onClick={switchRows}
-                    sx={styles.expandIconButton}
-                  >
-                    {isExpanded ? (
-                      <UnfoldLessIcon sx={[styles.unfoldIcon, styles.iconSize]} />
-                    ) : (
-                      <UnfoldMoreIcon sx={[styles.unfoldIcon, styles.iconSize]} />
-                    )}
-                  </IconButton>
-                ) : null,
               disableUnderline,
             },
             htmlInput: inputProps,
             inputLabel: {
               ...InputLabelProps,
               sx: {
+                textOverflow: 'clip',
                 ...InputLabelProps?.sx,
                 ...(leftProps.required && { '& .MuiInputLabel-asterisk': { display: 'none' } }),
                 ...(tooltipDescription && { pointerEvents: 'auto', zIndex: 1 }),
@@ -281,7 +262,7 @@ const styledInputBaseStyles = (hasLabel, editswitcher, editswitchconfig, isColla
     display: 'flex',
     justifyContent: 'flex-end',
     gap: spacing(0.5),
-    top: hasLabel ? '-0.15rem' : '-1.25rem',
+    top: hasLabel ? '0.15rem' : '-1.25rem',
     right: spacing(1.5),
     zIndex: 999,
   }),

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -496,10 +496,14 @@ const CredentialsSelect = memo(
             left: '0.75rem',
             fontSize: '1rem',
             fontWeight: 500,
+            ...(required && {
+              '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
+            }),
           }}
           shrink
         >
           {label}
+          {required && ' *'}
           <Box
             component="span"
             sx={{ marginLeft: '0.15rem', ':hover': { opacity: 0.8 } }}
@@ -523,7 +527,7 @@ const CredentialsSelect = memo(
           </Box>
         </InputLabel>
       );
-    }, [description, label]);
+    }, [description, label, required]);
 
     const selectError = error || (mismatchedPrivateCredential && hasFetchedData);
 


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4657

- Fixed label clipping in the Firefox
- Fixed the display of Asterix's mui 
- Deleted deprecated expand icon in the InputBase (Kate`s requirment)
- Changed layout descripiton field and action icons

<img width="479" height="483" alt="Screenshot 2026-04-16 193305" src="https://github.com/user-attachments/assets/3344abec-4e34-48b0-8327-74c0b9d670f1" />
<img width="530" height="213" alt="image" src="https://github.com/user-attachments/assets/a45e788d-2dc3-42e2-ad3e-13e8e3c65f0a" />

<img width="441" height="106" alt="Screenshot 2026-04-16 193357" src="https://github.com/user-attachments/assets/c20fecbe-5e28-40db-972e-e786df515d8a" />
