### PR TITLE
fix: [EL-4657] Fixed cut of info icon and layout of select in the ToolBaseProperty

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -179,8 +179,8 @@ const ToolBaseProperty = memo(props => {
           >
             <Box sx={styles.infoIconWrapper}>
               <InfoIcon
-                width={22}
-                height={22}
+                width={19}
+                height={19}
               />
             </Box>
           </Tooltip>
@@ -651,7 +651,7 @@ const toolBasePropertyStyles = theme => ({
     marginLeft: 0,
   },
   select: {
-    marginTop: '1rem',
+    marginTop: '0.5rem',
   },
   nameInputContainer: {
     width: '100%',

--- a/src/[fsd]/shared/ui/input/InputBase.jsx
+++ b/src/[fsd]/shared/ui/input/InputBase.jsx
@@ -160,9 +160,20 @@ const InputBase = memo(props => {
   const isCollapsed = rows === minRows && minRows !== maxRows;
   const isExpanded = rows === maxRows;
 
+  const needsLabelUnclip =
+    typeof leftProps.label !== 'string' || Boolean(tooltipDescription);
+
   const styles = useMemo(
-    () => styledInputBaseStyles(leftProps.label, editswitcher, editswitchconfig, isCollapsed, minRows),
-    [leftProps.label, editswitcher, editswitchconfig, isCollapsed, minRows],
+    () =>
+      styledInputBaseStyles(
+        leftProps.label,
+        editswitcher,
+        editswitchconfig,
+        isCollapsed,
+        minRows,
+        needsLabelUnclip,
+      ),
+    [leftProps.label, editswitcher, editswitchconfig, isCollapsed, minRows, needsLabelUnclip],
   );
 
   const getLabelContent = () => {
@@ -234,7 +245,7 @@ const InputBase = memo(props => {
             inputLabel: {
               ...InputLabelProps,
               sx: {
-                textOverflow: 'clip',
+                ...styles.inputLabelSlot,
                 ...InputLabelProps?.sx,
                 ...(leftProps.required && { '& .MuiInputLabel-asterisk': { display: 'none' } }),
                 ...(tooltipDescription && { pointerEvents: 'auto', zIndex: 1 }),
@@ -251,7 +262,21 @@ const InputBase = memo(props => {
 InputBase.displayName = 'InputBase';
 
 /** @type {MuiSx} */
-const styledInputBaseStyles = (hasLabel, editswitcher, editswitchconfig, isCollapsed, minRows) => ({
+const styledInputBaseStyles = (
+  hasLabel,
+  editswitcher,
+  editswitchconfig,
+  isCollapsed,
+  minRows,
+  needsLabelUnclip,
+) => ({
+  inputLabelSlot: {
+    textOverflow: 'clip',
+    ...(needsLabelUnclip && {
+      overflow: 'visible',
+      maxWidth: 'none',
+    }),
+  },
   containerBox: {
     position: 'relative',
     display: 'flex',


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4657

- Fixed when cut info icon was cut
- Fixed layout of select in the ToolBaseProperty 
- Fixed size of info icon for select component 

**BEFORE**
<img width="654" height="132" alt="Screenshot 2026-04-17 124500" src="https://github.com/user-attachments/assets/7577b830-f974-4b21-82c9-f9dfc72b4767" />

**AFTER**
<img width="1071" height="383" alt="Screenshot 2026-04-17 131040" src="https://github.com/user-attachments/assets/f526eff8-05be-43cc-b3ca-378f81023314" />
