### PR TITLE
Fix: [EL-4726] notifications popup infinite scroll and align unseen badge with servers state

### DIFF
--- a/src/[fsd]/widgets/Sidebar/ui/button/NotificationButton.jsx
+++ b/src/[fsd]/widgets/Sidebar/ui/button/NotificationButton.jsx
@@ -44,11 +44,8 @@ const NotificationButton = memo(() => {
 
   useSocket(sioEvents.notifications_notify, onNotificationEvent);
 
-  const onCloseNotificationList = useCallback(clearDot => {
+  const onCloseNotificationList = useCallback(() => {
     setNotificationListAnchorEl(null);
-    if (clearDot) {
-      setHasMessages(false);
-    }
   }, []);
 
   const onClickNotificationButton = useCallback(
@@ -63,10 +60,10 @@ const NotificationButton = memo(() => {
   );
 
   useEffect(() => {
-    if (data?.total) {
-      setHasMessages(true);
+    if (data !== undefined) {
+      setHasMessages(!!data?.total);
     }
-  }, [data?.total]);
+  }, [data]);
 
   return (
     <>

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -4,7 +4,7 @@ import { debounce } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { Box, Popover, Skeleton, Typography } from '@mui/material';
+import { Box, CircularProgress, Popover, Skeleton, Typography } from '@mui/material';
 
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { TAG_NOTIFICATIONS, notificationsApi, useNotificationListQuery } from '@/api/notifications';
@@ -21,10 +21,12 @@ const NotificationList = memo(props => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const listRef = useRef();
+  const lastAppliedPageRef = useRef(-1);
   const { toastError } = useToast();
   const styles = notificationListStyles();
   const { personal_project_id } = useSelector(state => state.user);
   const [page, setPage] = useState(0);
+  const [allNotifications, setAllNotifications] = useState([]);
 
   const { data, isFetching, isError, error, refetch } = useNotificationListQuery(
     {
@@ -50,25 +52,46 @@ const NotificationList = memo(props => {
         ],
       },
     });
-    onCloseNotificationList(true);
+    onCloseNotificationList();
   }, [dispatch, navigate, onCloseNotificationList]);
 
   const onLoadMore = useCallback(() => {
     setPage(prev => prev + 1);
   }, []);
 
-  const hasMore = data && data.rows.length < data.total;
+  useEffect(() => {
+    if (!notificationListAnchorEl) return;
+    if (!data?.rows) return;
+    if (page === 0) {
+      lastAppliedPageRef.current = 0;
+      setAllNotifications(data.rows);
+      return;
+    }
+    if (lastAppliedPageRef.current === page) return;
+    lastAppliedPageRef.current = page;
+    setAllNotifications(prev => [...prev, ...data.rows]);
+  }, [data?.rows, notificationListAnchorEl, page]);
+
+  useEffect(() => {
+    if (!notificationListAnchorEl) {
+      setPage(0);
+      setAllNotifications([]);
+      lastAppliedPageRef.current = -1;
+    }
+  }, [notificationListAnchorEl]);
+
+  const hasMore = data && allNotifications.length < data.total;
 
   const handleScroll = useCallback(() => {
     const listDom = listRef.current;
-    if (!listDom) return;
+    if (!listDom || isFetching) return;
 
     const { clientHeight, scrollHeight, scrollTop } = listDom;
     const isReachBottom = scrollTop + clientHeight > scrollHeight - 10;
     if (isReachBottom && hasMore) {
       onLoadMore();
     }
-  }, [hasMore, onLoadMore]);
+  }, [hasMore, isFetching, onLoadMore]);
 
   const debouncedScroll = useMemo(() => debounce(handleScroll, 300), [handleScroll]);
 
@@ -130,15 +153,14 @@ const NotificationList = memo(props => {
             ref={listRef}
             sx={styles.listContainer}
           >
-            {!isFetching &&
-              data?.rows.map(notification => (
-                <NotificationListItem
-                  key={notification.id}
-                  notification={notification}
-                  onCloseNotificationList={onCloseNotificationList}
-                />
-              ))}
-            {isFetching && (
+            {allNotifications.map(notification => (
+              <NotificationListItem
+                key={notification.id}
+                notification={notification}
+                onCloseNotificationList={onCloseNotificationList}
+              />
+            ))}
+            {isFetching && !allNotifications.length && (
               <>
                 {[...Array(8)].map((_, index) => (
                   <Skeleton
@@ -151,12 +173,20 @@ const NotificationList = memo(props => {
                 ))}
               </>
             )}
-            {!data?.rows.length && !isFetching && (
+            {!allNotifications.length && !isFetching && (
               <Box sx={styles.emptyState}>
                 <Typography variant="bodySmall">No notifications right now</Typography>
               </Box>
             )}
           </Box>
+          {isFetching && page > 0 && (
+            <Box sx={styles.loadMoreSpinner}>
+              <CircularProgress
+                size="1.25rem"
+                thickness={4}
+              />
+            </Box>
+          )}
           <BaseBtn
             variant={BUTTON_VARIANTS.tertiary}
             onClick={onViewAll}
@@ -210,6 +240,13 @@ const notificationListStyles = () => ({
     '&:not(:last-of-type)': {
       borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
     },
+  }),
+  loadMoreSpinner: ({ palette }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: '0.75rem 0',
+    borderTop: `0.0625rem solid ${palette.border.notificationItem}`,
   }),
   emptyState: ({ palette }) => ({
     display: 'flex',


### PR DESCRIPTION
## Summary

This PR fixes notifications popup behavior so previously loaded items are preserved when loading the next
page, and aligns the unseen badge with server state.

## What Changed

- changed notifications popup pagination from replace-on-scroll to append-on-scroll
- preserved already loaded notifications while fetching the next page
- prevented duplicate page append on refetches by tracking the last applied page
- ignored late query results after the popup is closed to avoid stale repopulation
- reset popup pagination state on close so each reopen starts clean
- kept initial skeletons for the first load and added a dedicated bottom loader for paginated fetches
- showed the load-more spinner only for additional pages, not for initial/background page 0 refetches
- removed local clear-dot behavior on close and view-all
- made the red unseen badge derive from server unseen count instead of local UI state only

## User Impact

- scrolling in the notifications popup now behaves like infinite scroll
- previously loaded notifications remain visible while additional items load
- users see a loader when more items are being fetched
- the red unseen indicator stays visible until notifications are actually no longer unseen on the server

## Testing

- verified manually in the notifications popup
