### PR TITLE
fix: [EL-4458] register litellm permissions

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -604,6 +604,10 @@ export const PERMISSIONS = {
     delete: 'configurations.configuration.delete',
     update: 'configurations.configuration.update',
   },
+  litellm: {
+    section: 'configuration.litellm',
+    edit: 'configuration.litellm.edit',
+  },
   index: {
     schedule: 'models.applications.index_meta.edit',
   },


### PR DESCRIPTION
Add `configuration.litellm` and `configuration.litellm.edit` permission constants to `PERMISSIONS` in `constants.js`.