### PR TITLE
refactor: [EL-4379] Replaced deprecated embedding components to new Select component

### DIFF
--- a/src/[fsd]/shared/ui/select/SingleSelect.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelect.jsx
@@ -10,6 +10,7 @@ import {
   ListSubheader,
   MenuItem,
   Select,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -18,6 +19,7 @@ import { FLAT_MENU_ACTION_VALUE } from '@/[fsd]/shared/lib/constants/singleSelec
 import { Banner } from '@/[fsd]/shared/ui';
 import RemoveIcon from '@/assets/remove-icon.svg?react';
 import ArrowDownIcon from '@/components/Icons/ArrowDownIcon';
+import InfoIcon from '@/components/Icons/InfoIcon';
 
 import SingleSelectDropdown from './SingleSelectDropdown';
 import { getSingleSelectShowBorderSx, getSingleSelectWithoutBorderSx } from './singleSelectVariants';
@@ -73,6 +75,8 @@ const SingleSelect = memo(props => {
     isListFetching = false,
     optionGroups,
     onMenuActionClick,
+    infoIconDescription,
+    shrinkLabel = false,
   } = props;
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -309,6 +313,7 @@ const SingleSelect = memo(props => {
           <SingleSelectDropdown
             key="__menu_action__"
             isMenuAction
+            value={FLAT_MENU_ACTION_VALUE}
           />
         ) : null;
       };
@@ -599,11 +604,37 @@ const SingleSelect = memo(props => {
                   ...(effectiveMultiple && {
                     '&:not(.MuiInputLabel-shrink)': { top: '0.5rem' },
                   }),
+                  ...(required && {
+                    '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
+                  }),
                 },
                 labelSX,
               ]}
+              shrink={shrinkLabel ? true : undefined}
             >
               {label}
+              {required && ' *'}
+              {infoIconDescription && (
+                <Box
+                  component="span"
+                  sx={{
+                    marginLeft: '0.15rem',
+                    ':hover': { opacity: 0.8 },
+                  }}
+                >
+                  <Tooltip
+                    title={infoIconDescription}
+                    placement="top"
+                  >
+                    <Box component="span">
+                      <InfoIcon
+                        width={19}
+                        height={19}
+                      />
+                    </Box>
+                  </Tooltip>
+                </Box>
+              )}
             </InputLabel>
           ))}
         <Select

--- a/src/[fsd]/shared/ui/select/SingleSelectDropdown.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelectDropdown.jsx
@@ -51,6 +51,8 @@ const SingleSelectDropdown = memo(props => {
   if (isMenuAction) {
     return (
       <MenuItem
+        {...restProps}
+        onClick={muiOnClick}
         value={FLAT_MENU_ACTION_VALUE}
         sx={styles.menuActionItem}
       >

--- a/src/[fsd]/shared/ui/select/SingleSelectMenuItem.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelectMenuItem.jsx
@@ -24,7 +24,7 @@ const SingleSelectMenuItem = memo(props => {
     ...restProps
   } = props;
 
-  const styles = menuItemStyles();
+  const styles = menuItemStyles(option);
   const theme = useTheme();
   const selectedBackground = isSelected ? theme.palette.background.participant.active : undefined;
 
@@ -145,14 +145,15 @@ const SingleSelectMenuItem = memo(props => {
 
 SingleSelectMenuItem.displayName = 'SingleSelectMenuItem';
 
-const menuItemStyles = () => ({
-  menuItem: {
+const menuItemStyles = option => ({
+  menuItem: ({ palette }) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
     '&:hover #show-on-hover': {
       display: 'flex',
     },
-  },
+    borderBottom: option.variant === 'action' ? `0.0625rem solid ${palette.border.lines}` : 'none',
+  }),
   iconContainer: {
     display: 'flex',
     alignItems: 'center',

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -2,12 +2,12 @@ import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from '
 
 import { useSelector } from 'react-redux';
 
-import { Box, FormControl, FormHelperText, IconButton, InputLabel, Tooltip, Typography } from '@mui/material';
+import { Box, FormControl, FormHelperText, IconButton, Tooltip, Typography } from '@mui/material';
 
 import { useTrackEvent } from '@/GA';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
 import { useContextExecutionEntity } from '@/[fsd]/shared/lib/hooks';
-import { Label, Select } from '@/[fsd]/shared/ui';
+import { Select } from '@/[fsd]/shared/ui';
 import { useLazyGetConfigurationsListQuery, useListModelsQuery } from '@/api/configurations';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
 import BriefcaseIcon from '@/components/Icons/BriefcaseIcon.jsx';
@@ -489,38 +489,6 @@ const CredentialsSelect = memo(
       [renderValue, value, hasFetchedData],
     );
 
-    const labelNode = useMemo(() => {
-      return (
-        <InputLabel
-          id={`simple-select-label-${label}`}
-          sx={{
-            left: '0.75rem',
-            fontSize: '0.875rem',
-            fontWeight: 500,
-            '&.MuiInputLabel-shrink': {
-              overflow: 'visible',
-            },
-            '&.MuiInputLabel-shrink svg': {
-              transform: 'scale(1.3334)',
-              transformOrigin: 'left center',
-            },
-            ...(required && {
-              '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
-            }),
-          }}
-        >
-          <Label.InfoLabelWithTooltip
-            label={label}
-            required={required}
-            tooltip={description}
-            inheritLabel
-            inheritColor
-            labelTextPointerEventsNone={!!description}
-          />
-        </InputLabel>
-      );
-    }, [description, label, required]);
-
     const selectError = error || (mismatchedPrivateCredential && hasFetchedData);
 
     const showMismatchFooter = Boolean(
@@ -528,10 +496,11 @@ const CredentialsSelect = memo(
     );
 
     return (
-      <Box sx={[{ marginTop: '0.75rem' }, sx]}>
+      <Box sx={[{ marginTop: '0.5rem' }, sx]}>
         <Select.SingleSelect
           label={label}
-          labelNode={labelNode}
+          shrinkLabel
+          infoIconDescription={description}
           required={required}
           error={selectError}
           helperText={showMismatchFooter ? '' : helperText}

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -1,29 +1,15 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import {
-  Box,
-  CircularProgress,
-  ClickAwayListener,
-  FormControl,
-  FormHelperText,
-  IconButton,
-  Popper,
-  SvgIcon,
-  Tooltip,
-  Typography,
-} from '@mui/material';
-import MenuItem from '@mui/material/MenuItem';
+import { Box, Typography } from '@mui/material';
 
-import { Label } from '@/[fsd]/shared/ui';
+import { Select } from '@/[fsd]/shared/ui';
 import { useLazyListModelsQuery, useListModelsQuery } from '@/api/configurations';
-import CheckedIcon from '@/assets/checked-icon.svg?react';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
 import BriefcaseIcon from '@/components/Icons/BriefcaseIcon.jsx';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
-import ArrowDownIcon from './Icons/ArrowDownIcon';
 import Person from './Icons/Person';
 
 const EmbeddingModelSelect = memo(
@@ -35,17 +21,12 @@ const EmbeddingModelSelect = memo(
     helperText,
     value, // Current selected model
     onSelectModel, // Callback for selection change
-    sx,
     renderValue,
     disabled,
   }) => {
-    const [anchorEl, setAnchorEl] = useState(null);
-    const panelRef = useRef(null);
-    const open = Boolean(anchorEl);
     const { personal_project_id } = useSelector(state => state.user);
     const selectedProjectId = useSelectedProjectId();
-    const [getModels, { isFetching }] = useLazyListModelsQuery();
-    const [hasFetchedData, setHasFetchedData] = useState(false);
+    const [getModels] = useLazyListModelsQuery();
 
     const {
       data: embeddingModelsData = {
@@ -65,12 +46,17 @@ const EmbeddingModelSelect = memo(
     );
 
     const [models, setModels] = useState([]);
+    const defaultValueForSelect = value || projectDefaultEmbeddingModel || '';
+
+    const isNewConfigurationPersonal = useCallback(
+      model => model.project_id === personal_project_id,
+      [personal_project_id],
+    );
 
     const onRefresh = useCallback(
       async event => {
         event?.stopPropagation();
         setModels([]);
-        setHasFetchedData(false);
         let teamProjectModels = [];
         if (selectedProjectId) {
           const { data } = await getModels({
@@ -108,7 +94,6 @@ const EmbeddingModelSelect = memo(
           }
           return acc;
         }, []);
-        setHasFetchedData(true);
         setModels(uniqueModels);
       },
       [getModels, personal_project_id, selectedProjectId],
@@ -119,271 +104,70 @@ const EmbeddingModelSelect = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedProjectId, personal_project_id]);
 
-    const handleFocus = useCallback(() => {
-      if (disabled) {
-        return;
-      }
-      setAnchorEl(anchorEl ? null : panelRef.current);
-    }, [anchorEl, disabled]);
+    const newModelsMenuData = useMemo(() => {
+      const modelsOptions = models.map(model => ({
+        value: model.name,
+        label: model.display_name || model.name,
+        icon: isNewConfigurationPersonal(model) ? (
+          <Person sx={{ fontSize: '0.875rem' }} />
+        ) : (
+          <BriefcaseIcon sx={{ fontSize: '0.875rem' }} />
+        ),
+      }));
 
-    const handleClickAway = useCallback(() => {
-      setAnchorEl(null);
-    }, []);
+      return modelsOptions;
+    }, [models, isNewConfigurationPersonal]);
 
-    // Models menu data
-    const modelsMenuData = useMemo(() => {
-      return models.map(model => {
-        const isConfigurationPersonal = model.project_id === personal_project_id;
-        return {
-          id: `${model.name}_${model.project_id}`,
-          name: model.name || model.id,
-          private: isConfigurationPersonal,
-          settings: model.settings || {},
-          label: (
-            <span style={styles.labelContainer}>
-              {isConfigurationPersonal ? (
-                <Person
-                  key="person-icon"
-                  fontSize="1rem"
-                />
-              ) : (
-                <BriefcaseIcon
-                  key="briefcase-icon"
-                  fontSize="1rem"
-                />
-              )}
-              <span key="label-text">{model.display_name || model.name || model.id}</span>
-            </span>
-          ),
-        };
-      });
-    }, [models, personal_project_id]);
+    const optionsWithActions = useMemo(() => {
+      const actionOption = {
+        value: 'refresh-models',
+        label: 'REFRESH',
+        icon: <RefreshIcon sx={{ fontSize: '1rem' }} />,
+        variant: 'action',
+        onActivate: onRefresh,
+      };
 
-    // Find the selected option
-    const selectedOption = useMemo(() => {
-      return modelsMenuData.find(
-        option =>
-          option.name === value ||
-          (projectDefaultEmbeddingModel && option.name === projectDefaultEmbeddingModel),
-      );
-    }, [modelsMenuData, value, projectDefaultEmbeddingModel]);
+      return [actionOption, ...newModelsMenuData];
+    }, [newModelsMenuData, onRefresh]);
 
-    const onSelectItem = useCallback(
-      option => {
-        onSelectModel(selectedOption?.name === option.name ? null : option.name);
-        setAnchorEl(null); // Close dropdown
+    const customRenderSelectValue = useCallback(
+      foundOption => {
+        if (renderValue) return renderValue(foundOption);
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            {foundOption?.icon}
+            <Typography variant="labelMedium">{foundOption?.label}</Typography>
+          </Box>
+        );
       },
-      [onSelectModel, selectedOption?.name],
-    );
-
-    const onClick = useCallback(
-      option => () => {
-        if (!disabled) {
-          onSelectItem(option);
-        }
-      },
-      [disabled, onSelectItem],
+      [renderValue],
     );
 
     return (
       <>
-        <ClickAwayListener onClickAway={handleClickAway}>
-          <Box
-            sx={sx}
-            ref={panelRef}
-          >
-            <Box
-              onClick={handleFocus}
-              sx={styles.clickableBox(error, open)}
-            >
-              <Box sx={styles.labelBox}>
-                <Label.InfoLabelWithTooltip
-                  label={required ? `${label} *` : label}
-                  tooltip={description}
-                  variant="bodySmall"
-                  inheritColor
-                  labelSx={styles.labelTypography(open)}
-                />
-                <Tooltip
-                  title="Refresh the models"
-                  placement="top"
-                >
-                  <IconButton
-                    variant="elitea"
-                    color="tertiary"
-                    onClick={onRefresh}
-                    disabled={disabled}
-                  >
-                    <RefreshIcon />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-              {/* Render selected value */}
-              <Box sx={styles.selectedValueBox}>
-                {renderValue ? (
-                  renderValue(selectedOption)
-                ) : (
-                  <Typography
-                    variant="bodyMedium"
-                    sx={styles.selectedValueTypography(selectedOption)}
-                  >
-                    {selectedOption ? selectedOption?.label : !open ? 'Select model' : ''}
-                  </Typography>
-                )}
-                <SvgIcon
-                  viewBox="0 0 16 16"
-                  sx={styles.arrowIcon(open)}
-                >
-                  <ArrowDownIcon />
-                </SvgIcon>
-              </Box>
-            </Box>
-            {error && helperText && (
-              <FormControl error>
-                <FormHelperText>{error ? helperText : undefined}</FormHelperText>
-              </FormControl>
-            )}
-            {value && !selectedOption && hasFetchedData && (
-              <FormControl error>
-                <FormHelperText>{'Your model does not match any available models.'}</FormHelperText>
-              </FormControl>
-            )}
-            <Popper
-              open={open}
-              anchorEl={panelRef.current}
-              placement="bottom-start"
-              sx={styles.popper(panelRef)}
-            >
-              <Box sx={styles.popperBox}>
-                {!isFetching &&
-                  modelsMenuData.map((option, index) => (
-                    <MenuItem
-                      key={option.name + index}
-                      onClick={onClick(option)}
-                      sx={styles.menuItem(selectedOption, option)}
-                    >
-                      <Box sx={styles.menuItemContent}>{option.label}</Box>
-                      {selectedOption &&
-                        option.name === selectedOption.name &&
-                        option.private === selectedOption.private && (
-                          <Box sx={styles.checkedIconBox}>
-                            <CheckedIcon />
-                          </Box>
-                        )}
-                    </MenuItem>
-                  ))}
-                {isFetching && (
-                  <Box sx={styles.loadingBox}>
-                    <CircularProgress size={24} />
-                  </Box>
-                )}
-              </Box>
-            </Popper>
-          </Box>
-        </ClickAwayListener>
+        <Box sx={{ marginTop: '0.5rem' }}>
+          <Select.SingleSelect
+            showBorder
+            disabled={disabled}
+            required={required}
+            label={label}
+            infoIconDescription={description}
+            value={defaultValueForSelect}
+            options={optionsWithActions}
+            showOptionIcon
+            onValueChange={onSelectModel}
+            customRenderValue={customRenderSelectValue}
+            error={error}
+            helperText={helperText}
+            showEmptyPlaceholder={false}
+          />
+        </Box>
       </>
     );
   },
 );
 
 EmbeddingModelSelect.displayName = 'EmbeddingModelSelect';
-
-/** @type {MuiSx} */
-const styles = {
-  // Static styles
-  labelContainer: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '0.5rem',
-  },
-  labelBox: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-start',
-    gap: '0.5rem',
-  },
-  selectedValueBox: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  menuItemContent: {
-    display: 'flex',
-    gap: '0.5rem',
-    alignItems: 'center',
-  },
-  loadingBox: {
-    padding: '0.5rem',
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  // Dynamic styles (functions)
-  clickableBox: (error, open) => ({
-    cursor: 'pointer',
-    padding: '0.5rem 0.75rem',
-    width: '100%',
-    borderBottom: ({ palette }) =>
-      error
-        ? `0.0625rem solid ${palette.icon.fill.error}`
-        : open
-          ? `0.0625rem solid ${palette.primary.main}`
-          : `0.0625rem solid ${palette.border.lines}`,
-    ...(!error &&
-      !open && {
-        '&:hover': {
-          borderBottom: ({ palette }) => `0.0625rem solid ${palette.border.hover}`,
-        },
-      }),
-  }),
-  labelTypography: open => ({
-    color: ({ palette }) => (open ? palette.primary.main : palette.text.primary),
-  }),
-  selectedValueTypography: selectedOption => ({
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    minHeight: '1.5rem',
-    color: ({ palette }) =>
-      selectedOption?.label ? palette.text.select.selected.primary : palette.text.default,
-  }),
-  arrowIcon: open => ({
-    fontSize: '1rem',
-    transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-  }),
-  popper: panelRef => ({
-    width: panelRef.current?.clientWidth,
-    zIndex: theme => theme.zIndex.modal,
-  }),
-  popperBox: ({ palette }) => ({
-    marginTop: '0.25rem',
-    maxHeight: '18.75rem',
-    overflowY: 'auto',
-    borderRadius: '0.5rem',
-    border: `0.0625rem solid ${palette.border.lines}`,
-    background: palette.background.secondary,
-  }),
-  menuItem: (selectedOption, option) => ({
-    justifyContent: 'space-between',
-    padding: '0.5rem 1.5rem',
-    fontSize: '0.875rem',
-    color: ({ palette }) => palette.text.secondary,
-    '&:hover': {
-      backgroundColor: ({ palette }) => palette.background.button.iconLabelButton.hover,
-    },
-    '&.Mui-disabled': {
-      color: ({ palette }) => palette.text.disabled,
-    },
-    background: ({ palette }) =>
-      selectedOption && option.name === selectedOption.name && option.private === selectedOption.private
-        ? palette.background.participant.active
-        : undefined,
-  }),
-  checkedIconBox: ({ palette }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: palette.primary.main,
-  }),
-};
 
 export default EmbeddingModelSelect;


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4379

- Replaced depreacated select in the EmbeddingModelSelect by the Single Select
- Enhanced action option in the Single Select
- Rid same labelNode in the EmbeddingModelSelect and CredentialsSelect
- Added info icon and info description in the Single Select

<img width="524" height="287" alt="Screenshot 2026-04-21 124413" src="https://github.com/user-attachments/assets/ec6a2b58-52ac-4505-9db6-de8f38e398c3" />

<img width="518" height="291" alt="Screenshot 2026-04-21 124358" src="https://github.com/user-attachments/assets/f0a250a6-302c-4278-b617-a5b37a301f34" />
