### PR TITLE
fix: [EL-4379] Fixed ui styles in the drop down list of new Select

### DIFF
--- a/src/[fsd]/shared/ui/select/SingleSelect.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelect.jsx
@@ -359,47 +359,52 @@ const SingleSelect = memo(props => {
                     ) : null}
                   </Box>
                 </ListSubheader>,
-                ...groupOptions.map((option, index) => {
-                  const rowKey = `${groupKey}-opt-${option.value}-${index}`;
-
-                  if (option.variant === 'action') {
-                    return (
+                ...(groupOptions.length === 0
+                  ? [
                       <MenuItem
-                        key={rowKey}
-                        value={option.value}
-                        sx={({ palette }) => ({
-                          justifyContent: 'flex-start',
-                          padding: '0.5rem 1.5rem',
-                          fontSize: '0.875rem',
-                          color: palette.text.secondary,
-                        })}
+                        key={`${groupKey}-empty`}
+                        disabled
+                        sx={{ justifyContent: 'flex-start', padding: '0.5rem 1.5rem', fontSize: '0.875rem' }}
                       >
-                        {option.label}
-                      </MenuItem>
-                    );
-                  }
+                        {isListFetching ? '' : 'Still no saved credentials'}
+                      </MenuItem>,
+                    ]
+                  : groupOptions.map((option, index) => {
+                      const rowKey = `${groupKey}-opt-${option.value}-${index}`;
 
-                  return (
-                    <SingleSelectDropdown
-                      key={rowKey}
-                      value={option.value}
-                      option={option}
-                      isSelected={
-                        effectiveMultiple
-                          ? Array.isArray(realValue) && realValue.includes(option.value)
-                          : option.value === realValue
+                      if (option.variant === 'action') {
+                        return (
+                          <MenuItem
+                            key={rowKey}
+                            value={option.value}
+                            sx={styles.groupAction}
+                          >
+                            {option.label}
+                          </MenuItem>
+                        );
                       }
-                      onClear={onClear ? wrappedOnClear : undefined}
-                      customRenderOption={customRenderOption}
-                      showOptionIcon={showOptionIcon}
-                      showOptionDescription={showOptionDescription}
-                      iconPosition={iconPosition}
-                      optionsWithAvatar={optionsWithAvatar}
-                      menuItemIconSX={{ ...menuItemIconSX, ...selectIconWithLabelSx }}
-                      onDeleteOption={onDeleteOption}
-                    />
-                  );
-                }),
+
+                      return (
+                        <SingleSelectDropdown
+                          key={rowKey}
+                          value={option.value}
+                          option={option}
+                          isSelected={
+                            effectiveMultiple
+                              ? Array.isArray(realValue) && realValue.includes(option.value)
+                              : option.value === realValue
+                          }
+                          onClear={onClear ? wrappedOnClear : undefined}
+                          customRenderOption={customRenderOption}
+                          showOptionIcon={showOptionIcon}
+                          showOptionDescription={showOptionDescription}
+                          iconPosition={iconPosition}
+                          optionsWithAvatar={optionsWithAvatar}
+                          menuItemIconSX={{ ...menuItemIconSX, ...selectIconWithLabelSx }}
+                          onDeleteOption={onDeleteOption}
+                        />
+                      );
+                    })),
               ];
             });
       };
@@ -774,7 +779,7 @@ const singleSelectStyles = (theme, { customSelectedColor, customSelectedFontSize
     },
   },
   groupHeader: ({ palette }) => ({
-    padding: '0.5rem 1.5rem',
+    padding: '0.5rem 1rem',
     fontSize: '0.875rem',
     color: palette.text.secondary,
     lineHeight: 1.4,
@@ -783,6 +788,12 @@ const singleSelectStyles = (theme, { customSelectedColor, customSelectedFontSize
     '.MuiMenuItem-root + &': {
       borderTop: `1px solid ${palette.border.lines}`,
     },
+  }),
+  groupAction: ({ palette }) => ({
+    justifyContent: 'flex-start',
+    padding: '0.5rem 1rem',
+    fontSize: '0.875rem',
+    color: palette.text.secondary,
   }),
   groupHeaderTitle: ({ palette }) => ({
     textTransform: 'uppercase',
@@ -797,6 +808,7 @@ const singleSelectStyles = (theme, { customSelectedColor, customSelectedFontSize
     gap: '0.5rem',
   },
   groupHeaderEnd: {
+    padding: 0,
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',

--- a/src/[fsd]/shared/ui/select/SingleSelectMenuItem.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelectMenuItem.jsx
@@ -157,6 +157,7 @@ const menuItemStyles = option => ({
   iconContainer: {
     display: 'flex',
     alignItems: 'center',
+    gap: '0.5rem',
   },
   iconContainerWithDescription: {
     alignItems: 'flex-start',
@@ -199,7 +200,6 @@ const menuItemStyles = option => ({
     width: '1rem',
     height: '1rem',
     fontSize: '1rem',
-    marginRight: '0.6rem',
     minWidth: '1rem !important',
     '& svg': {
       fontSize: '1rem',

--- a/src/components/CredentialsSelect.jsx
+++ b/src/components/CredentialsSelect.jsx
@@ -383,7 +383,7 @@ const CredentialsSelect = memo(
           <IconButton
             size="small"
             onClick={onRefresh}
-            sx={({ palette }) => ({ color: palette.text.default })}
+            sx={styles.refreshIcon}
           >
             <RefreshIcon />
           </IconButton>
@@ -546,6 +546,29 @@ const styles = {
     alignItems: 'center',
     gap: '0.5rem',
   },
+  refreshIcon: ({ palette }) => ({
+    color: palette.text.default,
+    padding: 0,
+    position: 'relative',
+    backgroundColor: 'transparent',
+    '&:hover, &:active, &.Mui-focusVisible': {
+      backgroundColor: 'transparent',
+    },
+    '&:hover': {
+      color: palette.text.secondary,
+    },
+    '&:hover::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '26px',
+      height: '26px',
+      transform: 'translate(-21%, -18%)',
+      borderRadius: '50%',
+      backgroundColor: palette.background.userInputBackgroundActive,
+    },
+  }),
   selectedValueTypography: selectedOption => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4379

- Added status to empty list for Saved credentials group in dropdown list
- Fixed hover state for "refresh" button
- Fixed paddings - set to 16px

<img width="733" height="233" alt="Screenshot 2026-04-21 153609" src="https://github.com/user-attachments/assets/5491b430-9e08-408c-9c39-a5c1251508a8" />
<img width="717" height="270" alt="image" src="https://github.com/user-attachments/assets/b77b558a-8206-47f9-8d48-9e4d17d170e2" />
<img width="93" height="64" alt="image" src="https://github.com/user-attachments/assets/a5f0394d-72f9-4203-a623-9cde2d881cd4" />

