### PR TITLE
Fix/4798

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -535,6 +535,8 @@ const ToolBaseProperty = memo(props => {
           projectId={specifiedProjectId}
           disabled={disableConfigFields || disabled}
           description={v.description}
+          error={!!toastError}
+          helperText={errorText}
         />
       );
     } else if (type === 'image_generation_model') {
@@ -546,6 +548,8 @@ const ToolBaseProperty = memo(props => {
           value={settings[k]}
           projectId={specifiedProjectId}
           disabled={disableConfigFields || disabled}
+          error={!!toastError}
+          helperText={errorText}
         />
       );
     } else if (type === 'toolkit_reference') {

--- a/src/components/EmbeddingModelSelect.jsx
+++ b/src/components/EmbeddingModelSelect.jsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { Box, Typography } from '@mui/material';
+import { Box, FormControl, FormHelperText, Typography } from '@mui/material';
 
 import { Select } from '@/[fsd]/shared/ui';
 import { useLazyListModelsQuery, useListModelsQuery } from '@/api/configurations';
@@ -132,6 +132,13 @@ const EmbeddingModelSelect = memo(
 
     const hasModelsOptions = useMemo(() => newModelsMenuData.length > 0, [newModelsMenuData]);
 
+    const hasFetchedData = models.length > 0;
+    const selectedOption = useMemo(
+      () => newModelsMenuData.find(opt => opt.value === value),
+      [newModelsMenuData, value],
+    );
+    const showMismatchFooter = Boolean(value && !selectedOption && hasFetchedData);
+
     const customRenderSelectValue = useCallback(
       foundOption => {
         if (renderValue) return renderValue(foundOption);
@@ -160,11 +167,26 @@ const EmbeddingModelSelect = memo(
             showOptionIcon
             onValueChange={onSelectModel}
             customRenderValue={customRenderSelectValue}
-            error={error}
-            helperText={helperText}
+            error={error || showMismatchFooter}
             showEmptyPlaceholder={false}
             isListFetching={isFetching}
           />
+          {error && helperText && (
+            <FormControl
+              error
+              fullWidth
+            >
+              <FormHelperText>{helperText}</FormHelperText>
+            </FormControl>
+          )}
+          {showMismatchFooter && !helperText && (
+            <FormControl
+              error
+              fullWidth
+            >
+              <FormHelperText>Your model does not match any available models.</FormHelperText>
+            </FormControl>
+          )}
         </Box>
       </>
     );

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -302,6 +302,14 @@ const ToolCard = memo(props => {
       );
     }
 
+    if (errorType === 'configuration_model_not_found') {
+      return (
+        <Banner.BannerMessage
+          message={`Model "${toolValidationMessage.model_name}" is no longer available in project configurations.`}
+        />
+      );
+    }
+
     return (
       <Banner.BannerMessage
         message={

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -262,6 +262,14 @@ export const ToolkitForm = memo(props => {
       if (toolType === 'mcp' && field === 'settings.scopes') {
         McpAuthHelpers.logout(values?.settings?.url);
       }
+      // Clear any existing validation error for this field when user changes its value
+      const fieldKey = field.includes('.') ? field.split('.').pop() : field;
+      setToolErrors(prev => {
+        if (!prev[fieldKey]) return prev;
+        const next = { ...prev };
+        delete next[fieldKey];
+        return next;
+      });
       onChangeToolDetail(prevState => updateObjectByPath(prevState, field, value, replace));
     },
     [onChangeToolDetail, setFieldValue, toolType, values?.settings?.url],

--- a/src/pages/Toolkits/ToolkitForm.jsx
+++ b/src/pages/Toolkits/ToolkitForm.jsx
@@ -429,9 +429,25 @@ export const ToolkitForm = memo(props => {
 
   useEffect(() => {
     if (isError) {
+      const VALUE_ERROR_PREFIX = 'Value error, ';
       const validationErrors =
         error.data?.settings_errors?.reduce((acc, curr) => {
-          acc[curr.loc[1]] = curr.message;
+          let msg = curr.msg || '';
+          // Parse structured error JSON from Pydantic "Value error, {...}" format
+          const body = msg.startsWith(VALUE_ERROR_PREFIX) ? msg.slice(VALUE_ERROR_PREFIX.length) : msg;
+          try {
+            const parsed = JSON.parse(body);
+            if (parsed?.error_type === 'configuration_model_not_found') {
+              msg = `Model "${parsed.model_name}" is no longer available in project configurations.`;
+            } else if (parsed?.error_type === 'credential_not_found') {
+              msg = 'Your configuration does not match any available configurations.';
+            } else if (parsed?.error_type === 'private_credential_not_found') {
+              msg = 'Your private configuration does not match any available configurations.';
+            }
+          } catch {
+            // not JSON – use original msg
+          }
+          acc[curr.loc[1]] = msg;
           return acc;
         }, {}) || {};
       if (Object.keys(validationErrors).length > 0) {


### PR DESCRIPTION
fix: [EL-4798] selecting valid model does not clear validation error

Clear the field-level validation error from toolErrors when the user changes
a field value via editField. Previously, after the toolkit validator set an
error for embedding_model (or any configuration_model field), selecting a
valid model would update the settings but leave the error in toolErrors,
keeping toastError truthy and the Save button disabled.

The fix extracts the leaf field key from the dot-notation path and removes
it from toolErrors so the error clears immediately on user interaction

Connected to: https://github.com/EliteaAI/elitea_issues/issues/4798#issuecomment-4342765966