### PR TITLE
feat: [EL-4738] Added infotooltip into BaseSwitch and replaced old switch components

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
@@ -2,9 +2,9 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 
-import { Box, FormControlLabel, Switch as MuiSwitch, Tooltip, Typography } from '@mui/material';
+import { Box, FormControlLabel, Tooltip, Typography } from '@mui/material';
 
-import { Text } from '@/[fsd]/shared/ui';
+import { Switch, Text } from '@/[fsd]/shared/ui';
 import AttachSvgIcon from '@/assets/attach-icon.svg?react';
 import CalendarIcon from '@/assets/calendar.svg?react';
 import ImageSvgIcon from '@/assets/image.svg?react';
@@ -99,12 +99,10 @@ const AgentInternalToolSwitch = memo(props => {
       </Box>
       <FormControlLabel
         control={
-          <MuiSwitch
+          <Switch.BaseSwitch
             checked={allowTool}
             onChange={onChange}
             disabled={disabled}
-            size="small"
-            variant="elitea"
           />
         }
         label=""

--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/CommonInterruptSettings.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/CommonInterruptSettings.jsx
@@ -1,10 +1,11 @@
 import { memo, useCallback, useContext, useMemo } from 'react';
 
-import { Box, FormControlLabel, Switch, Typography } from '@mui/material';
+import { Box, FormControlLabel, Typography } from '@mui/material';
 
 import { FlowEditorContext } from '@/[fsd]/app/providers';
 import { PipelineNodeTypes } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
 import { FlowEditorHelpers } from '@/[fsd]/features/pipelines/flow-editor/lib/helpers';
+import { Switch } from '@/[fsd]/shared/ui';
 import styled from '@emotion/styled';
 
 const StyledFormControlLabel = styled(FormControlLabel)(({ theme }) => ({
@@ -108,12 +109,11 @@ const CommonInterruptSettings = memo(props => {
     >
       <StyledFormControlLabel
         control={
-          <Switch
+          <Switch.BaseSwitch
             disabled={yamlJsonObject.entry_point === id || disabled}
             checked={
               yamlJsonObject.entry_point === id ? false : !!realInterruptBefore.find(item => item === id)
             }
-            color="primary"
             onChange={onChangeInterruptBefore}
           />
         }
@@ -129,14 +129,13 @@ const CommonInterruptSettings = memo(props => {
       />
       <StyledFormControlLabel
         control={
-          <Switch
+          <Switch.BaseSwitch
             disabled={yamlNode?.transition === PipelineNodeTypes.End || disabled}
             checked={
               yamlNode?.transition === PipelineNodeTypes.End
                 ? false
                 : !!realInterruptAfter.find(item => item === id)
             }
-            color="primary"
             onChange={onChangeInterruptAfter}
           />
         }
@@ -153,10 +152,9 @@ const CommonInterruptSettings = memo(props => {
       {showStructuredOutput && (
         <StyledFormControlLabel
           control={
-            <Switch
+            <Switch.BaseSwitch
               disabled={disabled}
               checked={!!yamlNode?.structured_output}
-              color="primary"
               onChange={onChangeStructuredOutput}
             />
           }

--- a/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableItem.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableItem.jsx
@@ -230,18 +230,18 @@ export default StateVariableItem;
 
 /** @type {MuiSx} */
 const stateVariableItemStyles = (isDefault, nameFieldWidth, enabled, shouldExpandNameField) => ({
-  outerContainer: ({ spacing }) => ({
+  outerContainer: {
     display: 'flex',
     flexDirection: 'column',
-    gap: spacing(1),
+    gap: '0.5rem',
     minWidth: 0,
-  }),
-  container: ({ spacing }) => ({
+  },
+  container: {
     display: 'flex',
-    alignItems: 'flex-start',
-    gap: spacing(1),
+    alignItems: 'center',
+    gap: '0.5rem',
     minWidth: 0,
-  }),
+  },
   errorText: ({ palette }) => ({
     color: palette.error.main,
     fontSize: '0.6875rem',

--- a/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableItemActions.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableItemActions.jsx
@@ -1,9 +1,10 @@
 import { memo, useCallback } from 'react';
 
-import { Box, IconButton, Switch } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 
 import { FlowEditorConstants } from '@/[fsd]/features/pipelines/flow-editor/lib/constants';
 import { FlowEditorState } from '@/[fsd]/features/pipelines/flow-editor/ui';
+import { Switch } from '@/[fsd]/shared/ui';
 import DeleteIcon from '@/components/Icons/DeleteIcon';
 
 const StateVariableItemActions = memo(props => {
@@ -30,9 +31,8 @@ const StateVariableItemActions = memo(props => {
   if (showToggle) {
     return (
       <Box sx={styles.actionContainer}>
-        <Switch
+        <Switch.BaseSwitch
           checked={enabled}
-          size="small"
           onChange={handleToggle}
           sx={styles.switch}
           disabled={disabled}
@@ -83,38 +83,18 @@ StateVariableItemActions.displayName = 'StateVariableItemActions';
 
 /** @type {MuiSx} */
 const stateVariableItemActionsStyles = () => ({
-  actionContainer: ({ spacing }) => ({
-    width: spacing(3.5),
-    height: spacing(4),
+  actionContainer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-  }),
-  deleteButton: ({ spacing }) => ({
-    padding: spacing(0.5),
+  },
+  deleteButton: {
+    padding: '0.25rem',
     alignSelf: 'center',
-  }),
-  deleteIcon: ({ spacing }) => ({
-    fontSize: spacing(2),
-  }),
-  switch: ({ palette }) => ({
-    '& .MuiSwitch-switchBase': {
-      color: palette.secondary.main,
-
-      '&.Mui-checked': {
-        color: palette.primary.main,
-
-        '& + .MuiSwitch-track': {
-          backgroundColor: palette.split.hover,
-          opacity: 1,
-        },
-      },
-    },
-    '& .MuiSwitch-track': {
-      backgroundColor: palette.background.button.secondary.hover,
-      opacity: 1,
-    },
-  }),
+  },
+  deleteIcon: {
+    fontSize: '1rem',
+  },
 });
 
 export default StateVariableItemActions;

--- a/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableTable.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableTable.jsx
@@ -1,12 +1,13 @@
 import React, { memo, useCallback, useState } from 'react';
 
-import { Switch, ThemeProvider, Typography } from '@mui/material';
+import { ThemeProvider, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import { DataGrid, GridRowEditStopReasons, gridClasses, useGridApiRef } from '@mui/x-data-grid';
 
 import { FlowEditorConstants } from '@/[fsd]/features/pipelines/flow-editor/lib/constants';
 import { FlowEditorSettings } from '@/[fsd]/features/pipelines/flow-editor/ui';
+import { Switch } from '@/[fsd]/shared/ui';
 import AlertDialog from '@/components/AlertDialog.jsx';
 import DeleteIcon from '@/components/Icons/DeleteIcon.jsx';
 import useEliteATheme from '@/hooks/useEliteATheme';
@@ -266,10 +267,9 @@ const StateVariableTable = memo(props => {
         const { name } = row;
         return name === FlowEditorConstants.STATE_INPUT || name === FlowEditorConstants.STATE_MESSAGES
           ? [
-              <Switch
+              <Switch.BaseSwitch
                 key={`switch-${id}`}
                 checked={row.enabled}
-                color="primary"
                 onChange={event => {
                   setRows(
                     rows.map(item => (item.id === id ? { ...item, enabled: event.target.checked } : item)),

--- a/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexActions.jsx
+++ b/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexActions.jsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { Box, Button as MuiButton, Switch, Typography } from '@mui/material';
+import { Box, Button as MuiButton, Typography } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
 import {
@@ -19,7 +19,7 @@ import {
 } from '@/[fsd]/features/toolkits/indexes/model/indexes.slice';
 import { IndexScheduleModal } from '@/[fsd]/features/toolkits/indexes/ui';
 import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
-import { Button } from '@/[fsd]/shared/ui';
+import { Button, Switch } from '@/[fsd]/shared/ui';
 import { useUpdateIndexScheduleMutation } from '@/api';
 import { PERMISSIONS } from '@/common/constants';
 import { convertToolkitSchema } from '@/common/toolkitSchemaUtils';
@@ -200,14 +200,12 @@ const IndexActions = memo(props => {
                 slotProps={{ popper: { modifiers: [{ name: 'offset', options: { offset: [0, -8] } }] } }}
               >
                 <Box component="span">
-                  <Switch
+                  <Switch.BaseSwitch
                     checked={scheduleData.enabled}
                     onChange={() =>
                       handleChangeIndexSchedule({ ...scheduleData, enabled: !scheduleData.enabled }, true)
                     }
                     disabled={Boolean(schedulingTooltipMessage)}
-                    size="small"
-                    variant="elitea"
                   />
                 </Box>
               </Tooltip>

--- a/src/[fsd]/shared/ui/switch/BaseSwitch.jsx
+++ b/src/[fsd]/shared/ui/switch/BaseSwitch.jsx
@@ -1,6 +1,4 @@
-import { forwardRef, memo, useCallback } from 'react';
-
-import PropTypes from 'prop-types';
+import React, { forwardRef, memo, useCallback, useMemo } from 'react';
 
 import { Box, FormControlLabel, Switch as MuiSwitch, Tooltip, Typography } from '@mui/material';
 
@@ -8,6 +6,36 @@ import InfoIcon from '@/components/Icons/InfoIcon';
 
 export const SWITCH_VARIANTS = {
   elitea: 'elitea',
+};
+
+const INFO_TOOLTIP_DEFAULTS = {
+  placement: 'top',
+  zIndex: 9999,
+  icon: { width: 16, height: 16 },
+};
+
+const parseInfoTooltip = (infoTooltip, slotProps) => {
+  if (!infoTooltip) return null;
+
+  const isObject = typeof infoTooltip === 'object' && !React.isValidElement(infoTooltip);
+
+  return {
+    title: isObject ? infoTooltip.title : infoTooltip,
+    placement: isObject
+      ? (infoTooltip.placement ?? INFO_TOOLTIP_DEFAULTS.placement)
+      : INFO_TOOLTIP_DEFAULTS.placement,
+    zIndex: isObject
+      ? (infoTooltip.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex)
+      : (slotProps?.tooltip?.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex),
+    icon: {
+      width: isObject
+        ? (infoTooltip.icon?.width ?? INFO_TOOLTIP_DEFAULTS.icon.width)
+        : INFO_TOOLTIP_DEFAULTS.icon.width,
+      height: isObject
+        ? (infoTooltip.icon?.height ?? INFO_TOOLTIP_DEFAULTS.icon.height)
+        : INFO_TOOLTIP_DEFAULTS.icon.height,
+    },
+  };
 };
 
 const BaseSwitch = memo(
@@ -20,7 +48,7 @@ const BaseSwitch = memo(
       checked: checkedProp,
       value: valueProp,
       onChange: onChangeProp,
-      size,
+      size = 'small',
       variant = 'elitea',
       disabled,
       ...restProps
@@ -28,16 +56,14 @@ const BaseSwitch = memo(
 
     const styles = genStyles({ width });
 
-    const checked = checkedProp !== undefined ? checkedProp : !!valueProp;
+    const isBooleanMode = valueProp !== undefined;
+    const checked = checkedProp ?? !!valueProp;
 
     const handleChange = useCallback(
       (event, checkedValue) => {
-        if (onChangeProp) {
-          const isValueProp = valueProp !== undefined;
-          onChangeProp(isValueProp ? checkedValue : event, checkedValue);
-        }
+        onChangeProp?.(isBooleanMode ? checkedValue : event, checkedValue);
       },
-      [onChangeProp, valueProp],
+      [onChangeProp, isBooleanMode],
     );
 
     const switchComponent = (
@@ -53,6 +79,29 @@ const BaseSwitch = memo(
       />
     );
 
+    const tooltipConfig = useMemo(() => parseInfoTooltip(infoTooltip, slotProps), [infoTooltip, slotProps]);
+
+    const tooltipIcon = tooltipConfig ? (
+      <Tooltip
+        title={tooltipConfig.title}
+        placement={tooltipConfig.placement}
+        slotProps={{
+          popper: {
+            sx: {
+              zIndex: tooltipConfig.zIndex,
+            },
+          },
+        }}
+      >
+        <Box sx={styles.iconContainer}>
+          <InfoIcon
+            width={tooltipConfig.icon.width}
+            height={tooltipConfig.icon.height}
+          />
+        </Box>
+      </Tooltip>
+    ) : null;
+
     if (label) {
       return (
         <Box sx={[styles.container, slotProps?.container?.sx]}>
@@ -60,38 +109,28 @@ const BaseSwitch = memo(
             control={switchComponent}
             label={
               <Typography
-                variant="bodyMedium"
-                color="text.secondary"
+                variant={slotProps?.label?.variant || 'bodyMedium'}
+                color={slotProps?.label?.color || 'text.secondary'}
                 component="div"
-                sx={styles.label}
+                sx={[styles.label, slotProps?.label?.sx]}
               >
                 {label}
-                {infoTooltip && (
-                  <Tooltip
-                    title={infoTooltip}
-                    placement="top"
-                    slotProps={{
-                      popper: {
-                        sx: {
-                          zIndex: slotProps?.tooltip?.zIndex || 9999,
-                        },
-                      },
-                    }}
-                  >
-                    <Box sx={styles.iconContainer}>
-                      <InfoIcon
-                        width={16}
-                        height={16}
-                      />
-                    </Box>
-                  </Tooltip>
-                )}
+                {tooltipIcon}
               </Typography>
             }
             disabled={disabled}
             labelPlacement={slotProps?.formControlLabel?.labelPlacement || 'end'}
-            sx={slotProps?.formControlLabel?.sx}
+            sx={[styles.formControlLabel, slotProps?.formControlLabel?.sx ?? {}]}
           />
+        </Box>
+      );
+    }
+
+    if (tooltipIcon) {
+      return (
+        <Box sx={[styles.standaloneWithTooltip, slotProps?.container?.sx]}>
+          {switchComponent}
+          {tooltipIcon}
         </Box>
       );
     }
@@ -101,25 +140,6 @@ const BaseSwitch = memo(
 );
 
 BaseSwitch.displayName = 'BaseSwitch';
-
-BaseSwitch.propTypes = {
-  // Standard MUI Switch props
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium']),
-  variant: PropTypes.string,
-  onChange: PropTypes.func,
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  value: PropTypes.bool,
-  infoTooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  slotProps: PropTypes.shape({
-    container: PropTypes.object,
-    formControlLabel: PropTypes.object,
-    switch: PropTypes.object,
-    tooltip: PropTypes.object,
-  }),
-};
 
 const genStyles = ({ width }) => ({
   container: {
@@ -131,8 +151,22 @@ const genStyles = ({ width }) => ({
     alignItems: 'center',
     gap: '0.5rem',
   },
+  standaloneWithTooltip: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.25rem',
+  },
   label: { display: 'flex', alignItems: 'center', gap: '0.25rem' },
-  iconContainer: { display: 'flex', alignItems: 'center', gap: '0.25rem', height: '100%' },
+  iconContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.25rem',
+    height: '100%',
+    '& :hover': { opacity: 0.8 },
+  },
+  formControlLabel: {
+    gap: '0.7rem',
+  },
 });
 
 export default BaseSwitch;

--- a/src/[fsd]/stories/shared/switch/BaseSwitch.stories.jsx
+++ b/src/[fsd]/stories/shared/switch/BaseSwitch.stories.jsx
@@ -54,6 +54,14 @@ Default.args = {
   disabled: false,
 };
 
+export const WithInfoTooltip = Template.bind({});
+WithInfoTooltip.args = {
+  variant: 'elitea',
+  checked: false,
+  disabled: false,
+  infoTooltip: 'This is an info tooltip',
+};
+
 export const Checked = Template.bind({});
 Checked.args = {
   variant: 'elitea',

--- a/src/[fsd]/widgets/ContextBudget/ui/ContextStrategyModalContent.jsx
+++ b/src/[fsd]/widgets/ContextBudget/ui/ContextStrategyModalContent.jsx
@@ -2,18 +2,10 @@ import { memo, useCallback, useEffect } from 'react';
 
 import { useFormikContext } from 'formik';
 
-import {
-  Box,
-  Button,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Switch,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { Box, Button, DialogContent, DialogTitle, IconButton } from '@mui/material';
 
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
+import { Switch } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { SEPARATOR } from '@/[fsd]/widgets/ContextBudget/lib/constants';
 import { handleConvertToNumberChange } from '@/[fsd]/widgets/ContextBudget/lib/validation';
@@ -25,7 +17,6 @@ import {
 } from '@/[fsd]/widgets/ContextBudget/ui';
 import AlertDialog from '@/components/AlertDialog';
 import CloseIcon from '@/components/Icons/CloseIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import { StyledDialogActions } from '@/components/StyledDialog';
 
 const parseModelValue = value => {
@@ -160,27 +151,17 @@ const ContextStrategyModalContent = memo(props => {
     <>
       <DialogTitle sx={styles.dialogTitle}>
         <Box sx={styles.dialogTitleContent}>
-          <Box sx={styles.dialogTitleLeft}>
-            <Switch
-              size="small"
-              checked={values.enabled}
-              onChange={e => handleInputChange(e, 'enabled')}
-              color="primary"
-            />
-            <Box sx={styles.titleWithIcon}>
-              <Typography
-                variant="headingMedium"
-                color="text.secondary"
-              >
-                Context Management
-              </Typography>
-              <Tooltip title="Configure how conversation context is managed and optimized">
-                <Box sx={styles.infoIconContainer}>
-                  <InfoIcon />
-                </Box>
-              </Tooltip>
-            </Box>
-          </Box>
+          <Switch.BaseSwitch
+            checked={values.enabled}
+            onChange={e => handleInputChange(e, 'enabled')}
+            label="Context Management"
+            infoTooltip="Configure how conversation context is managed and optimized"
+            slotProps={{
+              label: {
+                variant: 'headingMedium',
+              },
+            }}
+          />
           <IconButton
             variant="elitea"
             color="tertiary"


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4738

- Added infotooltip into BaseSwitch
- Replaced old switch components

**BEFORE**
<img width="334" height="86" alt="Screenshot 2026-04-27 114819" src="https://github.com/user-attachments/assets/2105c429-6e68-4cb8-8b51-195d77f3da43" />

**AFTER**
<img width="283" height="93" alt="Screenshot 2026-04-27 135020" src="https://github.com/user-attachments/assets/89fa07e6-b08a-4aef-a5e3-6b3a3ad74384" />
<img width="155" height="69" alt="Screenshot 2026-04-27 121359" src="https://github.com/user-attachments/assets/a6240dc4-daca-43b7-bf6e-96410d01fafe" />
<img width="419" height="110" alt="Screenshot 2026-04-27 132515" src="https://github.com/user-attachments/assets/6de1bbf3-cf9f-4c50-919f-55f861ed1d25" />
<img width="332" height="207" alt="Screenshot 2026-04-27 132521" src="https://github.com/user-attachments/assets/5064cc5c-7805-4f95-9e27-74ea661227f6" />
