### PR TITLE
fix: [EL-4753] prevent duplicate notifications on infinite scroll in popup

### DIFF
--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -62,6 +62,7 @@ const NotificationList = memo(props => {
   useEffect(() => {
     if (!notificationListAnchorEl) return;
     if (!data?.rows) return;
+    if (isFetching) return;
     if (page === 0) {
       lastAppliedPageRef.current = 0;
       setAllNotifications(data.rows);
@@ -70,7 +71,7 @@ const NotificationList = memo(props => {
     if (lastAppliedPageRef.current === page) return;
     lastAppliedPageRef.current = page;
     setAllNotifications(prev => [...prev, ...data.rows]);
-  }, [data?.rows, notificationListAnchorEl, page]);
+  }, [data?.rows, notificationListAnchorEl, page, isFetching]);
 
   useEffect(() => {
     if (!notificationListAnchorEl) {


### PR DESCRIPTION

# EL-4753 — fix: prevent duplicate notifications on infinite scroll in popup

The accumulation effect in `NotificationList` fired as soon as `page` incremented, while RTK Query was still fetching the next page. At that point `data?.rows` still held stale page 0 data, causing it to be appended again as a duplicate. When the real next-page data arrived, the `lastAppliedPageRef` guard blocked it from being added, so the last group was never rendered.

**Fix:** Added an early `return` when `isFetching` is `true`, ensuring notifications are only accumulated after RTK Query has resolved with fresh data for the requested page.