### PR TITLE
fix: [EL-4713] Private credential field fails to reset to default value when discarding changes

### DIFF
--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -316,7 +316,8 @@ const CredentialsSelect = memo(
     useEffect(() => {
       if (!hasFetchedData || !selectedOption) return;
 
-      const isDefaultAutoSelected = selectedOption && isBlankEliteaTitle(value?.elitea_title);
+      const isDefaultAutoSelected =
+        selectedOption && (section === 'vectorstorage' || isBlankEliteaTitle(value?.elitea_title));
 
       if (isDefaultAutoSelected && !hasAutoSelectedRef.current) {
         hasAutoSelectedRef.current = true;
@@ -326,7 +327,7 @@ const CredentialsSelect = memo(
         };
         onSelectConfiguration?.(config);
       }
-    }, [hasFetchedData, selectedOption, value, onSelectConfiguration]);
+    }, [hasFetchedData, selectedOption, value, onSelectConfiguration, section]);
 
     const onSelectItem = useCallback(
       option => {

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -375,7 +375,7 @@ export const ToolkitForm = memo(props => {
       const orig = initialSettings[key];
 
       // Only revert if this is a credential that was changed from team to private
-      if (typeof curr === 'object' && 'elitea_title' in curr) {
+      if (typeof curr === 'object' && curr && 'elitea_title' in curr) {
         if (curr.private !== orig?.private || curr.elitea_title !== orig?.elitea_title) {
           // Revert to original team credential
           editField(`settings.${key}`, orig);


### PR DESCRIPTION
1. add null checking when reverting credentials changes on toolkit
2. for vectorstorage credentials, we should allow to select project default credentials