### PR TITLE
fix: [EL-4695] preserve checkbox state and selection across pagination

### DIFF
--- a/src/[fsd]/entities/grid-table/lib/hooks/useRowSelection.hooks.js
+++ b/src/[fsd]/entities/grid-table/lib/hooks/useRowSelection.hooks.js
@@ -7,21 +7,40 @@ export const useRowSelection = options => {
 
   const allRowIds = useMemo(() => rows.map(row => row[idField]), [rows, idField]);
 
+  const allRowIdsSet = useMemo(() => new Set(allRowIds), [allRowIds]);
+
+  const currentPageSelectedCount = useMemo(
+    () => selectedIds.filter(id => allRowIdsSet.has(id)).length,
+    [selectedIds, allRowIdsSet],
+  );
+
   const isAllSelected = useMemo(
-    () => selectedIds.length === rows.length && rows.length > 0,
-    [selectedIds.length, rows.length],
+    () => currentPageSelectedCount === rows.length && rows.length > 0,
+    [currentPageSelectedCount, rows.length],
   );
 
   const isIndeterminate = useMemo(
-    () => selectedIds.length > 0 && selectedIds.length < rows.length,
-    [selectedIds.length, rows.length],
+    () => currentPageSelectedCount > 0 && currentPageSelectedCount < rows.length,
+    [currentPageSelectedCount, rows.length],
   );
 
   const selectedCount = selectedIds.length;
 
   const handleSelectAll = useCallback(() => {
-    setSelectedIds(isAllSelected ? [] : allRowIds);
-  }, [isAllSelected, allRowIds]);
+    // Selection is preserved across pages. When all rows on the current page are selected,
+    // toggling "select all" removes only the current page row IDs and keeps selections
+    // from other pages intact.
+    if (isAllSelected) {
+      setSelectedIds(prev => prev.filter(id => !allRowIdsSet.has(id)));
+    } else {
+      setSelectedIds(prev => {
+        const prevSelectedIdsSet = new Set(prev);
+        const nextRowIds = allRowIds.filter(id => !prevSelectedIdsSet.has(id));
+
+        return [...prev, ...nextRowIds];
+      });
+    }
+  }, [isAllSelected, allRowIds, allRowIdsSet]);
 
   const handleSelectRow = useCallback(rowId => {
     setSelectedIds(prev => {

--- a/src/pages/NotificationCenter/NotificationTable.jsx
+++ b/src/pages/NotificationCenter/NotificationTable.jsx
@@ -58,8 +58,17 @@ const NotificationTable = memo(props => {
     isIndeterminate,
     handleSelectAll,
     handleSelectRow,
-    clearSelection,
+    selectRows,
   } = useRowSelection({ rows, idField: 'id' });
+
+  const removeIdsFromSelection = useCallback(
+    ids => {
+      const idsSet = new Set(ids);
+
+      return selectRows(rowSelectionModel.filter(id => !idsSet.has(id)));
+    },
+    [rowSelectionModel, selectRows],
+  );
 
   const { page, pageSize } = paginationModel;
 
@@ -103,25 +112,12 @@ const NotificationTable = memo(props => {
     [setSortModel, setPaginationModel],
   );
 
-  const handleDeleteSelected = useCallback(async () => {
-    if (!rowSelectionModel.length || !personal_project_id) return;
-    try {
-      await bulkDeleteNotifications({ projectId: personal_project_id, ids: rowSelectionModel }).unwrap();
-      clearSelection();
-      toastSuccess('Notifications deleted successfully');
-    } catch (err) {
-      toastError(buildErrorMessage(err));
-    }
-  }, [
-    rowSelectionModel,
-    bulkDeleteNotifications,
-    personal_project_id,
-    clearSelection,
-    toastError,
-    toastSuccess,
-  ]);
-
   const selectedRowIds = useMemo(() => new Set(rowSelectionModel), [rowSelectionModel]);
+
+  const currentPageSelectedIds = useMemo(
+    () => rows.filter(row => selectedRowIds.has(row.id)).map(row => row.id),
+    [rows, selectedRowIds],
+  );
 
   const shouldMarkAsRead = useMemo(
     () => rows.some(row => selectedRowIds.has(row.id) && !row.is_seen),
@@ -129,30 +125,48 @@ const NotificationTable = memo(props => {
   );
 
   const canMarkToggle = useMemo(
-    () => rowSelectionModel.length > 0 && !!personal_project_id,
-    [rowSelectionModel, personal_project_id],
+    () => currentPageSelectedIds.length > 0 && !!personal_project_id,
+    [currentPageSelectedIds, personal_project_id],
   );
+
+  const handleDeleteSelected = useCallback(async () => {
+    if (!currentPageSelectedIds.length || !personal_project_id) return;
+    try {
+      await bulkDeleteNotifications({ projectId: personal_project_id, ids: currentPageSelectedIds }).unwrap();
+      removeIdsFromSelection(currentPageSelectedIds);
+      toastSuccess('Notifications deleted successfully');
+    } catch (err) {
+      toastError(buildErrorMessage(err));
+    }
+  }, [
+    currentPageSelectedIds,
+    bulkDeleteNotifications,
+    personal_project_id,
+    removeIdsFromSelection,
+    toastError,
+    toastSuccess,
+  ]);
 
   const handleMarkToggle = useCallback(async () => {
     if (!canMarkToggle) return;
     try {
       await bulkMarkSeenNotifications({
         projectId: personal_project_id,
-        ids: rowSelectionModel,
+        ids: currentPageSelectedIds,
         isSeen: shouldMarkAsRead,
       }).unwrap();
-      clearSelection();
+      removeIdsFromSelection(currentPageSelectedIds);
       toastSuccess(shouldMarkAsRead ? 'Notifications marked as read' : 'Notifications marked as unread');
     } catch (err) {
       toastError(buildErrorMessage(err));
     }
   }, [
     canMarkToggle,
-    rowSelectionModel,
+    currentPageSelectedIds,
     bulkMarkSeenNotifications,
     personal_project_id,
     shouldMarkAsRead,
-    clearSelection,
+    removeIdsFromSelection,
     toastError,
     toastSuccess,
   ]);
@@ -197,7 +211,7 @@ const NotificationTable = memo(props => {
         toolbarSx={styles.toolbarOverride}
         toolbar={
           <NotificationTableToolbar
-            rowSelectionModel={rowSelectionModel}
+            rowSelectionModel={currentPageSelectedIds}
             onDeleteSelected={handleDeleteSelected}
             onMarkToggle={handleMarkToggle}
             markAsRead={shouldMarkAsRead}


### PR DESCRIPTION
- Fix useRowSelection hook to compute checkbox state based on current page rows only
- Preserve cross-page selections when navigating pages
- Scope bulk actions (mark as read/delete) to current page selections only
- Add performance optimizations: use Set for deduplication and O(n) lookups