### PR TITLE
fix: [EL-4266] strip isFromCreation from URL after version detail loads

### DIFF
--- a/src/[fsd]/entities/application-tab-bar/ui/ApplicationVersionSelect.jsx
+++ b/src/[fsd]/entities/application-tab-bar/ui/ApplicationVersionSelect.jsx
@@ -23,7 +23,7 @@ const ApplicationVersionSelect = memo(props => {
   const navigate = useNavigate();
 
   const { agentId, version } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { pathname, search } = useLocation();
 
   const selectedProjectId = useSelectedProjectId();
@@ -138,9 +138,28 @@ const ApplicationVersionSelect = memo(props => {
     [getVersionDetail, dispatch, viewMode, applicationId, formik.values?.owner_id],
   );
 
+  const stripIsFromCreation = useCallback(() => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        next.delete('isFromCreation');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
   const getDetail = useCallback(
     async vId => {
       const result = await getVersionDetail({ projectId, applicationId, versionId: vId });
+
+      if (!result.data) {
+        // Version not found on the server. Strip isFromCreation so useIsVersionNotFound
+        // (skip: isFromCreation) in the parent page can detect the missing version
+        // and render <Page404 />.
+        if (isFromCreation) stripIsFromCreation();
+        return;
+      }
 
       dispatch(
         eliteaApi.util.updateQueryData(
@@ -164,8 +183,12 @@ const ApplicationVersionSelect = memo(props => {
           },
         ),
       );
+
+      // isFromCreation is a one-time flag — strip it after the version is loaded
+      // so it does not persist or accumulate in the URL.
+      if (isFromCreation) stripIsFromCreation();
     },
-    [applicationId, dispatch, getVersionDetail, isFromCreation, projectId, viewMode],
+    [applicationId, dispatch, getVersionDetail, isFromCreation, projectId, stripIsFromCreation, viewMode],
   );
 
   useEffect(() => {


### PR DESCRIPTION
- Remove isFromCreation param on successful getDetail to keep URL clean
- Remove isFromCreation param on failed getDetail so useIsVersionNotFound can detect the deleted version and show Page404

### Problem

Navigating to a URL containing a deleted agent/pipeline version (e.g. `/agents/all/4/12?isFromCreation=true`) showed a blank page instead of the 404 error page.

The `isFromCreation` search param was intentionally added to prevent false 404 flashes during the creation flow (the new version may not be in the versions list at the moment of the first fetch). However, the param was never removed from the URL, causing `useIsVersionNotFound` to permanently skip the not-found check via `skip: isFromCreation`.

### Fix

Strip `isFromCreation` from the URL inside `getDetail` after the version detail request resolves:

- **Success** — version loaded and cached → param stripped → URL is clean, normal editing continues.
- **Failure** — version not found on server → param stripped → `skip` becomes `false` → `useIsVersionNotFound` detects the missing version → `<Page404 />` is rendered.

### Changed files

- `src/[fsd]/entities/application-tab-bar/ui/ApplicationVersionSelect.jsx`
