### PR TITLE
fix: [EL-4744] Fixed alignment of empty option in the group dropdawn list

### DIFF
--- a/src/[fsd]/shared/ui/select/SingleSelect.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelect.jsx
@@ -364,7 +364,7 @@ const SingleSelect = memo(props => {
                       <MenuItem
                         key={`${groupKey}-empty`}
                         disabled
-                        sx={{ justifyContent: 'flex-start', padding: '0.5rem 1.5rem', fontSize: '0.875rem' }}
+                        sx={{ justifyContent: 'flex-start', padding: '0.5rem 1rem', fontSize: '0.875rem' }}
                       >
                         {isListFetching ? '' : 'Still no saved credentials'}
                       </MenuItem>,


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4744

- Fixed padding sides to 16px for empty option in the SingleSelect

<img width="218" height="154" alt="image" src="https://github.com/user-attachments/assets/c4973e57-546a-415e-b143-c6efb80f8b81" />

