### PR TITLE
fix: [EL-4696] rewrite notification center search with template DSL

### DIFF
--- a/src/[fsd]/entities/notification/index.js
+++ b/src/[fsd]/entities/notification/index.js
@@ -1,0 +1,16 @@
+// Public API of the notification entity.
+//
+// Consumers outside this folder MUST import from this barrel only —
+// the DSL primitives (tpl, var, link, status, textsOf, varsOf) are
+// intentionally not re-exported. They are authoring tools used inside
+// notificationTemplates.js and should stay internal so the DSL can
+// evolve without breaking external code.
+
+export {
+  ALL_VARIABLE_KEYS,
+  NOTIFICATION_TEMPLATES,
+  STATIC_SEARCH_INDEX,
+  buildNotificationQueryFilters,
+  deriveRenderState,
+  formatUsersForTemplate,
+} from './lib/notificationTemplates';

--- a/src/[fsd]/entities/notification/lib/notificationTemplates.js
+++ b/src/[fsd]/entities/notification/lib/notificationTemplates.js
@@ -1,0 +1,213 @@
+/**
+ * Declarative catalog of notification message templates.
+ *
+ * Each entry maps a NotificationType to a `tpl` template. The same declaration
+ * drives:
+ *   - rendering (via renderTemplate in NotificationListItemMessage),
+ *   - static search (STATIC_SEARCH_INDEX),
+ *   - dynamic meta-key search (ALL_VARIABLE_KEYS),
+ *   - query classification (buildNotificationQueryFilters).
+ *
+ * Not every NotificationType is templated yet — types with complex inline
+ * structures (AgentUnpublished, ChatUserAdded, Rates, Comments,
+ * ContributorRequestForPublishApprove) remain on the legacy parseInformation
+ * path in NotificationListItemMessage. Unmapped types fall through cleanly.
+ */
+import { NotificationType } from '@/common/constants';
+
+import { link, linkText, status, textsOf, tpl, variable as v, varsOf } from './templateDSL';
+
+export const NOTIFICATION_TEMPLATES = {
+  [NotificationType.BucketExpirationWarning]: tpl`Bucket ${link('bucket_name', {
+    id: 'bucket_name',
+    isNewTab: true,
+  })} will start deleting files in 24 hours according to its retention policy (files are removed based on each file's creation date; the bucket itself will remain).`,
+
+  [NotificationType.IndexDataChanged]: tpl`Index ${link('index_name', {
+    id: 'toolkit_id',
+    indexName: 'index_name',
+    isNewTab: true,
+  })} ${status('_renderState', {
+    failed: 'is failed.',
+    reindexed_scheduled: 'is successfully reindexed by schedule.',
+    reindexed: 'is successfully reindexed.',
+    created: 'is successfully created.',
+  })}`,
+
+  [NotificationType.PrivateProjectCreated]: tpl`Project was successfully created.`,
+
+  [NotificationType.UserWasAddedToSomeProjectAsTeammate]: tpl`${v('users')} added into ${link(
+    'project_name',
+  )}.`,
+
+  [NotificationType.RewardNewLevel]: tpl`Congratulations! You've got ${v(
+    'new_level',
+  )} level of prompt expert!`,
+
+  [NotificationType.TokenExpiring]: tpl`Token ${v(
+    'token_name',
+  )} will be expired in 5 days. For more details view your ${linkText('Configuration')}.`,
+  [NotificationType.TokenIsExpired]: tpl`Token ${v(
+    'token_name',
+  )} is expired! For more details view your ${linkText('Configuration')}.`,
+
+  [NotificationType.SpendingLimitExpiring]: tpl`Your spending limit is expiring. For more details view your ${linkText(
+    'settings section',
+  )}.`,
+  [NotificationType.SpendingLimitIsExpired]: tpl`Your spending limit is expired. For more details view your ${linkText(
+    'settings section',
+  )}.`,
+
+  [NotificationType.PersonalAccessTokenExpiring]: tpl`Your personal access token ${v(
+    'token_name',
+  )} will expire in 24 hours. After expiration, it will no longer work. You can delete and recreate a new token if needed. ${linkText(
+    'Manage Personal Access Tokens',
+    { isNewTab: true },
+  )}`,
+
+  [NotificationType.ModeratorUnpublish]: tpl`${linkText('Configuration')} is unpublished after complaint.`,
+  [NotificationType.AuthorApproval]: tpl`${linkText('Configuration')} is approved by ${v(
+    'approver',
+  )} for publishing.`,
+  [NotificationType.AuthorReject]: tpl`${linkText('Configuration')} is rejected by ${v('rejecter')}.`,
+  [NotificationType.ModeratorApprovalOfVersion]: tpl`${linkText('Configuration')} is published.`,
+  [NotificationType.ModeratorRejectOfVersion]: tpl`${linkText('Configuration')} is rejected.`,
+};
+
+/**
+ * IndexDataChanged uses a synthetic `_renderState` key because the branch
+ * selector depends on multiple real meta fields (error, reindex, initiator),
+ * not a single status column. Call this before passing meta to renderTemplate.
+ */
+export const deriveRenderState = meta => {
+  if (!meta) return null;
+  if (meta.error && String(meta.error).trim()) return 'failed';
+  if (meta.reindex) return meta.initiator === 'schedule' ? 'reindexed_scheduled' : 'reindexed';
+  return 'created';
+};
+
+/**
+ * Synthesise the `users` display string for the
+ * UserWasAddedToSomeProjectAsTeammate template.
+ * Joins the array with commas and appends the correct verb ('are'/'is').
+ * Returns an empty string when the list is empty or meta is absent.
+ */
+export const formatUsersForTemplate = meta => {
+  const users = Array.isArray(meta?.users) ? meta.users : [];
+  return users.length ? `${users.join(', ')} ${users.length > 1 ? 'are' : 'is'}` : '';
+};
+
+/**
+ * Flat list of static-text entries derived from the catalog. Each entry
+ * records the lower-cased text, the notification type it came from, and —
+ * when the text came from a `status(...)` case — which case produced it.
+ *
+ *   { text: string, type: string, status?: { metaKey, caseKey } }
+ *
+ * The `status` annotation lets query classification narrow a type to only
+ * the branches whose rendered text actually matches the query, fixing
+ * false positives like `"success"` returning failed-index rows.
+ *
+ * Trade-off: this index is built once at module load. With the current
+ * catalog (~8 templates, ~15 entries) the cost is negligible vs. app
+ * bootstrap and the eager build keeps lookups synchronous and lock-free.
+ * If the catalog grows past the low hundreds of templates, consider
+ * switching to a lazy (memoised) build on first search instead.
+ */
+export const STATIC_SEARCH_INDEX = Object.entries(NOTIFICATION_TEMPLATES).flatMap(([type, tplParsed]) =>
+  textsOf(tplParsed)
+    // Whitespace-only segments (e.g. the single space between two placeholders)
+    // carry no search signal and, if indexed, would make any multi-word query
+    // spuriously match this type. Drop them here.
+    .filter(entry => entry.text.trim())
+    .map(entry => ({
+      text: entry.text.toLowerCase(),
+      type,
+      ...(entry.status ? { status: entry.status } : {}),
+    })),
+);
+
+/**
+ * Union of all meta keys referenced by any templated notification. The BE
+ * uses this list as a whitelist of JSONB keys to scan for dynamic (value)
+ * search matches — avoiding the false-positive leak of casting the entire
+ * meta JSON to text.
+ */
+export const ALL_VARIABLE_KEYS = [...new Set(Object.values(NOTIFICATION_TEMPLATES).flatMap(varsOf))];
+
+/**
+ * Translate a free-text search into BE-friendly filters.
+ *
+ * Strategy: tokenize the query on whitespace and classify each token
+ * independently. Each token is projected against three axes:
+ *
+ *   1. Static (text index): find entries in STATIC_SEARCH_INDEX whose text
+ *      contains the token. Entries are partitioned per event_type:
+ *        - If any match is *unconstrained* (plain text segment), the type
+ *          is emitted in `eventTypes` — BE matches all rows of that type.
+ *        - Otherwise, matches are all from specific `status(...)` cases —
+ *          emit a narrowed filter in `eventTypeStatuses` carrying the
+ *          set of matching case keys, which the BE translates into
+ *          per-branch SQL predicates.
+ *   2. event_type ILIKE (implicit on BE).
+ *   3. Dynamic (meta values): the BE has a hardcoded default whitelist of
+ *      meta keys it scans per token, so we do not need to ship one in the
+ *      URL. If a future FE template introduces a meta key the BE default
+ *      doesn't know about yet, pass `ALL_VARIABLE_KEYS` here as a stopgap
+ *      override until the BE catches up.
+ *
+ * The BE combines axes with OR within a token, and ANDs tokens together —
+ * so a multi-word query like "index attach" needs every token to match
+ * somewhere in a row (e.g. "index" via the type, "attach" via meta).
+ */
+export const buildNotificationQueryFilters = rawQuery => {
+  const q = (rawQuery || '').trim().toLowerCase();
+  if (!q) {
+    return { tokens: [] };
+  }
+
+  const rawTokens = q.split(/\s+/).filter(Boolean);
+  // Preserve order, drop duplicates — a repeated token adds no selectivity.
+  const seen = new Set();
+  const uniqueTokens = [];
+  for (const t of rawTokens) {
+    if (!seen.has(t)) {
+      seen.add(t);
+      uniqueTokens.push(t);
+    }
+  }
+
+  const tokens = uniqueTokens.map(token => {
+    const matches = STATIC_SEARCH_INDEX.filter(entry => entry.text.includes(token));
+
+    // Partition matches per type, tracking whether any match is unconstrained.
+    const perType = new Map();
+    for (const m of matches) {
+      const bucket = perType.get(m.type) ?? { unconstrained: false, cases: new Map() };
+      if (!m.status) {
+        bucket.unconstrained = true;
+      } else {
+        const existing = bucket.cases.get(m.status.metaKey) ?? new Set();
+        existing.add(m.status.caseKey);
+        bucket.cases.set(m.status.metaKey, existing);
+      }
+      perType.set(m.type, bucket);
+    }
+
+    const eventTypes = [];
+    const eventTypeStatuses = [];
+    for (const [type, bucket] of perType) {
+      if (bucket.unconstrained) {
+        eventTypes.push(type);
+        continue;
+      }
+      for (const [metaKey, caseSet] of bucket.cases) {
+        eventTypeStatuses.push({ type, metaKey, values: [...caseSet] });
+      }
+    }
+
+    return { token, eventTypes, eventTypeStatuses };
+  });
+
+  return { tokens };
+};

--- a/src/[fsd]/entities/notification/lib/templateDSL.js
+++ b/src/[fsd]/entities/notification/lib/templateDSL.js
@@ -1,0 +1,95 @@
+/**
+ * Tiny DSL for declaring notification message templates.
+ *
+ * A template is written as a tagged template literal and produces a parsed
+ * object of the shape { segments: Segment[] }. Each segment is either a
+ * literal text run or a typed placeholder describing how to render and search
+ * the value.
+ *
+ * Placeholder kinds:
+ *   - var(metaKey)                   — plain interpolation of meta[metaKey].
+ *   - link(metaKey, linkProps?)      — meta-backed link. linkProps string values
+ *                                      are treated as meta keys; non-string values
+ *                                      are literal.
+ *   - linkText(label, linkProps?)    — link with a literal label (no meta key).
+ *   - status(metaKey, cases)         — controlled vocabulary. cases is an object
+ *                                      whose values are literal strings; one is
+ *                                      picked by meta[metaKey]. All case values
+ *                                      participate in the static search index.
+ *
+ * The same declaration drives both rendering and search-index derivation,
+ * keeping a single source of truth per notification type.
+ */
+
+/**
+ * Meta-backed interpolation placeholder. Renders meta[metaKey] as plain text.
+ * Named `variable` rather than `var` (reserved word).
+ */
+export const variable = metaKey => ({ kind: 'var', metaKey });
+
+export const link = (metaKey, linkProps = {}) => ({ kind: 'link', metaKey, linkProps });
+
+export const linkText = (label, linkProps = {}) => ({ kind: 'linkText', label, linkProps });
+
+export const status = (metaKey, cases) => ({ kind: 'status', metaKey, cases });
+
+/**
+ * Tagged template literal. Combines literal text chunks and placeholder
+ * descriptors into a single { segments } structure.
+ */
+export const tpl = (strings, ...placeholders) => {
+  const segments = [];
+  strings.forEach((str, i) => {
+    if (str) segments.push({ type: 'text', text: str });
+    if (i < placeholders.length) {
+      const ph = placeholders[i];
+      segments.push({ type: ph.kind, ...ph });
+    }
+  });
+  return { segments };
+};
+
+/**
+ * All static text runs contributed by a template.
+ *
+ * Includes:
+ *   - literal `text` segments,
+ *   - all case values of `status` placeholders.
+ *
+ * Deliberately excludes `var`/`link`/`linkText` values — those are either
+ * runtime-dynamic (meta) or carry link chrome that shouldn't match the text
+ * index (e.g. the literal "Configuration" label).
+ */
+/**
+ * All static text runs contributed by a template, each annotated with the
+ * status-case context that produced it (when applicable).
+ *
+ * Return shape:
+ *   Array<{ text: string, status?: { metaKey, caseKey } }>
+ *
+ * Plain text segments appear with no `status` — they're unconstrained within
+ * the template's event_type. Each case of a `status(...)` placeholder yields
+ * a separate entry tagged with the case key, enabling narrowing search to
+ * specific branches (e.g. "is successfully" → only the success cases of
+ * IndexDataChanged, not the failed case).
+ */
+export const textsOf = tplParsed => {
+  const out = [];
+  for (const seg of tplParsed.segments) {
+    if (seg.type === 'text') {
+      out.push({ text: seg.text });
+    } else if (seg.type === 'status') {
+      for (const [caseKey, caseText] of Object.entries(seg.cases)) {
+        out.push({ text: caseText, status: { metaKey: seg.metaKey, caseKey } });
+      }
+    }
+  }
+  return out;
+};
+
+/**
+ * All meta keys a template may read at render time. Used to derive the set of
+ * JSONB keys the BE should scan for dynamic (value-level) search matches.
+ */
+export const varsOf = tplParsed =>
+  tplParsed.segments.filter(seg => seg.type === 'var' || seg.type === 'link').map(seg => seg.metaKey);

--- a/src/api/notifications.js
+++ b/src/api/notifications.js
@@ -11,17 +11,42 @@ export const notificationsApi = eliteaApi
   .injectEndpoints({
     endpoints: build => ({
       notificationList: build.query({
-        query: ({ projectId, page, pageSize = PAGE_SIZE, params, sortBy, sortOrder, search }) => ({
-          url: `/notifications/notifications/prompt_lib/${projectId}`,
-          params: {
-            ...params,
-            limit: pageSize,
-            offset: page * pageSize,
-            sort_by: sortBy,
-            sort_order: sortOrder,
-            ...(search ? { search } : {}),
-          },
-        }),
+        query: ({
+          projectId,
+          page,
+          pageSize = PAGE_SIZE,
+          params,
+          sortBy,
+          sortOrder,
+          tokens,
+          metaSearchKeys,
+        }) => {
+          const serializedSearchTokens = tokens?.length ? JSON.stringify(tokens) : null;
+
+          return {
+            url: `/notifications/notifications/prompt_lib/${projectId}`,
+            params: {
+              ...params,
+              limit: pageSize,
+              offset: page * pageSize,
+              sort_by: sortBy,
+              sort_order: sortOrder,
+              // Tokenized query: each token is an object { token, eventTypes,
+              // eventTypeStatuses } carrying the token's static-text matches.
+              // BE ANDs tokens, ORs axes within a token. Omitted when empty so
+              // unfiltered calls keep their current shape.
+              ...(serializedSearchTokens ? { search_tokens: serializedSearchTokens } : {}),
+              // The BE has a default whitelist of meta keys it scans for
+              // free-text search (see `_DEFAULT_META_SEARCH_KEYS` in the
+              // notifications plugin). Normally we rely on that default to
+              // keep the URL short. Only send `meta_search_keys` when the
+              // caller explicitly wants to override it (e.g. a new FE-only
+              // template introducing a meta key the BE default doesn't know
+              // about yet).
+              ...(metaSearchKeys?.length ? { meta_search_keys: metaSearchKeys } : {}),
+            },
+          };
+        },
         providesTags: [TAG_NOTIFICATIONS],
       }),
       notificationRead: build.mutation({

--- a/src/components/NotificationListItem.jsx
+++ b/src/components/NotificationListItem.jsx
@@ -25,6 +25,7 @@ export const getIcon = (type, theme, notification) => {
     case NotificationType.PromptOfSomeProjectWasPublished:
     case NotificationType.NewPromptVersionOfSomeProjectWasPublished:
     case NotificationType.ChatUserAdded:
+    case NotificationType.PrivateProjectCreated:
       return <SuccessIcon fill={theme.palette.status.published} />;
 
     case NotificationType.IndexDataChanged:

--- a/src/components/NotificationListItemMessage.jsx
+++ b/src/components/NotificationListItemMessage.jsx
@@ -1,7 +1,12 @@
-import { useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { Link, Typography } from '@mui/material';
 
+import {
+  NOTIFICATION_TEMPLATES,
+  deriveRenderState,
+  formatUsersForTemplate,
+} from '@/[fsd]/entities/notification';
 import { NotificationType, PUBLIC_PROJECT_ID, ViewMode } from '@/common/constants';
 import useNotificationNavigate from '@/hooks/useNotificationNavigate';
 import useNotificationNewTabNavigate from '@/hooks/useNotificationNewTabNavigate.js';
@@ -9,75 +14,32 @@ import { getBasename } from '@/routes';
 
 const MAX_NAME_LEN = 33;
 
-const leadingText = (param1, param2) => ({
-  [NotificationType.TokenExpiring]: `Token ${param1} will be expired in 5 days. For more details view your `,
-  [NotificationType.TokenIsExpired]: `Token ${param1} is expired! For more details view your `,
-  [NotificationType.SpendingLimitExpiring]: 'Your spending limit is expiring. For more details view your ',
-  [NotificationType.SpendingLimitIsExpired]: 'Your spending limit is expired. For more details view your ',
-  [NotificationType.RewardNewLevel]: `Congratulations! You've got ${param1} level of prompt expert!`,
-  [NotificationType.UserWasAddedToSomeProjectAsTeammate]: `${param1} added into `,
-  [NotificationType.ChatUserAdded]: `${param1} added ${param2} to `,
-  [NotificationType.PrivateProjectCreated]: 'Project was successfully created',
-  [NotificationType.IndexDataChanged]: param1, // Dynamic message based on index state
-  [NotificationType.BucketExpirationWarning]: 'Bucket ',
-  [NotificationType.PersonalAccessTokenExpiring]: `Your personal access token ${param1} will expire in 24 hours. After expiration, it will no longer work. You can delete and recreate a new token if needed. `,
-});
+const formatName = name =>
+  name && name.length > MAX_NAME_LEN ? `${name.slice(0, MAX_NAME_LEN)}...` : name || '';
 
-const middleText = {};
-
-const endingText = param => ({
-  [NotificationType.ModeratorUnpublish]: ' is unpublished after complaint.',
-  [NotificationType.AuthorApproval]: ` is approved by ${param} for publishing.`,
-  [NotificationType.AuthorReject]: ` is rejected by ${param}.`,
-  [NotificationType.ModeratorApprovalOfVersion]: ' is published.',
-  [NotificationType.ModeratorRejectOfVersion]: ' is rejected.',
-  [NotificationType.TokenExpiring]: '.',
-  [NotificationType.TokenIsExpired]: '.',
-  [NotificationType.SpendingLimitIsExpired]: '.',
-  [NotificationType.SpendingLimitExpiring]: '.',
-  [NotificationType.Rates]: '.',
-  [NotificationType.Comments]: '.',
-  [NotificationType.ContributorRequestForPublishApprove]: '.',
-  [NotificationType.UserWasAddedToSomeProjectAsTeammate]: '.',
-  [NotificationType.PrivateProjectCreated]: '.',
-  [NotificationType.IndexDataChanged]: '',
-  [NotificationType.BucketExpirationWarning]:
-    " will start deleting files in 24 hours according to its retention policy (files are removed based on each file's creation date; the bucket itself will remain).",
-  [NotificationType.PersonalAccessTokenExpiring]: '',
-});
-const formatName = name => {
-  return name && name.length > MAX_NAME_LEN ? `${name.slice(0, MAX_NAME_LEN)}...` : name || '';
+/**
+ * Resolve a link/linkText placeholder into the flat linkInfo object expected
+ * by the navigation hooks. In `linkProps`, string values are treated as meta
+ * keys, non-string values (booleans, numbers) are literals. `project_id`
+ * falls back to the notification's top-level project_id when not specified.
+ */
+const resolveLinkInfo = (seg, notification, adaptedMeta) => {
+  const resolved = { project_id: notification.project_id };
+  Object.entries(seg.linkProps || {}).forEach(([k, v]) => {
+    resolved[k] = typeof v === 'string' ? adaptedMeta?.[v] : v;
+  });
+  const text = seg.label ?? (seg.metaKey ? adaptedMeta?.[seg.metaKey] : undefined) ?? '';
+  return { ...resolved, linkText: text };
 };
 
-const formatIndexMessage = (meta, withLink = false) => {
-  const { index_name, error, reindex, indexed, updated } = meta;
-  const indexNamePlaceholder = withLink ? '{INDEX_LINK}' : index_name || 'Index';
-  const reindexedCount = updated || 0;
-
-  // Check if operation failed
-  if (error && error.trim()) {
-    return `Index ${indexNamePlaceholder} is failed.`;
-  }
-
-  // Check if it's a reindex operation
-  if (reindex) {
-    // Check if it's scheduled
-    const isScheduled = meta.initiator === 'schedule';
-    const scheduledText = isScheduled ? ' by schedule' : '';
-    return `Index ${indexNamePlaceholder} is successfully reindexed${scheduledText}. { "reindexed": ${reindexedCount}, "indexed": ${indexed || 0} }`;
-  }
-
-  // New index created
-  return `Index ${indexNamePlaceholder} is successfully created: { "indexed": ${indexed || 0} }`;
-};
-
-const MyNewTabLink = ({ linkInfo, needTrim, event_type }) => {
-  const { linkText, project_id, id, indexName } = linkInfo;
+const MyNewTabLink = memo(props => {
+  const { linkInfo, needTrim, eventType } = props;
+  const { linkText: label, project_id, id, indexName } = linkInfo;
 
   const href = useNotificationNewTabNavigate({
     project_id,
     id,
-    event_type,
+    event_type: eventType,
     indexName,
   });
 
@@ -85,23 +47,25 @@ const MyNewTabLink = ({ linkInfo, needTrim, event_type }) => {
     <Link
       variant="labelMedium"
       sx={{ textDecoration: 'underline', cursor: 'pointer' }}
-      target={'_blank'}
+      target="_blank"
       href={href}
     >
-      {needTrim ? formatName(linkText) : linkText}
+      {needTrim ? formatName(label) : label}
     </Link>
   );
-};
+});
+MyNewTabLink.displayName = 'MyNewTabLink';
 
-const MyCurrentTabLink = ({ linkInfo, needTrim, onCloseNotificationList, event_type }) => {
-  const { linkText, project_id, id, version_id, version_name, indexName } = linkInfo;
+const MyCurrentTabLink = memo(props => {
+  const { linkInfo, needTrim, onCloseNotificationList, eventType } = props;
+  const { linkText: label, project_id, id, version_id, version_name, indexName } = linkInfo;
   const viewMode = project_id == PUBLIC_PROJECT_ID ? ViewMode.Public : ViewMode.Owner;
 
   const doNavigate = useNotificationNavigate({
     viewMode,
     id,
-    event_type,
-    name: linkText,
+    event_type: eventType,
+    name: label,
     version_id,
     version_name,
     indexName,
@@ -116,69 +80,108 @@ const MyCurrentTabLink = ({ linkInfo, needTrim, onCloseNotificationList, event_t
   return (
     <Link
       variant="labelMedium"
-      component={'span'}
+      component="span"
       sx={{ textDecoration: 'underline', cursor: 'pointer' }}
       onClick={onClick}
     >
-      {needTrim ? formatName(linkText) : linkText}
+      {needTrim ? formatName(label) : label}
     </Link>
   );
-};
+});
+MyCurrentTabLink.displayName = 'MyCurrentTabLink';
 
-const MyLink = props => {
+const MyLink = memo(props => {
   const { linkInfo } = props;
-
   return linkInfo?.isNewTab ? <MyNewTabLink {...props} /> : <MyCurrentTabLink {...props} />;
+});
+MyLink.displayName = 'MyLink';
+
+/**
+ * Synthesize meta fields that aren't stored raw on the notification but are
+ * needed by templates. Keeps template declarations readable.
+ */
+const adaptMetaForTemplate = (eventType, meta) => {
+  if (!meta) return meta;
+  switch (eventType) {
+    case NotificationType.IndexDataChanged:
+      return { ...meta, _renderState: deriveRenderState(meta) };
+    case NotificationType.UserWasAddedToSomeProjectAsTeammate:
+      return { ...meta, users: formatUsersForTemplate(meta) };
+    default:
+      return meta;
+  }
 };
 
-const parseInformation = notification => {
+const pickStatusCase = (seg, adaptedMeta) => {
+  const key = adaptedMeta?.[seg.metaKey];
+  if (key && seg.cases[key]) return seg.cases[key];
+  // Key present but not in the template — BE added a value we haven't mapped
+  // yet. Surface it so the gap is noticeable and a template fix gets filed.
+  if (key) return `[${key}]`;
+  // Key absent (meta unavailable) — nothing meaningful to show.
+  return '';
+};
+
+const renderTemplate = (tplParsed, notification, adaptedMeta, onCloseNotificationList) =>
+  tplParsed.segments.map((seg, i) => {
+    switch (seg.type) {
+      case 'text':
+        return <span key={i}>{seg.text}</span>;
+      case 'var':
+        return <span key={i}>{adaptedMeta?.[seg.metaKey] ?? ''}</span>;
+      case 'link':
+      case 'linkText': {
+        const linkInfo = resolveLinkInfo(seg, notification, adaptedMeta);
+        if (!linkInfo.linkText) return null;
+        return (
+          <MyLink
+            key={i}
+            linkInfo={linkInfo}
+            needTrim={seg.type === 'link'}
+            onCloseNotificationList={onCloseNotificationList}
+            eventType={notification.event_type}
+          />
+        );
+      }
+      case 'status':
+        return <span key={i}>{pickStatusCase(seg, adaptedMeta)}</span>;
+      default:
+        return null;
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Legacy rendering path — retained for notification types not yet migrated to
+// NOTIFICATION_TEMPLATES. Preserves original behavior byte-for-byte.
+// ---------------------------------------------------------------------------
+
+const legacyLeadingText = (param1, param2) => ({
+  [NotificationType.ChatUserAdded]: `${param1} added ${param2} to `,
+});
+
+const LEGACY_ENDING_TEXT = {
+  [NotificationType.Rates]: '.',
+  [NotificationType.Comments]: '.',
+  [NotificationType.ContributorRequestForPublishApprove]: '.',
+  [NotificationType.ChatUserAdded]: '',
+};
+
+const parseLegacyInformation = notification => {
   const { event_type, project_id, meta } = notification;
   switch (event_type) {
     case NotificationType.AgentUnpublished: {
       const reasonSuffix = meta.reason ? ` Reason: ${meta.reason}` : '';
       return {
-        event_type,
-        leadingTextParam1: '',
-        leadingTextParam2: '',
         agentUnpublishedMeta: {
           sourceVersionId: meta.source_version_id,
           sourceApplicationId: meta.source_application_id,
           projectId: notification.project_id,
           reasonSuffix,
         },
-        endingTextParam: '',
       };
     }
-    case NotificationType.ModeratorApprovalOfVersion:
-    case NotificationType.ModeratorRejectOfVersion:
-    case NotificationType.ModeratorUnpublish:
-    case NotificationType.AuthorApproval:
-    case NotificationType.AuthorReject:
-    case NotificationType.TokenExpiring:
-    case NotificationType.TokenIsExpired:
-      return {
-        event_type,
-        leadingTextParam1: meta.token_name,
-        leadingTextParam2: '',
-        firstLinkInfo: {
-          linkText: 'Configuration',
-        },
-        endingTextParam: '',
-      };
-    case NotificationType.SpendingLimitIsExpired:
-    case NotificationType.SpendingLimitExpiring:
-      return {
-        event_type,
-        leadingTextParam1: '',
-        leadingTextParam2: '',
-        firstLinkInfo: {
-          linkText: 'settings section',
-        },
-        endingTextParam: '',
-      };
     case NotificationType.Rates:
       return {
-        event_type,
         leadingTextParam1: meta.rates_count,
         leadingTextParam2: '',
         firstLinkInfo: {
@@ -187,11 +190,9 @@ const parseInformation = notification => {
           version_id: meta.prompt_version_id,
           project_id,
         },
-        endingTextParam: '',
       };
     case NotificationType.Comments:
       return {
-        event_type,
         leadingTextParam1: meta.comments_count,
         leadingTextParam2: meta.replies_count,
         firstLinkInfo: {
@@ -200,18 +201,9 @@ const parseInformation = notification => {
           version_id: meta.prompt_version_id,
           project_id,
         },
-        endingTextParam: '',
-      };
-    case NotificationType.RewardNewLevel:
-      return {
-        event_type,
-        leadingTextParam1: meta.new_level,
-        leadingTextParam2: '',
-        endingTextParam: '',
       };
     case NotificationType.ContributorRequestForPublishApprove:
       return {
-        event_type,
         leadingTextParam1: meta.author_name,
         leadingTextParam2: '',
         firstLinkInfo: {
@@ -220,22 +212,9 @@ const parseInformation = notification => {
           version_id: meta.prompt_version_id,
           project_id,
         },
-        endingTextParam: '',
-      };
-    case NotificationType.UserWasAddedToSomeProjectAsTeammate:
-      return {
-        event_type,
-        leadingTextParam1: `${meta.users.join(', ')} ${meta.users.length > 1 ? 'are' : 'is'}`,
-        leadingTextParam2: '',
-        firstLinkInfo: {
-          linkText: meta.project_name,
-          project_id,
-        },
-        endingTextParam: '',
       };
     case NotificationType.ChatUserAdded:
       return {
-        event_type,
         leadingTextParam1: meta.initiator_name ? meta.initiator_name : 'You were ',
         leadingTextParam2: meta.initiator_name ? 'you ' : '',
         firstLinkInfo: {
@@ -244,76 +223,21 @@ const parseInformation = notification => {
           project_id,
           isNewTab: true,
         },
-        endingTextParam: '',
-      };
-    case NotificationType.PrivateProjectCreated:
-      return {
-        event_type,
-        leadingTextParam1: '',
-        leadingTextParam2: '',
-        endingTextParam: '',
-      };
-    case NotificationType.IndexDataChanged:
-      return {
-        event_type,
-        leadingTextParam1: formatIndexMessage(meta, !!meta.toolkit_id), // Only use link placeholder if toolkit_id exists
-        leadingTextParam2: '',
-        firstLinkInfo: meta.toolkit_id
-          ? {
-              linkText: meta.index_name || 'Index',
-              id: meta.toolkit_id,
-              project_id,
-              indexName: meta.index_name,
-              isNewTab: true,
-            }
-          : null,
-        endingTextParam: '',
-      };
-    case NotificationType.BucketExpirationWarning: {
-      return {
-        event_type,
-        leadingTextParam1: '',
-        leadingTextParam2: '',
-        firstLinkInfo: {
-          linkText: meta.bucket_name || 'Bucket',
-          id: meta.bucket_name,
-          project_id,
-          isNewTab: true,
-        },
-        endingTextParam: '',
-      };
-    }
-    case NotificationType.PersonalAccessTokenExpiring:
-      return {
-        event_type,
-        leadingTextParam1: meta.token_name,
-        leadingTextParam2: '',
-        firstLinkInfo: {
-          linkText: 'Manage Personal Access Tokens',
-          project_id,
-          isNewTab: true,
-        },
-        endingTextParam: '',
       };
     default:
       return {};
   }
 };
 
-const NotificationListItemMessage = props => {
-  const { notification, onCloseNotificationList, textVariant = 'bodySmall' } = props;
+const LegacyMessage = memo(props => {
+  const { notification, onCloseNotificationList, textVariant, textColor } = props;
+  const { event_type } = notification;
   const {
-    event_type,
     leadingTextParam1 = '',
     leadingTextParam2 = '',
     firstLinkInfo,
-    hasMiddleText,
-    secondLinkInfo,
-    endingTextParam = '',
     agentUnpublishedMeta,
-  } = parseInformation(notification);
-
-  const textColor = notification.is_seen ? 'text.primary' : 'text.secondary';
+  } = parseLegacyInformation(notification);
 
   // Special handling for AgentUnpublished — inline version link
   if (event_type === NotificationType.AgentUnpublished && agentUnpublishedMeta) {
@@ -341,28 +265,50 @@ const NotificationListItemMessage = props => {
     );
   }
 
-  // Special handling for IndexDataChanged to embed link within message text
-  if (
-    event_type === NotificationType.IndexDataChanged &&
-    firstLinkInfo &&
-    leadingTextParam1.includes('{INDEX_LINK}')
-  ) {
-    const parts = leadingTextParam1.split('{INDEX_LINK}');
-    return (
-      <Typography
-        variant={textVariant}
-        sx={{ color: textColor }}
-      >
-        {parts[0]}
+  return (
+    <Typography
+      variant={textVariant}
+      sx={{ color: textColor }}
+    >
+      {legacyLeadingText(leadingTextParam1, leadingTextParam2)[event_type]}
+      {firstLinkInfo && (
         <MyLink
           linkInfo={firstLinkInfo}
-          needTrim={false}
+          needTrim
           onCloseNotificationList={onCloseNotificationList}
-          event_type={event_type}
+          eventType={event_type}
         />
-        {parts[1]}
-        {endingText(endingTextParam)[event_type]}
-      </Typography>
+      )}
+      {LEGACY_ENDING_TEXT[event_type]}
+    </Typography>
+  );
+});
+LegacyMessage.displayName = 'LegacyMessage';
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+const NotificationListItemMessage = memo(props => {
+  const { notification, onCloseNotificationList, textVariant = 'bodySmall' } = props;
+  const { event_type, meta, is_seen } = notification;
+
+  const textColor = is_seen ? 'text.primary' : 'text.secondary';
+  const template = NOTIFICATION_TEMPLATES[event_type];
+
+  const adaptedMeta = useMemo(
+    () => (template ? adaptMetaForTemplate(event_type, meta) : meta),
+    [template, event_type, meta],
+  );
+
+  if (!template) {
+    return (
+      <LegacyMessage
+        notification={notification}
+        onCloseNotificationList={onCloseNotificationList}
+        textVariant={textVariant}
+        textColor={textColor}
+      />
     );
   }
 
@@ -371,27 +317,10 @@ const NotificationListItemMessage = props => {
       variant={textVariant}
       sx={{ color: textColor }}
     >
-      {leadingText(leadingTextParam1, leadingTextParam2)[event_type]}
-      {firstLinkInfo && (
-        <MyLink
-          linkInfo={firstLinkInfo}
-          needTrim
-          onCloseNotificationList={onCloseNotificationList}
-          event_type={event_type}
-        />
-      )}
-      {hasMiddleText && middleText[event_type]}
-      {secondLinkInfo && (
-        <MyLink
-          linkInfo={secondLinkInfo}
-          needTrim
-          onCloseNotificationList={onCloseNotificationList}
-          event_type={event_type}
-        />
-      )}
-      {endingText(endingTextParam)[event_type]}
+      {renderTemplate(template, notification, adaptedMeta, onCloseNotificationList)}
     </Typography>
   );
-};
+});
+NotificationListItemMessage.displayName = 'NotificationListItemMessage';
 
 export default NotificationListItemMessage;

--- a/src/pages/NotificationCenter/NotificationCenter.jsx
+++ b/src/pages/NotificationCenter/NotificationCenter.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { Box } from '@mui/material';
 
+import { buildNotificationQueryFilters } from '@/[fsd]/entities/notification';
 import { useNotificationListQuery } from '@/api/notifications';
 import { SortOrderOptions } from '@/common/constants';
 import { buildErrorMessage } from '@/common/utils';
@@ -34,6 +35,7 @@ export default function NotificationCenter() {
     () => (debouncedSearch.length < MIN_SEARCH_LENGTH ? '' : debouncedSearch),
     [debouncedSearch],
   );
+  const notificationQueryFilters = useMemo(() => buildNotificationQueryFilters(apiSearch), [apiSearch]);
 
   const handleSearchChange = useCallback(value => {
     setSearch(value);
@@ -50,7 +52,7 @@ export default function NotificationCenter() {
       pageSize: paginationModel.pageSize,
       sortBy: sortModel.field,
       sortOrder: sortModel.direction,
-      search: apiSearch,
+      tokens: notificationQueryFilters.tokens,
     },
     { refetchOnFocus: true, skip: !personal_project_id },
   );


### PR DESCRIPTION
- Add FSD entity src/[fsd]/entities/notification/ with templateDSL, template catalog, static search index, meta-key whitelist, and buildNotificationQueryFilters.
- Rewrite NotificationListItemMessage to render from parsed templates; keep legacy path for not-yet-templated types.
- Send search_tokens from notificationList; meta_search_keys only on explicit override.
- Wire NotificationCenter to buildNotificationQueryFilters on debounced input.

<img width="1088" height="510" alt="image" src="https://github.com/user-attachments/assets/9f9fbe3d-7f7e-47ea-9ed1-721b3fd4d192" />


# EL-4696 — Notification Center search

## What's broken today

Searching in the Notification Center returns weird results:

- **Obvious words don't match.** Most notification text lives on the FE — stitched together from `leadingText`, `endingText`, and `formatIndexMessage` in `NotificationListItemMessage.jsx`. The BE doesn't know any of those strings, so searches like `"will start deleting"` or `"Project was successfully"` return nothing.
- **Unrelated rows do match.** The BE casts the full `meta` JSON to text and runs `ILIKE` on it. Searching `"bucket"` can return a failed-index notification because `meta.error` happens to contain `"createNewBucket"` somewhere in a tool list the user never sees.

## What this PR does

Makes the FE the **single source of truth** for notification text and ships a structured search payload the BE can use precisely.

Each notification type now has **one template** with typed placeholders:

```js
tpl`Bucket ${link('bucket_name')} will start deleting files in 24 hours...`
tpl`Index ${link('index_name')} ${status('_renderState', {
  failed: 'is failed.',
  reindexed: 'is successfully reindexed.',
  created: 'is successfully created.',
})}`
```

That one declaration drives everything:

1. **Rendering** — the old triple-head system (`leadingText` / `middleText` / `endingText` / `formatIndexMessage`) is gone. `NotificationListItemMessage` walks the parsed template segments.
2. **Static search index** — literal text and every `status(...)` case value are indexed *per event type*. Searching `"is failed"` resolves only to `IndexDataChanged`, and the failed case doesn't pollute the index with `"successfully"`.
3. **Dynamic search** — `ALL_VARIABLE_KEYS` gives the BE a whitelist of `meta` keys to scan, replacing the leaky full-JSON cast.
4. **Query classification** — `buildNotificationQueryFilters` tokenises the query and returns `search_tokens` the BE uses to AND tokens and OR axes within each token.

Types not yet templated (`AgentUnpublished`, `ChatUserAdded`, `Rates`, `Comments`, `ContributorRequestForPublishApprove`) still go through a legacy code path, preserved byte-for-byte, so nothing regresses.

## Where to look

- **Entity (new):** `src/[fsd]/entities/notification/` — DSL, template catalog, search helpers, public barrel.
- **Renderer:** `src/components/NotificationListItemMessage.jsx` — templated path + legacy fallback.
- **API:** `src/api/notifications.js` — sends `search_tokens`; `meta_search_keys` only on explicit override.
- **Page:** `src/pages/NotificationCenter/NotificationCenter.jsx` — calls `buildNotificationQueryFilters` on the debounced input.
- **Background:** `docs/notification-search-proposal.md` — full design rationale (non-goals, grammar, BE contract).


## Needs BE

This PR depends on the matching BE change (search tokens + meta key whitelist). Without it, search still works but falls back to the old behaviour.

## How to test

1. Open Notification Center.
2. Search `"will start deleting"` → bucket-expiration rows match (previously none).
3. Search `"is failed"` → only failed index rows match (previously: unrelated rows).
4. Search `"bucket"` → only rows whose visible text mentions bucket, not failed-index rows whose `meta.error` mentions a tool name.
5. Multi-word queries like `"index attach"` — every token must match somewhere in the row.

## Open question — should we keep this pattern on the FE?

Worth a team discussion before this becomes the default for future notification types:

- **Pros.** One declaration per type, rendering and search stay in sync automatically, no stored/rendered text drift, no BE-side message templates, i18n-friendly when we get there.
- **Cons.** A custom mini-DSL (`tpl` / `variable` / `link` / `status`) to learn; the FE/BE contract (`search_tokens`, `meta_search_keys`, synthetic status keys like `_renderState`) has to stay in sync across repos; types with complex inline structure (`AgentUnpublished`, `ChatUserAdded`, etc.) still need a legacy path — we now have two rendering paths instead of one.
- **Alternatives considered.** Storing a pre-rendered `text` column (rejected — stale on template changes, needs backfill/coordinated deploys); pure client-side filtering (rejected — breaks pagination totals and `limit/offset`).

Decision needed: migrate the remaining legacy types to templates over time, or keep the DSL scoped to the types it currently covers and accept a permanent two-path renderer?