### PR TITLE
fix: [EL-4473] fix text overlap by applying line-clamp to Typography child

### DIFF
--- a/src/components/NotificationListItem.jsx
+++ b/src/components/NotificationListItem.jsx
@@ -189,12 +189,15 @@ const notificationListItemStyles = clampLines => ({
     overflow: 'hidden',
   },
   message: {
+    overflow: 'hidden',
     ...(clampLines
       ? {
-          display: '-webkit-box',
-          WebkitLineClamp: clampLines,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
+          '& > *': {
+            display: '-webkit-box',
+            WebkitLineClamp: clampLines,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          },
         }
       : {}),
   },


### PR DESCRIPTION
Previously, `display: -webkit-box ` was applied to the wrapper Box element, which didn't properly engage line-clamping when the child was a block-level Typography component. Moving the styles to` '& > *' targets ` the Typography directly, ensuring consistent line-clamping across browsers.


<img width="429" height="381" alt="image" src="https://github.com/user-attachments/assets/e08a2646-7ba6-42c3-9b08-fbe688376c47" />
