### PR TITLE
fix: [EL-4687] Login button appears for SharePoint App-Only auth (should only show for Delegated)

### DIFF
--- a/src/[fsd]/features/sharepoint/ui/SharepointOAuthStatus.jsx
+++ b/src/[fsd]/features/sharepoint/ui/SharepointOAuthStatus.jsx
@@ -6,7 +6,7 @@ import { Box, Button, Typography } from '@mui/material';
 
 import { McpAuthHelpers } from '@/[fsd]/features/mcp/lib/helpers';
 import { useConfigOAuthModal, useMcpTokenChange } from '@/[fsd]/features/mcp/lib/hooks';
-import { McpAuthModal, McpAuthStatus, McpLogoutModal } from '@/[fsd]/features/mcp/ui';
+import { McpAuthModal, McpLogoutModal } from '@/[fsd]/features/mcp/ui';
 import { useResolvedSharepointConfig } from '@/[fsd]/features/sharepoint/lib/hooks/useResolvedSharepointConfig.hooks';
 import { useSharepointCheckConnection } from '@/[fsd]/features/sharepoint/lib/hooks/useSharepointCheckConnection.hooks';
 import OnlineIcon from '@/assets/online-icon.svg?react';
@@ -50,18 +50,6 @@ const SharepointOAuthStatus = memo(() => {
     onSuccess: !oauthEndpoint ? onNonDelegatedSuccess : undefined,
   });
 
-  // authConfig injected into McpAuthStatus for the non-delegated (app credentials) case.
-  const nonDelegatedAuthConfig = useMemo(
-    () => ({
-      tokenOptions: { serverUrl: connectionTokenKey },
-      serverUrl: connectionTokenKey,
-      tokenStorageKey: connectionTokenKey,
-      onLogin: handleMcpAuthRequired => runCheck(handleMcpAuthRequired, null),
-      isRunning,
-    }),
-    [connectionTokenKey, runCheck, isRunning],
-  );
-
   const onLogin = useCallback(() => {
     runCheck(configOAuth.handleConfigAuthRequired, oauthTokenKey);
   }, [runCheck, configOAuth.handleConfigAuthRequired, oauthTokenKey]);
@@ -80,15 +68,9 @@ const SharepointOAuthStatus = memo(() => {
 
   // No credential configured at all — nothing to render (checked after all hooks)
   if (!spConfig) return null;
-
-  // Non-delegated (app credentials only): use McpAuthStatus with injected authConfig
-  if (!oauthEndpoint) {
-    return <McpAuthStatus authConfig={nonDelegatedAuthConfig} />;
-  }
-
   return (
     <>
-      <Box sx={styles.loginStatusContainer}>
+      <Box sx={styles.loginStatusContainer(!!oauthEndpoint)}>
         <Box sx={styles.statusContent}>
           <OnlineIcon style={styles.statusIconOnline} />
           <Typography
@@ -132,20 +114,22 @@ const getStyles = isLoggedIn => ({
   loginStatusText: ({ palette }) => ({
     color: isLoggedIn ? palette.text.mcp.loginSuccess : palette.text.mcp.logout,
   }),
-  loginStatusContainer: ({ palette }) => ({
-    marginTop: '1rem',
-    height: '2.75rem',
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.5rem',
-    marginBottom: '1rem',
-    padding: '.5rem .5rem .5rem 1rem',
-    borderRadius: '2.345rem',
-    backgroundColor: isLoggedIn ? palette.background.mcp.loginSuccess : palette.background.mcp.logout,
-    border: `0.0625rem solid ${isLoggedIn ? palette.border.mcp.loginSuccess : palette.border.mcp.logout}`,
-    justifyContent: 'space-between',
-  }),
+  loginStatusContainer:
+    isDelegated =>
+    ({ palette }) => ({
+      display: isDelegated ? 'flex' : 'none',
+      marginTop: '1rem',
+      height: '2.75rem',
+      width: '100%',
+      alignItems: 'center',
+      gap: '0.5rem',
+      marginBottom: '1rem',
+      padding: '.5rem .5rem .5rem 1rem',
+      borderRadius: '2.345rem',
+      backgroundColor: isLoggedIn ? palette.background.mcp.loginSuccess : palette.background.mcp.logout,
+      border: `0.0625rem solid ${isLoggedIn ? palette.border.mcp.loginSuccess : palette.border.mcp.logout}`,
+      justifyContent: 'space-between',
+    }),
 });
 
 SharepointOAuthStatus.displayName = 'SharepointOAuthStatus';


### PR DESCRIPTION
# PR: Simplify SharepointOAuthStatus Component

## Summary

Simplified the `SharepointOAuthStatus` component by removing separate handling for non-delegated (app credentials) authentication and consolidating the UI into a single, cleaner implementation.

## Changes

### 1. Removed Unused Import

```diff
- import { McpAuthModal, McpAuthStatus, McpLogoutModal } from '@/[fsd]/features/mcp/ui';
+ import { McpAuthModal, McpLogoutModal } from '@/[fsd]/features/mcp/ui';
```

Removed `McpAuthStatus` which is no longer used after refactoring.

### 2. Removed Non-Delegated Auth Config

```diff
- // authConfig injected into McpAuthStatus for the non-delegated (app credentials) case.
- const nonDelegatedAuthConfig = useMemo(
-   () => ({
-     tokenOptions: { serverUrl: connectionTokenKey },
-     serverUrl: connectionTokenKey,
-     tokenStorageKey: connectionTokenKey,
-     onLogin: handleMcpAuthRequired => runCheck(handleMcpAuthRequired, null),
-     isRunning,
-   }),
-   [connectionTokenKey, runCheck, isRunning],
- );
```

Removed the `useMemo` block that was creating a separate auth configuration for non-delegated (app credentials only) scenarios.

### 3. Unified Rendering Logic

**Before:**
```jsx
// No credential configured at all — nothing to render (checked after all hooks)
if (!spConfig) return null;

// Non-delegated (app credentials only): use McpAuthStatus with injected authConfig
if (!oauthEndpoint) {
  return <McpAuthStatus authConfig={nonDelegatedAuthConfig} />;
}

return (
  <>
    <Box sx={styles.loginStatusContainer}>
      {/* OAuth status UI */}
    </Box>
    {/* Modals */}
  </>
);
```

**After:**
```jsx
// No credential configured at all — nothing to render (checked after all hooks)
if (!spConfig) return null;

return (
  <>
    <Box sx={styles.loginStatusContainer(!!oauthEndpoint)}>
      {/* OAuth status UI */}
    </Box>
    {/* Modals */}
  </>
);
```

Removed the conditional rendering path that used `McpAuthStatus` for non-delegated auth. Now the component always renders the same UI structure but conditionally displays it based on whether OAuth is configured.

### 4. Updated Style Logic

```diff
- loginStatusContainer: ({ palette }) => ({
-   marginTop: '1rem',
-   height: '2.75rem',
-   width: '100%',
-   display: 'flex',
-   ...
- }),
+ loginStatusContainer:
+   isDelegated =>
+   ({ palette }) => ({
+     display: isDelegated ? 'flex' : 'none',
+     marginTop: '1rem',
+     height: '2.75rem',
+     width: '100%',
+     ...
+   }),
```

Modified `loginStatusContainer` to accept an `isDelegated` parameter and conditionally show/hide the OAuth status container:
- **Delegated (OAuth configured)**: `display: 'flex'` → visible
- **Non-delegated (app credentials only)**: `display: 'none'` → hidden

## Behavior

### Before
- **Delegated auth** (OAuth configured): Showed OAuth status with login/logout buttons
- **Non-delegated auth** (app credentials only): Showed `McpAuthStatus` component with different UI

### After
- **Delegated auth** (OAuth configured): Shows OAuth status with login/logout buttons (same as before)
- **Non-delegated auth** (app credentials only): Hides the entire status container (cleaner UX)

## Rationale

1. **Reduced Complexity**: Removed dual-path rendering logic that handled OAuth and app credentials differently
2. **Better UX**: For non-delegated auth, the status container is now hidden rather than showing a different UI component
3. **Code Maintainability**: Single rendering path is easier to understand and maintain
4. **Removed Dead Code**: Eliminated `nonDelegatedAuthConfig` and `McpAuthStatus` usage that added unnecessary complexity

## Testing

- [x] OAuth-enabled Sharepoint toolkit: Status container displays with login/logout functionality
- [x] App credentials-only Sharepoint toolkit: Status container is hidden
- [x] No credentials configured: Component returns null (no changes)

## Files Changed

- `src/[fsd]/features/sharepoint/ui/SharepointOAuthStatus.jsx`

## Related Components

- `McpAuthStatus` - No longer used in this component
- `McpAuthModal` - Still used for OAuth flow
- `McpLogoutModal` - Still used for logout confirmation
