### PR TITLE
fix: [EL-4275] preserve content on continue after token limit interruption

### DIFF
--- a/src/components/Chat/hooks.js
+++ b/src/components/Chat/hooks.js
@@ -384,12 +384,16 @@ export const useChatSocket = ({
 
       switch (socketMessageType) {
         case SocketMessageType.StartTask: {
+          const isContinuing = msg.isContinuing;
           msg.isLoading = true;
           msg.isStreaming = true;
           msg.isSending = false;
           msg.isRegenerating = undefined;
-          msg.content = '';
-          msg.references = [];
+          msg.isContinuing = undefined;
+          if (!isContinuing) {
+            msg.content = '';
+            msg.references = [];
+          }
           msg.task_id = task_id;
           msg.participant_id = participant_id;
           msg.question_id = question_id;

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1176,6 +1176,8 @@ const ChatBox = forwardRef((props, boxRef) => {
                 isStreaming: true,
                 // Clear requiresConfirmation state since user confirmed to continue
                 requiresConfirmation: undefined,
+                // Flag to prevent StartTask from resetting content on continuation
+                isContinuing: true,
               },
         ),
       );


### PR DESCRIPTION
## Summary

- When a message is interrupted due to `stop_reason=length`, clicking "Continue" triggered a `StartTask` socket event that unconditionally reset `msg.content = ''`, wiping the existing partial response
- The backend would then re-stream from scratch, producing the same content again (duplicate response)
- Fix: set `isContinuing: true` on the message before emitting continue, and skip the `content`/`references` reset in `StartTask` when that flag is present

## Changes

- `src/pages/NewChat/ChatBox.jsx` — set `isContinuing: true` in `onContinueTokenLimitExecution` state update
- `src/components/Chat/hooks.js` — check `msg.isContinuing` in `StartTask` case; skip content reset and clear the flag