### PR TITLE
Fix: [EL-4704] create toolkit form UI issues

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
@@ -62,6 +62,7 @@ const ToolBase = memo(props => {
   } = editToolDetail;
   // console.log('toolErrors', toolErrors);
   const theme = useTheme();
+  const styles = toolBaseStyles();
   const systemSenderName = useSystemSenderName();
   const [, setNotSelectedFields] = useState([]);
   const [showDisabledConfigFields, setShowDisabledConfigFields] = useState(false);
@@ -210,7 +211,7 @@ const ToolBase = memo(props => {
   };
 
   const toolBaseConfiguration = (
-    <>
+    <Box sx={styles.configurationContainer}>
       {!hideNameDescriptionInput && (
         <ToolkitForm.NameDescriptionInput
           type={editToolDetail?.type || ''}
@@ -466,7 +467,7 @@ const ToolBase = memo(props => {
             />
           );
         })}
-    </>
+    </Box>
   );
 
   // Handler for when remote MCP tools are fetched
@@ -581,5 +582,14 @@ const ToolBase = memo(props => {
 });
 
 ToolBase.displayName = 'ToolBase';
+
+/** @type {MuiSx} */
+const toolBaseStyles = () => ({
+  configurationContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+});
 
 export default ToolBase;

--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -597,7 +597,8 @@ const ToolBaseProperty = memo(props => {
           <Input.StyledInputEnhancer
             key={k}
             required={required}
-            label={description ? renderLabelWithHint(required) : label}
+            label={label}
+            tooltipDescription={description}
             value={settings[k]}
             onChange={handleInputChange(buildEditFieldPath(k))}
             error={!!toastError}
@@ -608,9 +609,6 @@ const ToolBaseProperty = memo(props => {
             placeholder={placeholder}
             onFocus={() => toggleFieldFocus(k)}
             onBlur={() => toggleFieldFocus(null)}
-            InputLabelProps={{
-              shrink: true,
-            }}
           />
           {isFocused('label') && MAX_NAME_LENGTH === settings[k]?.length && (
             <Typography

--- a/src/[fsd]/shared/ui/input/InputBase.jsx
+++ b/src/[fsd]/shared/ui/input/InputBase.jsx
@@ -160,8 +160,7 @@ const InputBase = memo(props => {
   const isCollapsed = rows === minRows && minRows !== maxRows;
   const isExpanded = rows === maxRows;
 
-  const needsLabelUnclip =
-    typeof leftProps.label !== 'string' || Boolean(tooltipDescription);
+  const needsLabelUnclip = typeof leftProps.label !== 'string' || Boolean(tooltipDescription);
 
   const styles = useMemo(
     () =>

--- a/src/[fsd]/shared/ui/input/textFieldVariants.js
+++ b/src/[fsd]/shared/ui/input/textFieldVariants.js
@@ -93,7 +93,7 @@ export const eliteaTextFieldStyle = () => ({
     minWidth: 16,
     minHeight: 16,
     overflow: 'visible',
-    transform: 'scale(1.2)',
+    transform: 'scale(1.3334)',
     transformOrigin: 'center',
   },
   '& .MuiInputLabel-root': {

--- a/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
+++ b/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
@@ -19,6 +19,7 @@ const InfoLabelWithTooltip = memo(props => {
     inheritColor = false,
     inheritLabel = false,
     iconSize = 16,
+    required = false,
   } = props;
 
   const labelSx = [
@@ -27,19 +28,21 @@ const InfoLabelWithTooltip = memo(props => {
     ...(labelSxProp ? [labelSxProp] : []),
   ];
 
+  const labelContent = required ? `${label} *` : label;
+
   const labelNode = inheritLabel ? (
     <Box
       component="span"
       sx={labelSx}
     >
-      {label}
+      {labelContent}
     </Box>
   ) : (
     <Typography
       variant={variant}
       sx={labelSx}
     >
-      {label}
+      {labelContent}
     </Typography>
   );
 

--- a/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
+++ b/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
@@ -14,14 +14,17 @@ const InfoLabelWithTooltip = memo(props => {
     tooltip,
     variant = 'bodySmall',
     sx,
+    labelSx: labelSxProp,
     labelTextPointerEventsNone = false,
     inheritColor = false,
     inheritLabel = false,
+    iconSize = 16,
   } = props;
 
   const labelSx = [
     inheritColor ? { color: 'inherit' } : styles.label,
     ...(labelTextPointerEventsNone ? [{ pointerEvents: 'none' }] : []),
+    ...(labelSxProp ? [labelSxProp] : []),
   ];
 
   const labelNode = inheritLabel ? (
@@ -47,8 +50,8 @@ const InfoLabelWithTooltip = memo(props => {
         <Tooltip title={tooltip}>
           <Box sx={styles.iconWrapper}>
             <InfoIcon
-              width={16}
-              height={16}
+              width={iconSize}
+              height={iconSize}
             />
           </Box>
         </Tooltip>

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -513,7 +513,6 @@ const CredentialsSelect = memo(
             inheritLabel
             inheritColor
             labelTextPointerEventsNone={!!description}
-            iconSize={14}
           />
         </InputLabel>
       );

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -7,7 +7,7 @@ import { Box, FormControl, FormHelperText, IconButton, InputLabel, Tooltip, Typo
 import { useTrackEvent } from '@/GA';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
 import { useContextExecutionEntity } from '@/[fsd]/shared/lib/hooks';
-import { Select } from '@/[fsd]/shared/ui';
+import { Label, Select } from '@/[fsd]/shared/ui';
 import { useLazyGetConfigurationsListQuery, useListModelsQuery } from '@/api/configurations';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
 import BriefcaseIcon from '@/components/Icons/BriefcaseIcon.jsx';
@@ -16,7 +16,6 @@ import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import RouteDefinitions, { getBasename } from '@/routes';
 
 import CredentialWarningBanner from './CredentialWarningBanner';
-import InfoIcon from './Icons/InfoIcon';
 import Person from './Icons/Person';
 
 const credentialMenuItemValue = Object.freeze({
@@ -502,29 +501,14 @@ const CredentialsSelect = memo(
           }}
           shrink
         >
-          {label}
-          {required && ' *'}
-          <Box
-            component="span"
-            sx={{ marginLeft: '0.15rem', ':hover': { opacity: 0.8 } }}
-          >
-            {description && (
-              <Tooltip
-                title={description}
-                placement="top"
-              >
-                <Box
-                  component="span"
-                  sx={{ display: 'inline-flex', verticalAlign: 'middle' }}
-                >
-                  <InfoIcon
-                    width={18}
-                    height={18}
-                  />
-                </Box>
-              </Tooltip>
-            )}
-          </Box>
+          <Label.InfoLabelWithTooltip
+            label={label}
+            required={required}
+            tooltip={description}
+            inheritLabel
+            inheritColor
+            labelTextPointerEventsNone={!!description}
+          />
         </InputLabel>
       );
     }, [description, label, required]);

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -448,26 +448,25 @@ const CredentialsSelect = memo(
     const customRenderSelectValue = useCallback(
       foundOption => {
         if (!foundOption) {
+          if (!value?.elitea_title) return null;
           return (
-            <Box sx={styles.unmatchedValueBox(value?.elitea_title && hasFetchedData)}>
-              {value?.elitea_title ? (
-                value?.private ? (
-                  <Person
-                    key="person-icon"
-                    fontSize="1rem"
-                  />
-                ) : (
-                  <BriefcaseIcon
-                    key="briefcase-icon"
-                    fontSize="1rem"
-                  />
-                )
-              ) : null}
+            <Box sx={styles.unmatchedValueBox(hasFetchedData)}>
+              {value?.private ? (
+                <Person
+                  key="person-icon"
+                  fontSize="1rem"
+                />
+              ) : (
+                <BriefcaseIcon
+                  key="briefcase-icon"
+                  fontSize="1rem"
+                />
+              )}
               <Typography
                 variant="labelMedium"
-                sx={styles.unmatchedValueTypography(value?.elitea_title && hasFetchedData)}
+                sx={styles.unmatchedValueTypography(hasFetchedData)}
               >
-                {!value?.elitea_title ? 'Select credentials' : value.elitea_title}
+                {value.elitea_title}
               </Typography>
             </Box>
           );
@@ -493,13 +492,19 @@ const CredentialsSelect = memo(
           id={`simple-select-label-${label}`}
           sx={{
             left: '0.75rem',
-            fontSize: '1rem',
+            fontSize: '0.875rem',
             fontWeight: 500,
+            '&.MuiInputLabel-shrink': {
+              overflow: 'visible',
+            },
+            '&.MuiInputLabel-shrink svg': {
+              transform: 'scale(1.3334)',
+              transformOrigin: 'left center',
+            },
             ...(required && {
               '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
             }),
           }}
-          shrink
         >
           <Label.InfoLabelWithTooltip
             label={label}
@@ -508,6 +513,7 @@ const CredentialsSelect = memo(
             inheritLabel
             inheritColor
             labelTextPointerEventsNone={!!description}
+            iconSize={14}
           />
         </InputLabel>
       );

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';
 
+import { Label } from '@/[fsd]/shared/ui';
 import { useLazyListModelsQuery, useListModelsQuery } from '@/api/configurations';
 import CheckedIcon from '@/assets/checked-icon.svg?react';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
@@ -23,7 +24,6 @@ import BriefcaseIcon from '@/components/Icons/BriefcaseIcon.jsx';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
 import ArrowDownIcon from './Icons/ArrowDownIcon';
-import InfoIcon from './Icons/InfoIcon';
 import Person from './Icons/Person';
 
 const EmbeddingModelSelect = memo(
@@ -197,31 +197,14 @@ const EmbeddingModelSelect = memo(
               sx={styles.clickableBox(error, open)}
             >
               <Box sx={styles.labelBox}>
-                <Typography
+                <Label.InfoLabelWithTooltip
+                  label={required ? `${label} *` : label}
+                  tooltip={description}
                   variant="bodySmall"
-                  sx={styles.labelTypography(open)}
-                >
-                  {label}
-                  {required && <span> *</span>}
-                  {description && (
-                    <Box
-                      sx={{ marginLeft: '0.15rem', ':hover': { opacity: 0.8 } }}
-                      component="span"
-                    >
-                      <Tooltip
-                        title={description}
-                        placement="top"
-                      >
-                        <Box component="span">
-                          <InfoIcon
-                            width={14}
-                            height={14}
-                          />
-                        </Box>
-                      </Tooltip>
-                    </Box>
-                  )}
-                </Typography>
+                  inheritColor
+                  iconSize={14}
+                  labelSx={styles.labelTypography(open)}
+                />
                 <Tooltip
                   title="Refresh the models"
                   placement="top"

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -202,7 +202,6 @@ const EmbeddingModelSelect = memo(
                   tooltip={description}
                   variant="bodySmall"
                   inheritColor
-                  iconSize={14}
                   labelSx={styles.labelTypography(open)}
                 />
                 <Tooltip

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -270,7 +270,7 @@ const EmbeddingModelSelect = memo(
               open={open}
               anchorEl={panelRef.current}
               placement="bottom-start"
-              style={styles.popper(panelRef)}
+              sx={styles.popper(panelRef)}
             >
               <Box sx={styles.popperBox}>
                 {!isFetching &&
@@ -342,21 +342,27 @@ const styles = {
     width: '100%',
     borderBottom: ({ palette }) =>
       error
-        ? '0.0625rem solid red'
+        ? `0.0625rem solid ${palette.icon.fill.error}`
         : open
           ? `0.0625rem solid ${palette.primary.main}`
           : `0.0625rem solid ${palette.border.lines}`,
+    ...(!error &&
+      !open && {
+        '&:hover': {
+          borderBottom: ({ palette }) => `0.0625rem solid ${palette.border.hover}`,
+        },
+      }),
   }),
   labelTypography: open => ({
-    // color: error ? theme.palette.error.main : theme.palette.text.secondary,
-    color: ({ palette }) => (open ? palette.primary.main : palette.text.secondary),
+    color: ({ palette }) => (open ? palette.primary.main : palette.text.primary),
   }),
   selectedValueTypography: selectedOption => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     minHeight: '1.5rem',
-    color: ({ palette }) => (selectedOption?.label ? palette.text.secondary : palette.text.disabled),
+    color: ({ palette }) =>
+      selectedOption?.label ? palette.text.select.selected.primary : palette.text.default,
   }),
   arrowIcon: open => ({
     fontSize: '1rem',

--- a/src/components/FormViewToggle.jsx
+++ b/src/components/FormViewToggle.jsx
@@ -1,13 +1,25 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 
-import { Box, ToggleButton, ToggleButtonGroup } from '@mui/material';
-
-import Tooltip from '@/ComponentsLib/Tooltip';
+import { TabGroupButton } from '@/[fsd]/shared/ui/tab-group-button';
 import { ToolkitViewOptions } from '@/common/constants';
-import { SPACING } from '@/common/designTokens';
 
-export const FormViewToggle = ({ view = ToolkitViewOptions.Form, onChangeView, containerSX, disabled }) => {
-  const onChange = useCallback(
+const FORM_VIEW_TABS = [
+  {
+    value: ToolkitViewOptions.Form,
+    label: 'Form',
+    tooltip: 'Form view',
+  },
+  {
+    value: ToolkitViewOptions.Json,
+    label: 'Raw Json',
+    tooltip: 'Raw Json view',
+  },
+];
+
+export const FormViewToggle = memo(props => {
+  const { view = ToolkitViewOptions.Form, onChangeView, containerSX, disabled } = props;
+
+  const handleChange = useCallback(
     (_, newValue) => {
       if (newValue !== null && newValue !== view) {
         onChangeView(newValue);
@@ -17,59 +29,14 @@ export const FormViewToggle = ({ view = ToolkitViewOptions.Form, onChangeView, c
   );
 
   return (
-    <ToggleButtonGroup
-      size="small"
+    <TabGroupButton
+      arrayBtn={FORM_VIEW_TABS}
       value={view}
-      onChange={onChange}
-      exclusive={true}
+      onChange={handleChange}
       disabled={disabled}
-      aria-label="Toolkit View Toggler"
-      sx={{ ml: 0, ...containerSX }}
-    >
-      <Tooltip
-        key={ToolkitViewOptions.Form}
-        title="Form view"
-        placement="top"
-      >
-        <Box
-          component="span"
-          sx={{ display: 'inline-flex' }}
-        >
-          <ToggleButton
-            variant="elitea"
-            value={ToolkitViewOptions.Form}
-            sx={{
-              padding: `${SPACING.SM} ${SPACING.SM}`,
-              borderRadius: '8px 0 0 8px',
-              textTransform: 'none',
-            }}
-          >
-            Form
-          </ToggleButton>
-        </Box>
-      </Tooltip>
-      <Tooltip
-        key={ToolkitViewOptions.Json}
-        title="Raw Json view"
-        placement="top"
-      >
-        <Box
-          component="span"
-          sx={{ display: 'inline-flex' }}
-        >
-          <ToggleButton
-            variant="elitea"
-            value={ToolkitViewOptions.Json}
-            sx={{
-              padding: `${SPACING.SM} ${SPACING.SM}`,
-              borderRadius: '0 8px 8px 0',
-              textTransform: 'none',
-            }}
-          >
-            Raw Json
-          </ToggleButton>
-        </Box>
-      </Tooltip>
-    </ToggleButtonGroup>
+      customSx={containerSX}
+    />
   );
-};
+});
+
+FormViewToggle.displayName = 'FormViewToggle';

--- a/src/pages/NewChat/ToolkitEditor.jsx
+++ b/src/pages/NewChat/ToolkitEditor.jsx
@@ -14,7 +14,6 @@ import { useToolkitsDetailsQuery } from '@/api/toolkits';
 import { PUBLIC_PROJECT_ID } from '@/common/constants';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import { CONFIGURATION_VIEW_OPTIONS } from '@/pages/Applications/Components/Tools/ToolConfigurationForm.jsx';
-import { ContentContainer } from '@/pages/Common/Components/StyledComponents.jsx';
 import BaseEditor from '@/pages/NewChat/components/BaseEditor.jsx';
 import CreateToolkitButton from '@/pages/NewChat/components/CreateToolkitButton.jsx';
 import SaveToolkitButton from '@/pages/Toolkits/SaveToolkitButton.jsx';
@@ -213,6 +212,8 @@ const ToolkitEditor = ({ toolkit, onCloseToolkitEditor, onToolkitCreated, onTool
     setIsToolDirty(false);
   }, [toolkitDetails, isCreating]);
 
+  const styles = toolkitEditorStyles();
+
   if (!toolkit) {
     return null;
   }
@@ -250,7 +251,7 @@ const ToolkitEditor = ({ toolkit, onCloseToolkitEditor, onToolkitCreated, onTool
     >
       {isCreating ? (
         // Creation mode: Show ToolkitTypeSelector or ToolkitForm based on whether a type is selected
-        <ContentContainer height="100%">
+        <>
           {editToolDetail ? (
             <ToolkitForm
               editToolDetail={editToolDetail}
@@ -269,6 +270,7 @@ const ToolkitEditor = ({ toolkit, onCloseToolkitEditor, onToolkitCreated, onTool
               isMCP={isMCP}
               onValidationStateChange={setValidationState}
               revertCredentialsRef={revertCredentialsRef}
+              sx={styles.toolkitForm}
             />
           ) : (
             <ToolkitTypeSelector
@@ -278,31 +280,30 @@ const ToolkitEditor = ({ toolkit, onCloseToolkitEditor, onToolkitCreated, onTool
               disableNavigation={true}
             />
           )}
-        </ContentContainer>
+        </>
       ) : editToolDetail ? (
         // Edit mode: Show the existing toolkit configuration
-        <ContentContainer height="100%">
-          <ToolkitForm
-            editToolDetail={editToolDetail}
-            onChangeToolDetail={handleChangeToolDetail}
-            isEditing={true}
-            isToolDirty={isToolDirty}
-            isViewToggleVisible={false}
-            showNameFieldForcedly={false}
-            showToolkitIcon={false}
-            showOnlyConfigurationFields={false}
-            configurationViewOptions={CONFIGURATION_VIEW_OPTIONS.CredentialsSelect}
-            hasNotSavedCredentials={false}
-            hideNameDescriptionInput={false}
-            hideNameInput={!isMCP}
-            hideOperationButtons={true}
-            updateKey={1}
-            isMCP={isMCP}
-            onValidationStateChange={setValidationState}
-            disabled={isPublic && !hasPublicProjectAccess}
-            revertCredentialsRef={revertCredentialsRef}
-          />
-        </ContentContainer>
+        <ToolkitForm
+          editToolDetail={editToolDetail}
+          onChangeToolDetail={handleChangeToolDetail}
+          isEditing={true}
+          isToolDirty={isToolDirty}
+          isViewToggleVisible={false}
+          showNameFieldForcedly={false}
+          showToolkitIcon={false}
+          showOnlyConfigurationFields={false}
+          configurationViewOptions={CONFIGURATION_VIEW_OPTIONS.CredentialsSelect}
+          hasNotSavedCredentials={false}
+          hideNameDescriptionInput={false}
+          hideNameInput={!isMCP}
+          hideOperationButtons={true}
+          updateKey={1}
+          isMCP={isMCP}
+          onValidationStateChange={setValidationState}
+          disabled={isPublic && !hasPublicProjectAccess}
+          revertCredentialsRef={revertCredentialsRef}
+          sx={styles.toolkitForm}
+        />
       ) : (
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '200px' }}>
           <Typography
@@ -322,5 +323,13 @@ const ToolkitEditor = ({ toolkit, onCloseToolkitEditor, onToolkitCreated, onTool
     </BaseEditor>
   );
 };
+
+/** @type {MuiSx} */
+const toolkitEditorStyles = () => ({
+  toolkitForm: {
+    overflow: 'visible',
+    maxHeight: 'none',
+  },
+});
 
 export default ToolkitEditor;

--- a/src/pages/Toolkits/ConfigurationTab.jsx
+++ b/src/pages/Toolkits/ConfigurationTab.jsx
@@ -122,7 +122,7 @@ const styles = {
     paddingRight: '1.5rem !important',
   },
   leftPanel: {
-    overflow: 'scroll',
+    overflow: 'auto',
     maxHeight: '100%',
     height: '100%',
   },

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -447,7 +447,9 @@ export const ToolkitForm = memo(props => {
   const styles = toolkitFormStyles();
 
   return isFetching || editToolDetail?.isLoadingConfigurations ? (
-    <CircularProgress size={20} />
+    <Box sx={styles.loadingContainer}>
+      <CircularProgress />
+    </Box>
   ) : (
     <Box sx={[styles.container, sx]}>
       {editToolDetail.type !== ToolTypes.custom.value && !!effectiveToolSchema && isViewToggleVisible && (
@@ -532,5 +534,12 @@ const toolkitFormStyles = () => ({
   },
   formViewToggle: {
     marginBottom: '0.625rem',
+  },
+  loadingContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
   },
 });

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -527,10 +527,8 @@ export default ToolkitForm;
 /** @type {MuiSx} */
 const toolkitFormStyles = () => ({
   container: {
-    maxHeight: '100%',
     maxWidth: '40.1875rem',
     margin: '0 auto',
-    overflow: 'auto',
   },
   formViewToggle: {
     marginBottom: '0.625rem',


### PR DESCRIPTION
The changes cover four main areas:

- toolkit form spacing and scroll behavior
- loading state alignment on the create toolkit form
- label and tooltip consistency for credential and model selectors
- refactoring `FormViewToggle` to use the shared tab button pattern

## What Changed

### 1. Fixed toolkit form layout and scrolling

- added consistent vertical spacing between toolkit configuration fields
- moved scrolling responsibility to the parent container to avoid nested scroll issues
- removed conflicting internal overflow constraints from `ToolkitForm`
- updated chat toolkit editor and toolkit configuration containers to render the form without clipping

### 2. Aligned loading state behavior

- centered the `ToolkitForm` loading spinner so it matches the loader pattern used on the agent view page
- prevented the loading indicator from rendering in the top-left corner during create flow data loading

### 3. Standardized label and tooltip rendering

- replaced custom label + tooltip markup in `CredentialsSelect` with shared `InfoLabelWithTooltip`
- replaced custom label + tooltip markup in `EmbeddingModelSelect` with shared `InfoLabelWithTooltip`
- updated toolkit base property inputs to pass tooltip descriptions through the shared input path instead of
  custom label rendering
- enhanced `InfoLabelWithTooltip` to support:
  - required marker rendering
  - custom label styles
  - configurable tooltip icon sizing
- aligned text field label/icon scaling with the Simple input variant and design spec

### 4. Refactored form/raw-json toggle

- replaced custom MUI `ToggleButtonGroup` implementation in `FormViewToggle` with shared `TabGroupButton`
- preserved the existing public API while simplifying the component structure
- brought the component in line with project memoization and handler patterns


<img width="1060" height="1033" alt="image" src="https://github.com/user-attachments/assets/5a5b4ff1-de28-4f00-a8c5-c4d19a3986f2" />

<img width="1011" height="696" alt="image" src="https://github.com/user-attachments/assets/dfeaff34-735a-451e-87a9-48c34ff5e9ad" />
