### PR TITLE
fix: [EL-4715] user friendly tool validation error message

### DIFF
--- a/src/pages/Applications/Components/Applications/ApplicationValidator.jsx
+++ b/src/pages/Applications/Components/Applications/ApplicationValidator.jsx
@@ -4,25 +4,18 @@ import { useFormikContext } from 'formik';
 import { useDispatch } from 'react-redux';
 
 import { eliteaApi } from '@/api/eliteaApi';
-import { PUBLIC_PROJECT_ID } from '@/common/constants';
+import { ViewMode } from '@/common/constants';
 import useValidateApplicationVersion from '@/hooks/application/useValidateApplicationVersion';
+import useViewMode from '@/hooks/useViewMode';
 
-/**
- * ApplicationValidator component that triggers toolkit validation for an application.
- * Should be used inside a Formik context to access form values.
- *
- * @param {Object} props - Component props
- * @param {number|string} props.agentId - The application/agent ID
- * @param {number|string} props.projectId - The project ID
- * @param {boolean} [props.isCreateMode=false] - Whether the component is in create mode
- * @returns {null} This is a logic-only component that renders nothing
- */
-function ApplicationValidator({ agentId, projectId, isCreateMode = false }) {
+const ApplicationValidator = props => {
+  const { agentId, projectId, isCreateMode = false } = props;
   const { values } = useFormikContext();
   const dispatch = useDispatch();
   const prevToolsRef = useRef();
+  const viewMode = useViewMode();
 
-  const isPublished = projectId == PUBLIC_PROJECT_ID;
+  const isPublished = viewMode === ViewMode.Public;
   const shouldSkip =
     isPublished ||
     isCreateMode ||
@@ -78,7 +71,7 @@ function ApplicationValidator({ agentId, projectId, isCreateMode = false }) {
       ))}
     </>
   );
-}
+};
 
 /**
  * Validates a single sub-agent/pipeline tool using the same hook as the parent.

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -279,6 +279,38 @@ const ToolCard = memo(props => {
     return validationInfo;
   }, [validationInfo, tool, entityType]);
 
+  const validationBanner = useMemo(() => {
+    if (!validationInfo) return null;
+
+    const errorType = toolValidationMessage?.error_type;
+
+    if (errorType === 'private_credential_not_found' && personal_project_id !== projectId) {
+      return (
+        <CredentialWarningBanner
+          credentialId={toolValidationMessage.credential_id}
+          credentialType={tool?.type}
+          section="credentials"
+        />
+      );
+    }
+
+    if (errorType === 'credential_not_found' || errorType === 'private_credential_not_found') {
+      return (
+        <Banner.BannerMessage message="Your configuration does not match any available configurations." />
+      );
+    }
+
+    return (
+      <Banner.BannerMessage
+        message={
+          typeof toolValidationMessage === 'string'
+            ? toolValidationMessage
+            : toolValidationMessage?.message || JSON.stringify(toolValidationMessage)
+        }
+      />
+    );
+  }, [validationInfo, toolValidationMessage, personal_project_id, projectId, tool]);
+
   // Generate dialog texts based on entity type
   const dialogTitle = useMemo(() => {
     switch (entityType) {
@@ -531,24 +563,7 @@ const ToolCard = memo(props => {
             confirmButtonText="Remove"
           />
         </Box>
-        {validationInfo &&
-          (typeof toolValidationMessage === 'object' &&
-          toolValidationMessage?.error_type === 'private_credential_not_found' &&
-          personal_project_id !== projectId ? (
-            <CredentialWarningBanner
-              credentialId={toolValidationMessage.credential_id}
-              credentialType={tool?.type}
-              section="credentials"
-            />
-          ) : (
-            <Banner.BannerMessage
-              message={
-                typeof toolValidationMessage === 'string'
-                  ? toolValidationMessage
-                  : toolValidationMessage?.message || JSON.stringify(toolValidationMessage)
-              }
-            />
-          ))}
+        {validationBanner}
       </>
     </Tooltip>
   );


### PR DESCRIPTION
# Issue #4715 — Raw BE warning message in agent after public credential deletion

**Ticket:** https://github.com/EliteaAI/elitea_issues/issues/4715  
**Label:** `eng:frontend` | **Milestone:** R-2.0.2

---

## Root Cause

When a public credential referenced by a toolkit is deleted, `configurations/utils.py` raises a `LookupError` with `personal_project_lookup: False`. In `elitea_core/utils/application_tools.py`, the `else` branch (non-private credential lookup failure) was appending the raw `str(ex)` pydantic string to `toolkit_errors` instead of a structured JSON object. The FE's `parseValidationMsg` only recognises structured JSON with an `error_type` field — everything else was rendered as a raw string in the `ToolCard` banner.

---

## Fix

### Backend — `elitea_core/utils/application_tools.py`

The `else` branch now emits structured JSON matching the pattern already used for `private_credential_not_found`:

```python
# Before
else:
    errors.append({
        'loc': (to_be_expanded_fieldname, ),
        'msg': str(ex)
    })

# After
else:
    errors.append({
        'loc': (to_be_expanded_fieldname, ),
        'msg': json.dumps({
            'error_type': 'credential_not_found',
            'credential_id': metadata.get('elitea_title', 'unknown'),
        }),
    })
```

`metadata.get('elitea_title')` works for both cases because `configurations/utils.py` always includes `elitea_title: title` in the `LookupError` metadata regardless of `personal_project_lookup`.

---

### Frontend — `EliteaUI/src/pages/Applications/Components/Tools/ToolCard.jsx`

The nested ternary was extracted into a `validationBanner` memo for readability. The three-branch logic:

```jsx
const validationBanner = useMemo(() => {
  if (!validationInfo) return null;

  const errorType = toolValidationMessage?.error_type;

  // Branch 1: private credential missing in a team project
  // → show "Create a credential" banner with link to personal workspace
  if (errorType === 'private_credential_not_found' && personal_project_id !== projectId) {
    return (
      <CredentialWarningBanner
        credentialId={toolValidationMessage.credential_id}
        credentialType={tool?.type}
        section="credentials"
      />
    );
  }

  // Branch 2: public credential deleted  OR  private credential deleted in personal project
  // → user-friendly mismatch message
  if (errorType === 'credential_not_found' || errorType === 'private_credential_not_found') {
    return <Banner.BannerMessage message="Your configuration does not match any available configurations." />;
  }

  // Branch 3: other genuine validation errors (wrong field value, missing required field, etc.)
  // → show actual BE message
  return (
    <Banner.BannerMessage
      message={
        typeof toolValidationMessage === 'string'
          ? toolValidationMessage
          : toolValidationMessage?.message || JSON.stringify(toolValidationMessage)
      }
    />
  );
}, [validationInfo, toolValidationMessage, personal_project_id, projectId, tool]);

// Render site
{validationBanner}
```

**Branch breakdown:**

| Scenario | `error_type` | Condition matched | Result |
|----------|-------------|-------------------|--------|
| Private credential deleted, user in **team** project | `private_credential_not_found` | Branch 1 (`personal_project_id !== projectId`) | `CredentialWarningBanner` with "Create a credential" link |
| Private credential deleted, user in **personal** project | `private_credential_not_found` | Branch 2 (falls through Branch 1) | Friendly mismatch message |
| Public credential deleted | `credential_not_found` | Branch 2 | Friendly mismatch message |
| Other validation error (invalid field, missing value, etc.) | — (raw string or other object) | Branch 3 | Actual BE validation message |

---

## Files Changed

| Repo | File |
|------|------|
| `elitea_core` | `utils/application_tools.py` |
| `EliteaUI` | `src/pages/Applications/Components/Tools/ToolCard.jsx` |
