### PR TITLE
fix: [EL-4798] deleted embedding model persists in artifact toolkit config

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -535,6 +535,8 @@ const ToolBaseProperty = memo(props => {
           projectId={specifiedProjectId}
           disabled={disableConfigFields || disabled}
           description={v.description}
+          error={!!toastError}
+          helperText={errorText}
         />
       );
     } else if (type === 'image_generation_model') {
@@ -546,6 +548,8 @@ const ToolBaseProperty = memo(props => {
           value={settings[k]}
           projectId={specifiedProjectId}
           disabled={disableConfigFields || disabled}
+          error={!!toastError}
+          helperText={errorText}
         />
       );
     } else if (type === 'toolkit_reference') {

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { Box, Typography } from '@mui/material';
+import { Box, FormControl, FormHelperText, Typography } from '@mui/material';
 
 import { Select } from '@/[fsd]/shared/ui';
 import { useLazyListModelsQuery, useListModelsQuery } from '@/api/configurations';
@@ -132,6 +132,13 @@ const EmbeddingModelSelect = memo(
 
     const hasModelsOptions = useMemo(() => newModelsMenuData.length > 0, [newModelsMenuData]);
 
+    const hasFetchedData = models.length > 0;
+    const selectedOption = useMemo(
+      () => newModelsMenuData.find(opt => opt.value === value),
+      [newModelsMenuData, value],
+    );
+    const showMismatchFooter = Boolean(value && !selectedOption && hasFetchedData);
+
     const customRenderSelectValue = useCallback(
       foundOption => {
         if (renderValue) return renderValue(foundOption);
@@ -160,11 +167,26 @@ const EmbeddingModelSelect = memo(
             showOptionIcon
             onValueChange={onSelectModel}
             customRenderValue={customRenderSelectValue}
-            error={error}
-            helperText={helperText}
+            error={error || showMismatchFooter}
             showEmptyPlaceholder={false}
             isListFetching={isFetching}
           />
+          {error && helperText && (
+            <FormControl
+              error
+              fullWidth
+            >
+              <FormHelperText>{helperText}</FormHelperText>
+            </FormControl>
+          )}
+          {showMismatchFooter && !helperText && (
+            <FormControl
+              error
+              fullWidth
+            >
+              <FormHelperText>Your model does not match any available models.</FormHelperText>
+            </FormControl>
+          )}
         </Box>
       </>
     );

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -302,6 +302,14 @@ const ToolCard = memo(props => {
       );
     }
 
+    if (errorType === 'configuration_model_not_found') {
+      return (
+        <Banner.BannerMessage
+          message={`Model "${toolValidationMessage.model_name}" is no longer available in project configurations.`}
+        />
+      );
+    }
+
     return (
       <Banner.BannerMessage
         message={

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -429,9 +429,25 @@ export const ToolkitForm = memo(props => {
 
   useEffect(() => {
     if (isError) {
+      const VALUE_ERROR_PREFIX = 'Value error, ';
       const validationErrors =
         error.data?.settings_errors?.reduce((acc, curr) => {
-          acc[curr.loc[1]] = curr.message;
+          let msg = curr.msg || '';
+          // Parse structured error JSON from Pydantic "Value error, {...}" format
+          const body = msg.startsWith(VALUE_ERROR_PREFIX) ? msg.slice(VALUE_ERROR_PREFIX.length) : msg;
+          try {
+            const parsed = JSON.parse(body);
+            if (parsed?.error_type === 'configuration_model_not_found') {
+              msg = `Model "${parsed.model_name}" is no longer available in project configurations.`;
+            } else if (parsed?.error_type === 'credential_not_found') {
+              msg = 'Your configuration does not match any available configurations.';
+            } else if (parsed?.error_type === 'private_credential_not_found') {
+              msg = 'Your private configuration does not match any available configurations.';
+            }
+          } catch {
+            // not JSON – use original msg
+          }
+          acc[curr.loc[1]] = msg;
           return acc;
         }, {}) || {};
       if (Object.keys(validationErrors).length > 0) {


### PR DESCRIPTION
Add backend validation for configuration_model fields in expand_toolkit_settings so that toolkits referencing a deleted embedding model now return a proper validation error (settings_errors) instead of silently retaining the stale value.

Frontend: show validation errors for missing embedding models in toolkit forms, aligning the visual style with credential errors (FormHelperText instead of Banner). EmbeddingModelSelect now self-detects when its saved value is absent from the available models list and renders a plain red helper text below the dropdown, matching the pattern used by CredentialsSelect and ImageGenerationModelSelect.

API test added to verify that deleting an embedding model referenced by a toolkit triggers a 400 validation error with settings_errors pointing to the embedding_model field.

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/4798