### PR TITLE
fix: [EL-4703] Error message persists after toolkit validation and refresh button is clicked

### DIFF
--- a/src/hooks/application/useValidateApplicationVersion.js
+++ b/src/hooks/application/useValidateApplicationVersion.js
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
+import { useFormikContext } from 'formik';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  useLazyGetApplicationVersionDetailQuery,
   useLazyValidateApplicationVersionQuery,
   useValidateApplicationVersionQuery,
 } from '@/api/applications';
@@ -70,10 +72,14 @@ export const useManualValidateApplicationVersion = ({
   versionId,
   tools,
   toolId,
+  needValidateTheWholeAgent = true,
 } = {}) => {
   const dispatch = useDispatch();
   const { toastError } = useToast();
+  const { setFieldValue } = useFormikContext();
   const [validateAppVersion] = useLazyValidateApplicationVersionQuery();
+  const [fetchVersionDetail] = useLazyGetApplicationVersionDetailQuery();
+
   const subApplication = useMemo(() => {
     if (!tools?.length) return undefined;
     return tools.find(
@@ -136,7 +142,26 @@ export const useManualValidateApplicationVersion = ({
         });
       }
     }
-  }, [subApplication, validateAppVersion, applicationId, projectId, versionId, toastError, dispatch]);
+    if (needValidateTheWholeAgent) {
+      const details = await fetchVersionDetail({
+        projectId,
+        applicationId,
+        versionId,
+      }).unwrap();
+      setFieldValue('version_details.tools', details.tools || []);
+    }
+  }, [
+    subApplication,
+    needValidateTheWholeAgent,
+    validateAppVersion,
+    applicationId,
+    projectId,
+    versionId,
+    toastError,
+    dispatch,
+    fetchVersionDetail,
+    setFieldValue,
+  ]);
   return { doValidateVersion };
 };
 

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -110,13 +110,6 @@ const ToolCard = memo(props => {
     toolId: tool.id,
     tool,
   });
-  const { doValidateVersion } = useManualValidateApplicationVersion({
-    applicationId,
-    projectId,
-    versionId,
-    tools: values?.version_details?.tools || [],
-    toolId: tool.id,
-  });
 
   const isAttachmentToolkit = useMemo(
     () => tool.id && values?.version_details?.meta?.attachment_toolkit_id === tool.id,
@@ -173,6 +166,15 @@ const ToolCard = memo(props => {
       tool?.settings?.selected_tools?.some(item => !availableTools.includes(item)),
     [availableTools, tool?.settings?.selected_tools],
   );
+
+  const { doValidateVersion } = useManualValidateApplicationVersion({
+    applicationId,
+    projectId,
+    versionId,
+    tools: values?.version_details?.tools || [],
+    toolId: tool.id,
+    needValidateTheWholeAgent: tool?.type === 'application' && someToolsAreUnavailable,
+  });
 
   // Function to open agent/pipeline in new tab
   const onOpenInNewTab = useCallback(() => {
@@ -444,7 +446,7 @@ const ToolCard = memo(props => {
               )}
             </Box>
             <Box sx={styles.buttonsContainer}>
-              {validationInfo && (
+              {(validationInfo || someToolsAreUnavailable) && (
                 <>
                   <Box
                     component={AttentionIcon}


### PR DESCRIPTION
- If there is error of someToolsAreUnavailable, then we will fetch the version details and update the tools once the refresh button is clicked.