### PR TITLE
fix: [EL-4701] guard unpublished agent versions in conversations

### DIFF
--- a/src/pages/NewChat/AgentEditorPanel.jsx
+++ b/src/pages/NewChat/AgentEditorPanel.jsx
@@ -271,11 +271,7 @@ const AgentEditorPanel = ({
   }, [isPipeline, onClosePipelineEditor, onCloseAgentEditor]);
 
   const selectedVersion = useMemo(() => {
-    return (
-      participantDetails?.versions?.find(version => version.id === selectedVersionId) ||
-      participantDetails?.versions?.[0] ||
-      {}
-    );
+    return participantDetails?.versions?.find(version => version.id === selectedVersionId) || {};
   }, [participantDetails?.versions, selectedVersionId]);
 
   const isSelectedVersionPublished = useMemo(() => {

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -34,6 +34,7 @@ import { useListModelsQuery } from '@/api/configurations.js';
 import {
   ChatParticipantType,
   PROMPT_PAYLOAD_KEY,
+  PUBLIC_PROJECT_ID,
   ROLES,
   ToolActionStatus,
   WELCOME_MESSAGE_ID,
@@ -1737,6 +1738,14 @@ const ChatBox = forwardRef((props, boxRef) => {
     ],
   );
 
+  const isActiveParticipantBroken = useMemo(() => {
+    if (!activeParticipant) return false;
+    if (activeParticipant.entity_meta?.project_id != PUBLIC_PROJECT_ID) return false;
+    const versions = activeParticipantDetails?.versions;
+    if (!versions) return false;
+    return !versions.some(v => v.id === activeParticipant.entity_settings?.version_id);
+  }, [activeParticipant, activeParticipantDetails?.versions]);
+
   const isInputDisabled = useMemo(
     () =>
       isLoadingConversation ||
@@ -1746,7 +1755,8 @@ const ChatBox = forwardRef((props, boxRef) => {
       isUpdatingInternalToolsConfig ||
       activeConversation?.isSending ||
       (hasPendingHitlInterrupt && !hitlEditMode) ||
-      isStreamingNow,
+      isStreamingNow ||
+      isActiveParticipantBroken,
     [
       isLoadingConversation,
       isProcessingSymbols,
@@ -1757,6 +1767,7 @@ const ChatBox = forwardRef((props, boxRef) => {
       hasPendingHitlInterrupt,
       hitlEditMode,
       isStreamingNow,
+      isActiveParticipantBroken,
     ],
   );
 

--- a/src/pages/NewChat/Participants/ParticipantItem.jsx
+++ b/src/pages/NewChat/Participants/ParticipantItem.jsx
@@ -104,6 +104,7 @@ const ParticipantItem = memo(props => {
   );
   const [versionName, setVersionName] = useState('');
   const [originalDetails, setOriginalDetails] = useState({});
+  const [hasFetchedDetails, setHasFetchedDetails] = useState(false);
   const { fetchOriginalDetails } = useFetchParticipantDetails();
 
   // Monitor MCP token changes for remote MCP toolkits
@@ -161,6 +162,25 @@ const ParticipantItem = memo(props => {
   }, [originalDetails?.name, entity_meta?.name, participantName]);
 
   const isPublishedParticipant = entity_meta?.project_id == PUBLIC_PROJECT_ID;
+
+  const isPublishedAgentGone = useMemo(
+    () => isPublishedParticipant && hasFetchedDetails && !originalDetails?.versions?.length,
+    [isPublishedParticipant, hasFetchedDetails, originalDetails?.versions?.length],
+  );
+
+  const isVersionUnavailable = useMemo(
+    () =>
+      isPublishedParticipant &&
+      hasFetchedDetails &&
+      originalDetails?.versions?.length > 0 &&
+      !originalDetails.versions.some(v => v.id === participant.entity_settings?.version_id),
+    [
+      isPublishedParticipant,
+      hasFetchedDetails,
+      originalDetails?.versions,
+      participant.entity_settings?.version_id,
+    ],
+  );
 
   useValidateApplicationVersion(
     !isPublishedParticipant &&
@@ -237,6 +257,14 @@ const ParticipantItem = memo(props => {
   const styles = participantItemStyles({ collapsed, isActive, maxWidth });
 
   const warningMessage = useMemo(() => {
+    if (isPublishedAgentGone) {
+      return 'Published agent is no longer available';
+    }
+
+    if (isVersionUnavailable) {
+      return 'Published version not available, select another version';
+    }
+
     if (totalValidationInfo?.length || toolkitValidationInfoList?.length) {
       const isPipelineAgent = participant.entity_settings?.agent_type === 'pipeline';
 
@@ -299,6 +327,8 @@ const ParticipantItem = memo(props => {
 
     return '';
   }, [
+    isPublishedAgentGone,
+    isVersionUnavailable,
     totalValidationInfo?.length,
     toolkitValidationInfoList?.length,
     shouldDisableThisItem,
@@ -348,10 +378,19 @@ const ParticipantItem = memo(props => {
   }, []);
 
   useEffect(() => {
-    if ((totalValidationInfo?.length || toolkitValidationInfoList?.length) && isActive) {
+    if (
+      (totalValidationInfo?.length || toolkitValidationInfoList?.length || isPublishedAgentGone) &&
+      isActive
+    ) {
       onClickItem(undefined); // Deselect if active and not matched
     }
-  }, [isActive, onClickItem, toolkitValidationInfoList?.length, totalValidationInfo?.length]);
+  }, [
+    isActive,
+    onClickItem,
+    toolkitValidationInfoList?.length,
+    totalValidationInfo?.length,
+    isPublishedAgentGone,
+  ]);
 
   useEffect(() => {
     const getVersions = async () => {
@@ -362,10 +401,11 @@ const ParticipantItem = memo(props => {
           entity_meta.project_id,
         );
         setOriginalDetails(data);
+        setHasFetchedDetails(true);
       }
     };
     // Only fetch original details if we don't have them yet
-    if (entity_meta?.id && entity_meta?.project_id && !originalDetails?.versions?.length) {
+    if (entity_meta?.id && entity_meta?.project_id && !hasFetchedDetails) {
       getVersions();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -397,7 +437,9 @@ const ParticipantItem = memo(props => {
     !mcpIsDisconnected &&
     !remoteMcpLoggedOut &&
     !spOAuthLoggedOut &&
-    !someToolsAreUnavailable ? (
+    !someToolsAreUnavailable &&
+    !isVersionUnavailable &&
+    !isPublishedAgentGone ? (
       <Box
         onClick={onClickHandler}
         onMouseEnter={onMouseEnter}
@@ -525,7 +567,7 @@ const ParticipantItem = memo(props => {
       </Box>
     ) : (
       <StyledTipsContainer
-        onClick={isActive ? onClickHandler : undefined}
+        onClick={isActive || isVersionUnavailable ? onClickHandler : undefined}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         sx={styles.attentionWrapper}
@@ -567,7 +609,7 @@ const ParticipantItem = memo(props => {
               participant={participant}
               onEdit={onEdit}
               onDelete={onDelete}
-              disabledEdit={disabledEdit}
+              disabledEdit={disabledEdit || isPublishedAgentGone || isVersionUnavailable}
               disabledDeleteButton={disabledEdit}
               showButtons={isHovering}
               showEditButton={showEditButton}


### PR DESCRIPTION
Detect when a published agent's version used in a conversation has been unpublished. Show 'Published version not available, select another version' warning on the participant item (reusing the existing attention/error pattern). When all versions are unpublished, show 'Published agent is no longer available' with Edit button disabled. Remove silent auto-fallback to first available version in the version dropdown. Disable the send button when the active published participant has an unavailable version. The participant remains selectable so the user can access the version dropdown to pick another available version.

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/4701