### PR TITLE
fix: [EL-4793] Fixed ui issues footer and steper of publish modal

### DIFF
--- a/src/[fsd]/entities/version/ui/PublishWizardModal.jsx
+++ b/src/[fsd]/entities/version/ui/PublishWizardModal.jsx
@@ -67,6 +67,16 @@ const PublishWizardModal = memo(
       [validationResult, publishError],
     );
 
+    const visualStep = useMemo(() => {
+      if (step === PUBLISH_STEPS.PUBLISHING) {
+        return PUBLISH_STEPS.PUBLISHING + 1;
+      }
+      if (step === PUBLISH_STEPS.VALIDATION && validationResult) {
+        return PUBLISH_STEPS.PUBLISHING;
+      }
+      return step;
+    }, [step, validationResult]);
+
     const handleEnterDown = useCallback(
       event => {
         if (isAdminPublish && canAdminPublish) {
@@ -140,13 +150,13 @@ const PublishWizardModal = memo(
         {!isAdminPublish && (
           <Box sx={styles.stepperContainer}>
             <Stepper
-              activeStep={step}
+              activeStep={visualStep}
               sx={styles.stepper}
             >
               {STEP_LABELS.map((label, index) => (
                 <Step
                   key={label}
-                  sx={[styles.configStep, getStepStyle(index, step, styles)]}
+                  sx={[styles.configStep, getStepStyle(index, visualStep, styles)]}
                 >
                   <StepLabel slots={{ stepIcon: CheckedIcon }}>{label}</StepLabel>
                 </Step>
@@ -180,7 +190,7 @@ const PublishWizardModal = memo(
               />
             </Box>
           ) : (
-            <>
+            <Box sx={styles.stepsContentWrapper}>
               {step === PUBLISH_STEPS.PREPARATION && (
                 <PreparationStep
                   versionName={versionName}
@@ -219,7 +229,7 @@ const PublishWizardModal = memo(
                   {publishError}
                 </Alert>
               )}
-            </>
+            </Box>
           )}
         </DialogContent>
 
@@ -288,7 +298,7 @@ const styles = {
     '& .MuiDialog-paper': {
       width: '37.5rem !important',
       maxWidth: '90vw !important',
-      height: '38.75rem',
+      maxHeight: 'min(38.75rem, 90dvh)',
       borderRadius: '1rem !important',
     },
   },
@@ -318,9 +328,10 @@ const styles = {
     '& .MuiStepLabel-label': {
       fontSize: '0.75rem',
     },
-    '& .MuiStepConnector-root.Mui-active .MuiStepConnector-line': {
-      borderColor: `${palette.step.completed.border} !important`,
-    },
+    '& .MuiStepConnector-root.Mui-active .MuiStepConnector-line, & .MuiStepConnector-root.Mui-completed .MuiStepConnector-line':
+      {
+        borderColor: `${palette.step.completed.border} !important`,
+      },
   }),
   configStep: {
     borderRadius: '2rem',
@@ -373,11 +384,12 @@ const styles = {
   }),
   dialogContent: ({ palette }) => ({
     width: '100%',
-    overflow: 'hidden',
-    maxHeight: 'calc(100vh - 20rem)',
+    overflowY: 'auto',
     boxSizing: 'border-box',
     padding: '0.875rem 1.5rem !important',
     background: `${palette.background.secondary} !important`,
+    flex: 1,
+    minHeight: 0,
   }),
   dialogActions: ({ palette }) => ({
     width: '100%',
@@ -394,6 +406,9 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     padding: '3rem 1rem',
+  },
+  stepsContentWrapper: {
+    minHeight: '25rem',
   },
 };
 


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4793

Fixes regarding requirements from comments:
- Turned on active style for Publishing steper after validation
- Changed Publishing steper style in completed status after clicking publish button 
- Fixed empty spot under footer actions buttons and it sticked in the bottom during the high extra scale
- Scrolling is available for content during the high extra scale

| State                          | visualStep | Stepper                                          |
|--------------------------------|------------|--------------------------------------------------|
| PREPARATION                    | 0          | Prep=active, others default                      |
| VALIDATION (waiting)           | 1          | Prep=completed, Valid=active                     |
| VALIDATION (result received)   | 2          | Prep=completed, Valid=completed, Publish=active  |
| PUBLISHING (click on Publish)  | 3          | All three = completed                            |



<img width="1164" height="2008" alt="Screenshot 2026-04-29 231004" src="https://github.com/user-attachments/assets/cdba86d8-d4c4-4171-9429-15c7412d37a8" />
<img width="1188" height="2003" alt="Screenshot 2026-04-29 231625" src="https://github.com/user-attachments/assets/897f1264-72a1-46f9-8d47-2ae941719755" />
<img width="634" height="642" alt="image" src="https://github.com/user-attachments/assets/8ae1dc33-0ede-4545-bdeb-80505f2438dd" />

