### PR TITLE
feat: [EL-2925] Mention Toolkit and Tool in Chat Without Active Participation

### DIFF
--- a/src/ComponentsLib/Chat/UserInput.jsx
+++ b/src/ComponentsLib/Chat/UserInput.jsx
@@ -2,7 +2,7 @@ import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, 
 
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
-import { Box, IconButton, TextField } from '@mui/material';
+import { Box, IconButton, TextField, Typography } from '@mui/material';
 
 import StyledCircleProgress from '@/ComponentsLib/CircularProgress';
 import Tooltip from '@/ComponentsLib/Tooltip';
@@ -18,6 +18,31 @@ import { useMentionDetection } from './useMentionDetection';
 const MAX_ROWS = 10;
 const MIN_ROWS = 2;
 const MIN_HEIGHT = 70;
+
+const HighlightedText = memo(({ text, ranges }) => {
+  if (!ranges?.length || !text) return null;
+  const styles = userInputStyles(false, false);
+  const children = [];
+  let lastIndex = 0;
+  for (const { start, end } of ranges) {
+    if (start > lastIndex) children.push(text.slice(lastIndex, start));
+    children.push(
+      <Typography
+        key={start}
+        component="span"
+        variant="labelMedium"
+        sx={styles.highlightSpan}
+      >
+        {text.slice(start, end)}
+      </Typography>,
+    );
+    lastIndex = end;
+  }
+  if (lastIndex < text.length) children.push(text.slice(lastIndex));
+  return children;
+});
+
+HighlightedText.displayName = 'HighlightedText';
 
 const UserInput = forwardRef((props, ref) => {
   const {
@@ -55,6 +80,7 @@ const UserInput = forwardRef((props, ref) => {
         placement: 'top',
       },
       footerContainer = {},
+      highlight = {},
     } = {},
     clearInputAfterSend = true,
     disabledSend,
@@ -62,6 +88,7 @@ const UserInput = forwardRef((props, ref) => {
     onSend,
     onStop,
     onNormalKeyDown,
+    onInputChange,
     tooltipOfSendButton,
     showLoading = false,
     isStreaming = false,
@@ -74,6 +101,7 @@ const UserInput = forwardRef((props, ref) => {
   } = props;
 
   const inputRef = useRef(null);
+  const mirrorRef = useRef(null);
 
   const [question, setQuestion] = useState('');
   const [inputContent, setInputContent] = useState('');
@@ -98,7 +126,22 @@ const UserInput = forwardRef((props, ref) => {
     handleDrop: handleDropFromHook,
   } = useFileDragAndDrop(originalOnDrop);
 
+  const { ranges: highlightRanges = [] } = highlight;
+  const hasHighlights = highlightRanges.length > 0 && !!inputContent;
+  // console.log('highlightRanges', highlightRanges, hasHighlights);
+
   const styles = userInputStyles(isFocused, isDragOver);
+
+  useEffect(() => {
+    const textarea = inputRef.current;
+    const mirror = mirrorRef.current;
+    if (!textarea || !mirror || !hasHighlights) return;
+    const sync = () => {
+      mirror.scrollTop = textarea.scrollTop;
+    };
+    textarea.addEventListener('scroll', sync);
+    return () => textarea.removeEventListener('scroll', sync);
+  }, [hasHighlights]);
 
   useEffect(() => {
     onMentionChange?.(mentions);
@@ -164,9 +207,22 @@ const UserInput = forwardRef((props, ref) => {
       setShowExpandIcon(false);
     },
     getInputContent: () => inputContent,
+    getCursorPosition: () => inputRef.current?.selectionStart ?? null,
     setValue: value => {
       setQuestion(value);
       setInputContent(value);
+    },
+    replaceRange: (start, end, text) => {
+      const newValue = inputContent.slice(0, start) + text + inputContent.slice(end);
+      setInputContent(newValue);
+      setQuestion(newValue.trim() ? newValue : '');
+      const newCursorPos = start + text.length;
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+          inputRef.current.focus();
+        }
+      }, 0);
     },
     removeSymbol: symbol => {
       const index = inputContent.lastIndexOf(symbol);
@@ -186,8 +242,10 @@ const UserInput = forwardRef((props, ref) => {
   }));
 
   const onInputQuestion = event => {
-    setInputContent(event.target.value);
-    setQuestion(event.target.value?.trim() ? event.target.value : '');
+    const value = event.target.value;
+    setInputContent(value);
+    setQuestion(value?.trim() ? value : '');
+    onInputChange?.(value);
     setTimeout(() => {
       setShowExpandIcon(event.target.offsetHeight > MIN_HEIGHT);
     }, 0);
@@ -270,6 +328,20 @@ const UserInput = forwardRef((props, ref) => {
             />
           )}
           <Box sx={styles.textFieldWrapper}>
+            {hasHighlights && (
+              <Typography
+                ref={mirrorRef}
+                aria-hidden="true"
+                component="div"
+                color="text.secondary"
+                sx={styles.mirrorDiv}
+              >
+                <HighlightedText
+                  text={inputContent}
+                  ranges={highlightRanges}
+                />
+              </Typography>
+            )}
             <TextField
               value={inputContent}
               fullWidth
@@ -293,7 +365,12 @@ const UserInput = forwardRef((props, ref) => {
               slotProps={{
                 input: {
                   inputRef,
-                  sx: styles.textFieldInput(input),
+                  sx: [
+                    styles.textFieldInput(input),
+                    hasHighlights && {
+                      '& textarea': { color: 'transparent', caretColor: input?.color ?? '#FFFFFF' },
+                    },
+                  ],
                   disableUnderline: true,
                   endAdornment: showExpandIcon ? (
                     <IconButton
@@ -419,14 +496,39 @@ const userInputStyles = (isFocused, isDragOver) => {
       flexDirection: 'column',
       alignItems: 'center',
       width: '100%',
+      position: 'relative',
+    },
+    mirrorDiv: {
+      position: 'absolute',
+      inset: 0,
+      overflow: 'auto',
+      pointerEvents: 'none',
+      zIndex: 0,
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+      padding: 0,
+      fontSize: '.875rem',
+      fontStyle: 'normal',
+      fontWeight: 500,
+      lineHeight: '1.5rem',
+      fontFamily: 'inherit',
+      '&::-webkit-scrollbar': { display: 'none' },
+      scrollbarWidth: 'none',
+      msOverflowStyle: 'none',
+    },
+    highlightSpan: {
+      color: ({ palette }) => palette.primary.main,
+      borderRadius: '.25rem',
     },
     textField: {
       padding: 0,
       flex: '1 0 0',
       fontSize: '.875rem',
       fontStyle: 'normal',
-      fontWeight: 400,
-      lineHeight: '1.375rem',
+      fontWeight: 500,
+      lineHeight: '1.5rem',
+      position: 'relative',
+      zIndex: 1,
       '&::-webkit-scrollbar': {
         display: 'none',
       },

--- a/src/ComponentsLib/Chat/UserInput.jsx
+++ b/src/ComponentsLib/Chat/UserInput.jsx
@@ -6,6 +6,7 @@ import { Box, IconButton, TextField, Typography } from '@mui/material';
 
 import StyledCircleProgress from '@/ComponentsLib/CircularProgress';
 import Tooltip from '@/ComponentsLib/Tooltip';
+import HighlightedText from '@/[fsd]/features/chat/ui/highlighted-text/HighlightedText';
 import { useFileDragAndDrop } from '@/[fsd]/shared/lib/hooks';
 import StopIcon from '@/assets/stop-icon.svg?react';
 import { generateRandomAppendix, renameFile } from '@/common/attachmentValidationUtils';
@@ -18,31 +19,6 @@ import { useMentionDetection } from './useMentionDetection';
 const MAX_ROWS = 10;
 const MIN_ROWS = 2;
 const MIN_HEIGHT = 70;
-
-const HighlightedText = memo(({ text, ranges }) => {
-  if (!ranges?.length || !text) return null;
-  const styles = userInputStyles(false, false);
-  const children = [];
-  let lastIndex = 0;
-  for (const { start, end } of ranges) {
-    if (start > lastIndex) children.push(text.slice(lastIndex, start));
-    children.push(
-      <Typography
-        key={start}
-        component="span"
-        variant="labelMedium"
-        sx={styles.highlightSpan}
-      >
-        {text.slice(start, end)}
-      </Typography>,
-    );
-    lastIndex = end;
-  }
-  if (lastIndex < text.length) children.push(text.slice(lastIndex));
-  return children;
-});
-
-HighlightedText.displayName = 'HighlightedText';
 
 const UserInput = forwardRef((props, ref) => {
   const {
@@ -515,10 +491,6 @@ const userInputStyles = (isFocused, isDragOver) => {
       '&::-webkit-scrollbar': { display: 'none' },
       scrollbarWidth: 'none',
       msOverflowStyle: 'none',
-    },
-    highlightSpan: {
-      color: ({ palette }) => palette.primary.main,
-      borderRadius: '.25rem',
     },
     textField: {
       padding: 0,

--- a/src/[fsd]/features/chat/lib/hooks/index.js
+++ b/src/[fsd]/features/chat/lib/hooks/index.js
@@ -5,3 +5,6 @@ export { useInternalToolsConfig } from './useInternalToolsConfig.hooks';
 export { useAttachmentToolChange } from './useAttachmentToolChange.hooks';
 export { useNewConversationAgentAttachment } from './useNewConversationAgentAttachment.hooks';
 export { useConversationStartersSync } from './useConversationStartersSync.hooks';
+export { useSlashCommandHandler } from './useSlashCommandHandler.hooks';
+export { useSlashHighlights } from './useSlashHighlights.hooks';
+export { useSlashMention } from './useSlashMention.hooks';

--- a/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
@@ -1,0 +1,541 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Manages "/" slash-mention state in the chat input.
+ *
+ * Phases:
+ *   'idle'    → no active slash mention
+ *   'toolkit' → user typed "/" and is filtering toolkits by name
+ *   'tool'    → user selected a toolkit and is optionally filtering its tools
+ *
+ * Design principle — single source of truth:
+ *   syncWithValue() parses the actual textarea text on every onChange.
+ *   onKeyDown() only handles two things that require immediate response before
+ *   the textarea value updates: '/' (to open the dropdown at once) and Escape.
+ *   No character accumulation is done in onKeyDown.
+ *
+ * committedMentions: [{toolkit_id, project_id, toolkit_name, toolkit_type, toolkit_settings, tool_name}]
+ * These are passed as mentioned_toolkits in the socket payload when the message is sent.
+ * Call clearMentions() after a successful send.
+ *
+ * mentionAnchorRef: character index in the full text where the currently-editing mention starts.
+ * Exposed so useSlashMention can perform correct text replacements even when
+ * the mention is in the middle of the input (multi-mention editing).
+ */
+
+const getCommitedMentions = (prevCommitedMentions, newMention) => {
+  const existingMention = prevCommitedMentions.find(
+    mention => mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id,
+  );
+  if (existingMention) {
+    return prevCommitedMentions.map(mention => {
+      if (mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id) {
+        return newMention;
+      }
+      return mention;
+    });
+  } else {
+    return [
+      ...prevCommitedMentions,
+      {
+        ...newMention,
+      },
+    ];
+  }
+};
+
+export const useSlashCommandHandler = ({ setInputContent }) => {
+  const [phase, setPhase] = useState('idle'); // 'idle' | 'toolkit' | 'tool'
+  // phaseRef mirrors phase so onKeyDown/syncWithValue always read the latest value
+  // without needing phase in their dependency arrays (avoids stale closures).
+  const phaseRef = useRef('idle');
+
+  const [toolkitQuery, setToolkitQuery] = useState('');
+  const [toolQuery, setToolQuery] = useState('');
+  const [selectedToolkit, setSelectedToolkit] = useState(null); // {id, project_id, name, type, settings}
+  const [committedMentions, setCommittedMentions] = useState([]);
+  const [isQueryFinal, setIsQueryFinal] = useState(false);
+
+  // When in toolkit phase and a second '/' is detected in the text (fullMatch),
+  // this stores the tool-query portion so selectToolkit can seed toolQuery correctly.
+  const pendingToolQueryRef = useRef('');
+
+  // Remembers the last selected toolkit for the regex fallback path in idle phase.
+  const lastToolkitRef = useRef(null);
+
+  // committedMentionsRef mirrors committedMentions so syncWithValue can always
+  // read the latest value without listing it in the dependency array.
+  const committedMentionsRef = useRef([]);
+
+  // Character index in the full text where the currently-editing mention starts (the '/').
+  // Set when first entering slash mode, cleared on resetSlash.
+  // Exposed to useSlashMention so text replacements always target the correct range,
+  // even when the mention is in the middle of the input.
+  const mentionAnchorRef = useRef(null);
+
+  const resetSlash = useCallback(() => {
+    phaseRef.current = 'idle';
+    setPhase('idle');
+    setToolkitQuery('');
+    setToolQuery('');
+    setSelectedToolkit(null);
+    setIsQueryFinal(false);
+    pendingToolQueryRef.current = '';
+    mentionAnchorRef.current = null;
+  }, []);
+
+  /**
+   * Handles keypresses that need an immediate reaction before the textarea value updates.
+   * - '/' in idle  → open toolkit dropdown right away (before onChange fires)
+   * - '/' in toolkit → mark isQueryFinal so the auto-select effect runs
+   * - Escape        → dismiss
+   * Everything else is handled by syncWithValue.
+   */
+  const onKeyDown = useCallback(
+    event => {
+      const { key } = event;
+      const currentPhase = phaseRef.current;
+
+      if (currentPhase === 'idle' && key === '/') {
+        phaseRef.current = 'toolkit';
+        setPhase('toolkit');
+        setToolkitQuery('');
+        setIsQueryFinal(false);
+        // mentionAnchorRef is set by syncWithValue on the subsequent onChange.
+        return;
+      }
+
+      if (currentPhase === 'toolkit' && key === '/') {
+        // User typed the separator slash — signal that the toolkit name is complete.
+        setIsQueryFinal(true);
+        return;
+      }
+
+      if (key === 'Escape' && currentPhase !== 'idle') {
+        resetSlash();
+      }
+    },
+    [resetSlash],
+  );
+
+  /**
+   * Sync hook state from the actual textarea value on every onChange.
+   * This is the authoritative state update path — handles typing, backspace,
+   * Delete, cut, and paste uniformly.
+   *
+   * @param {string} text      - current full input text
+   * @param {number} [cursorPos] - current cursor position (selectionStart after the change).
+   *   When provided, matching uses text.slice(0, cursorPos) so that editing an earlier
+   *   mention in the middle of the input is detected correctly.
+   *   When omitted, falls back to full-text matching (original behaviour).
+   *
+   * Regex patterns (matched at end of textToCursor):
+   *   fullMatch        → /toolkitName/toolQuery   (toolQuery may be empty)
+   *   toolkitOnlyMatch → /toolkitName             (no second slash yet)
+   *
+   * Note: both patterns also match a bare "/" (empty name/query), which intentionally
+   * keeps the dropdown visible immediately after the slash is typed.
+   */
+  const syncWithValue = useCallback(
+    (text, cursorPos) => {
+      const currentPhase = phaseRef.current;
+
+      // Use text up to the cursor for detection so that editing an earlier mention
+      // in the middle of the input doesn't get confused by later mentions.
+      const textToCursor = cursorPos != null ? text.slice(0, cursorPos) : text;
+
+      // /word/word2 or /word/ (toolQuery empty after second slash)
+      const fullMatch = textToCursor.match(/\/([^/\s]+)\/([^/\s]*)$/);
+      // /word (no second slash); also matches bare "/" (empty name)
+      const toolkitOnlyMatch = !fullMatch && textToCursor.match(/\/([^/\s]*)$/);
+
+      // ── idle ───────────────────────────────────────────────────────────────────
+      if (currentPhase === 'idle') {
+        // Fast-path: iterate over ALL committed mentions (not just the last one) using
+        // literal prefix matching so toolkit names with spaces are handled correctly.
+        // This lets the user edit any earlier mention, not only the most recent one.
+        for (const mention of committedMentionsRef.current) {
+          const fullPrefix = '/' + mention.toolkit_name + '/';
+          const prefixIdx = textToCursor.lastIndexOf(fullPrefix);
+
+          if (prefixIdx !== -1) {
+            const toolQueryPart = textToCursor.slice(prefixIdx + fullPrefix.length);
+            if (!/[\s/]/.test(toolQueryPart)) {
+              // Cursor is within /toolkitName/toolQuery — re-enter tool phase.
+              const toolkit = {
+                id: mention.toolkit_id,
+                project_id: mention.project_id,
+                name: mention.toolkit_name,
+                type: mention.toolkit_type,
+                settings: mention.toolkit_settings,
+              };
+              setCommittedMentions(prev => {
+                const next = prev.filter(
+                  m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+                );
+                committedMentionsRef.current = next;
+                return next;
+              });
+              setSelectedToolkit(toolkit);
+              lastToolkitRef.current = toolkit;
+              setToolkitQuery(mention.toolkit_name);
+              setToolQuery(toolQueryPart);
+              phaseRef.current = 'tool';
+              setPhase('tool');
+              setIsQueryFinal(false);
+              if (mentionAnchorRef.current === null) mentionAnchorRef.current = prefixIdx;
+              return;
+            }
+          }
+
+          // Check toolkit-name-only form (no separator yet).
+          const nameOnly = '/' + mention.toolkit_name;
+          const nameIdx = textToCursor.lastIndexOf(nameOnly);
+          if (nameIdx !== -1 && /^[^\s/]*$/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
+            // Cursor is within /toolkitName (no separator) — re-enter toolkit phase.
+            const toolkit = {
+              id: mention.toolkit_id,
+              project_id: mention.project_id,
+              name: mention.toolkit_name,
+              type: mention.toolkit_type,
+              settings: mention.toolkit_settings,
+            };
+            setCommittedMentions(prev => {
+              const next = prev.filter(
+                m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+              );
+              committedMentionsRef.current = next;
+              return next;
+            });
+            lastToolkitRef.current = toolkit;
+            setToolkitQuery(mention.toolkit_name);
+            phaseRef.current = 'toolkit';
+            setPhase('toolkit');
+            setIsQueryFinal(false);
+            if (mentionAnchorRef.current === null) mentionAnchorRef.current = nameIdx;
+            return;
+          }
+        }
+
+        // Regex-based detection: handles paste and backspace for no-space toolkit names.
+        if (fullMatch) {
+          const detectedName = fullMatch[1].toLowerCase();
+          // Check committed mentions first so re-editing an earlier mention goes directly
+          // to tool phase with the stored toolkit settings (no API round-trip needed).
+          const committedMatch = committedMentionsRef.current.find(
+            m => m.toolkit_name.toLowerCase() === detectedName,
+          );
+          if (committedMatch) {
+            const toolkit = {
+              id: committedMatch.toolkit_id,
+              project_id: committedMatch.project_id,
+              name: committedMatch.toolkit_name,
+              type: committedMatch.toolkit_type,
+              settings: committedMatch.toolkit_settings,
+            };
+            setCommittedMentions(prev => {
+              const next = prev.filter(
+                m =>
+                  !(m.toolkit_id === committedMatch.toolkit_id && m.project_id === committedMatch.project_id),
+              );
+              committedMentionsRef.current = next;
+              return next;
+            });
+            setSelectedToolkit(toolkit);
+            lastToolkitRef.current = toolkit;
+            setToolkitQuery(fullMatch[1]);
+            setToolQuery(fullMatch[2]);
+            phaseRef.current = 'tool';
+            setPhase('tool');
+            setIsQueryFinal(false);
+          } else if (lastToolkitRef.current && lastToolkitRef.current.name.toLowerCase() === detectedName) {
+            // Fallback to lastToolkitRef for the most-recent toolkit (handles paste/backspace).
+            setSelectedToolkit(lastToolkitRef.current);
+            setToolkitQuery(fullMatch[1]);
+            setToolQuery(fullMatch[2]);
+            phaseRef.current = 'tool';
+            setPhase('tool');
+            setIsQueryFinal(false);
+          } else {
+            // Unknown toolkit name — enter toolkit phase, auto-select will resolve it.
+            pendingToolQueryRef.current = fullMatch[2];
+            setToolkitQuery(fullMatch[1]);
+            phaseRef.current = 'toolkit';
+            setPhase('toolkit');
+            setIsQueryFinal(true);
+          }
+          if (mentionAnchorRef.current === null) {
+            mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - fullMatch[0].length;
+          }
+        } else if (toolkitOnlyMatch) {
+          // Backspace into a mention or paste of a partial mention (no-space toolkit names).
+          // onKeyDown handles the normal '/' keypress — this covers backspace/paste only.
+          setToolkitQuery(toolkitOnlyMatch[1]);
+          phaseRef.current = 'toolkit';
+          setPhase('toolkit');
+          setIsQueryFinal(false);
+          if (mentionAnchorRef.current === null) {
+            mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - toolkitOnlyMatch[0].length;
+          }
+        } else {
+          // Partial committed mention check for space-containing toolkit names.
+          // Handles backspacing into a committed mention when the full name is no longer
+          // present — the committed-mention loop above only handles exact name matches,
+          // and the regexes can't match names containing spaces.
+          const lastSlashIdx = textToCursor.lastIndexOf('/');
+          if (lastSlashIdx !== -1) {
+            const afterSlash = textToCursor.slice(lastSlashIdx + 1);
+            if (afterSlash.length > 0 && !afterSlash.endsWith(' ')) {
+              for (const mention of committedMentionsRef.current) {
+                if (mention.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase())) {
+                  const toolkit = {
+                    id: mention.toolkit_id,
+                    project_id: mention.project_id,
+                    name: mention.toolkit_name,
+                    type: mention.toolkit_type,
+                    settings: mention.toolkit_settings,
+                  };
+                  setCommittedMentions(prev => {
+                    const next = prev.filter(
+                      m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+                    );
+                    committedMentionsRef.current = next;
+                    return next;
+                  });
+                  lastToolkitRef.current = toolkit;
+                  setToolkitQuery(afterSlash);
+                  phaseRef.current = 'toolkit';
+                  setPhase('toolkit');
+                  setIsQueryFinal(false);
+                  if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+                  return;
+                }
+              }
+              // Fall back to lastToolkitRef when the committed mention was already removed
+              // (un-committed when first entering toolkit phase from an earlier backspace).
+              if (
+                lastToolkitRef.current &&
+                lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase())
+              ) {
+                setToolkitQuery(afterSlash);
+                phaseRef.current = 'toolkit';
+                setPhase('toolkit');
+                setIsQueryFinal(false);
+                if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+              }
+            }
+          }
+        }
+        return;
+      }
+
+      // ── toolkit ────────────────────────────────────────────────────────────────
+      if (currentPhase === 'toolkit') {
+        if (fullMatch) {
+          // Second slash appeared (typed or pasted) — toolkit name is final.
+          pendingToolQueryRef.current = fullMatch[2];
+          setToolkitQuery(fullMatch[1]);
+          setIsQueryFinal(true);
+        } else if (toolkitOnlyMatch) {
+          // Toolkit name is still being typed.
+          setToolkitQuery(toolkitOnlyMatch[1]);
+          setIsQueryFinal(false);
+        } else {
+          // Before dismissing, check if the partial text still prefixes a committed mention
+          // or the last selected toolkit (handles space-containing names the regex can't detect).
+          let kept = false;
+          if (mentionAnchorRef.current !== null) {
+            const fragment = textToCursor.slice(mentionAnchorRef.current);
+            if (fragment.startsWith('/') && fragment.length > 1) {
+              const afterSlash = fragment.slice(1);
+              if (!afterSlash.includes('/') && !afterSlash.endsWith(' ')) {
+                const partialCommit = committedMentionsRef.current.find(m =>
+                  m.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase()),
+                );
+                const partialLast =
+                  lastToolkitRef.current &&
+                  lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase());
+                if (partialCommit || partialLast) {
+                  setToolkitQuery(afterSlash);
+                  setIsQueryFinal(false);
+                  kept = true;
+                }
+              }
+            }
+          }
+          if (!kept) resetSlash();
+        }
+        // Set anchor on the first syncWithValue call in toolkit phase
+        // (covers fresh '/' pressed — onKeyDown enters toolkit but doesn't set anchor).
+        if (mentionAnchorRef.current === null && (fullMatch || toolkitOnlyMatch)) {
+          const match = fullMatch || toolkitOnlyMatch;
+          mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - match[0].length;
+        }
+        return;
+      }
+
+      // ── tool ───────────────────────────────────────────────────────────────────
+      if (currentPhase === 'tool') {
+        if (!selectedToolkit) {
+          resetSlash();
+          return;
+        }
+        // Use textToCursor so editing a mention in the middle of the input is tracked
+        // correctly — the tool query is the portion from the prefix end to the cursor.
+        const toolkitPrefix = '/' + selectedToolkit.name + '/';
+        const prefixIdx = textToCursor.lastIndexOf(toolkitPrefix);
+
+        if (prefixIdx !== -1) {
+          const toolQueryPart = textToCursor.slice(prefixIdx + toolkitPrefix.length);
+          // A space or extra '/' after the prefix means the mention is finished.
+          if (/[\s/]/.test(toolQueryPart)) {
+            resetSlash();
+          } else {
+            setToolQuery(toolQueryPart);
+          }
+        } else {
+          // Prefix not found — check if the separator '/' was just deleted.
+          const toolkitNameOnly = '/' + selectedToolkit.name;
+          const nameIdx = textToCursor.lastIndexOf(toolkitNameOnly);
+          const afterName = nameIdx !== -1 ? textToCursor.slice(nameIdx + toolkitNameOnly.length) : null;
+          if (afterName !== null && afterName.trim() === '') {
+            // Separator deleted — commit as toolkit-only mention (no specific tool).
+            setCommittedMentions(prev => {
+              const next = getCommitedMentions(prev, {
+                toolkit_id: selectedToolkit.id,
+                project_id: selectedToolkit.project_id,
+                toolkit_name: selectedToolkit.name,
+                toolkit_type: selectedToolkit.type,
+                toolkit_settings: selectedToolkit.settings,
+                tool_name: null,
+              });
+              committedMentionsRef.current = next;
+              return next;
+            });
+            resetSlash();
+          } else {
+            // Check if user is backspacing through a space-containing toolkit name.
+            // Use mentionAnchorRef for precise fragment detection.
+            let reEntered = false;
+            if (mentionAnchorRef.current !== null) {
+              const fragment = textToCursor.slice(mentionAnchorRef.current);
+              if (fragment.startsWith('/') && fragment.length > 1) {
+                const afterSlash = fragment.slice(1);
+                if (
+                  !afterSlash.includes('/') &&
+                  !afterSlash.endsWith(' ') &&
+                  selectedToolkit.name.toLowerCase().startsWith(afterSlash.toLowerCase())
+                ) {
+                  // Partial toolkit name — user is backspacing into it. Re-enter toolkit phase.
+                  setCommittedMentions(prev => {
+                    const next = prev.filter(
+                      m =>
+                        !(m.toolkit_id === selectedToolkit.id && m.project_id === selectedToolkit.project_id),
+                    );
+                    committedMentionsRef.current = next;
+                    return next;
+                  });
+                  setToolkitQuery(afterSlash);
+                  phaseRef.current = 'toolkit';
+                  setPhase('toolkit');
+                  setIsQueryFinal(false);
+                  reEntered = true;
+                }
+              }
+            }
+            if (!reEntered) resetSlash();
+          }
+        }
+      }
+    },
+    // selectedToolkit is only read when currentPhase === 'tool', which is safe.
+    // committedMentionsRef is a ref — no dep needed.
+    [resetSlash, selectedToolkit],
+  );
+
+  /**
+   * Called when the user selects a toolkit from the dropdown.
+   * Advances to 'tool' phase so the user can optionally narrow to a specific tool.
+   */
+  const selectToolkit = useCallback(toolkit => {
+    lastToolkitRef.current = toolkit;
+    setSelectedToolkit(toolkit);
+    phaseRef.current = 'tool';
+    setPhase('tool');
+    // Seed toolQuery from whatever was typed after the second '/' (may be '').
+    setToolQuery(pendingToolQueryRef.current);
+    pendingToolQueryRef.current = '';
+    setIsQueryFinal(false);
+    setCommittedMentions(prev => {
+      const next = getCommitedMentions(prev, {
+        toolkit_id: toolkit.id,
+        project_id: toolkit.project_id,
+        toolkit_name: toolkit.name,
+        toolkit_type: toolkit.type,
+        toolkit_settings: toolkit.settings,
+        tool_name: null,
+      });
+      committedMentionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  /**
+   * Commits the current mention.
+   * toolName: null  → mention the entire toolkit (LLM picks the tool)
+   * toolName: string → mention a specific tool
+   */
+  const commitMention = useCallback(
+    (toolName = null) => {
+      if (!selectedToolkit) return;
+
+      setCommittedMentions(prev => {
+        const next = getCommitedMentions(prev, {
+          toolkit_id: selectedToolkit.id,
+          project_id: selectedToolkit.project_id,
+          toolkit_name: selectedToolkit.name,
+          toolkit_type: selectedToolkit.type,
+          toolkit_settings: selectedToolkit.settings,
+          tool_name: toolName || null,
+        });
+        committedMentionsRef.current = next;
+        return next;
+      });
+      resetSlash();
+    },
+    [selectedToolkit, resetSlash],
+  );
+
+  /** Remove a specific mention by index (e.g., user clicks × on a chip). */
+  const removeMention = useCallback(index => {
+    setCommittedMentions(prev => {
+      const next = prev.filter((_, i) => i !== index);
+      committedMentionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  /** Call after a successful message send to clear the pending mentions. */
+  const clearMentions = useCallback(() => {
+    setCommittedMentions([]);
+    committedMentionsRef.current = [];
+    setInputContent?.('');
+  }, [setInputContent]);
+
+  return {
+    phase,
+    toolkitQuery,
+    toolQuery,
+    selectedToolkit,
+    committedMentions,
+    isQueryFinal,
+    onKeyDown,
+    syncWithValue,
+    selectToolkit,
+    commitMention,
+    removeMention,
+    clearMentions,
+    resetSlash,
+    mentionAnchorRef,
+  };
+};

--- a/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
@@ -23,27 +23,6 @@ import { useCallback, useRef, useState } from 'react';
  * the mention is in the middle of the input (multi-mention editing).
  */
 
-const getCommitedMentions = (prevCommitedMentions, newMention) => {
-  const existingMention = prevCommitedMentions.find(
-    mention => mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id,
-  );
-  if (existingMention) {
-    return prevCommitedMentions.map(mention => {
-      if (mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id) {
-        return newMention;
-      }
-      return mention;
-    });
-  } else {
-    return [
-      ...prevCommitedMentions,
-      {
-        ...newMention,
-      },
-    ];
-  }
-};
-
 export const useSlashCommandHandler = ({ setInputContent }) => {
   const [phase, setPhase] = useState('idle'); // 'idle' | 'toolkit' | 'tool'
   // phaseRef mirrors phase so onKeyDown/syncWithValue always read the latest value
@@ -72,6 +51,21 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
   // Exposed to useSlashMention so text replacements always target the correct range,
   // even when the mention is in the middle of the input.
   const mentionAnchorRef = useRef(null);
+
+  const getCommitedMentions = useCallback((prevCommitedMentions, newMention) => {
+    const existingMention = prevCommitedMentions.find(
+      mention => mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id,
+    );
+    if (existingMention) {
+      return prevCommitedMentions.map(mention => {
+        if (mention.toolkit_id === newMention.toolkit_id && mention.project_id === newMention.project_id) {
+          return newMention;
+        }
+        return mention;
+      });
+    }
+    return [...prevCommitedMentions, { ...newMention }];
+  }, []);
 
   const resetSlash = useCallback(() => {
     phaseRef.current = 'idle';
@@ -118,6 +112,316 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
     [resetSlash],
   );
 
+  // ── Idle phase ───────────────────────────────────────────────────────────────
+  //
+  // Three strategies to re-enter toolkit/tool phase from idle:
+  //   1. Committed-mention literal prefix loop (handles space-containing names)
+  //   2. Regex full match: /toolkitName/toolQuery
+  //   3. Regex toolkit-only match: /toolkitName
+  //   4. lastSlashIdx fallback (space-containing names partially backspaced)
+  const syncIdlePhase = useCallback((textToCursor, cursorPos, fullMatch, toolkitOnlyMatch) => {
+    // Fast-path: iterate over ALL committed mentions using literal prefix matching
+    // so toolkit names with spaces are handled correctly.
+    // This lets the user edit any earlier mention, not only the most recent one.
+    for (const mention of committedMentionsRef.current) {
+      const fullPrefix = '/' + mention.toolkit_name + '/';
+      const prefixIdx = textToCursor.lastIndexOf(fullPrefix);
+
+      if (prefixIdx !== -1) {
+        const toolQueryPart = textToCursor.slice(prefixIdx + fullPrefix.length);
+        if (!/[\s/]/.test(toolQueryPart)) {
+          // Cursor is within /toolkitName/toolQuery — re-enter tool phase.
+          const toolkit = {
+            id: mention.toolkit_id,
+            project_id: mention.project_id,
+            name: mention.toolkit_name,
+            type: mention.toolkit_type,
+            settings: mention.toolkit_settings,
+          };
+          setCommittedMentions(prev => {
+            const next = prev.filter(
+              m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+            );
+            committedMentionsRef.current = next;
+            return next;
+          });
+          setSelectedToolkit(toolkit);
+          lastToolkitRef.current = toolkit;
+          setToolkitQuery(mention.toolkit_name);
+          setToolQuery(toolQueryPart);
+          phaseRef.current = 'tool';
+          setPhase('tool');
+          setIsQueryFinal(false);
+          if (mentionAnchorRef.current === null) mentionAnchorRef.current = prefixIdx;
+          return;
+        }
+      }
+
+      // Check toolkit-name-only form (no separator yet).
+      const nameOnly = '/' + mention.toolkit_name;
+      const nameIdx = textToCursor.lastIndexOf(nameOnly);
+      if (nameIdx !== -1 && /^[^\s/]*$/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
+        // Cursor is within /toolkitName (no separator) — re-enter toolkit phase.
+        const toolkit = {
+          id: mention.toolkit_id,
+          project_id: mention.project_id,
+          name: mention.toolkit_name,
+          type: mention.toolkit_type,
+          settings: mention.toolkit_settings,
+        };
+        setCommittedMentions(prev => {
+          const next = prev.filter(
+            m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+          );
+          committedMentionsRef.current = next;
+          return next;
+        });
+        lastToolkitRef.current = toolkit;
+        setToolkitQuery(mention.toolkit_name);
+        phaseRef.current = 'toolkit';
+        setPhase('toolkit');
+        setIsQueryFinal(false);
+        if (mentionAnchorRef.current === null) mentionAnchorRef.current = nameIdx;
+        return;
+      }
+    }
+
+    // Regex-based detection: handles paste and backspace for no-space toolkit names.
+    if (fullMatch) {
+      const detectedName = fullMatch[1].toLowerCase();
+      // Check committed mentions first so re-editing an earlier mention goes directly
+      // to tool phase with the stored toolkit settings (no API round-trip needed).
+      const committedMatch = committedMentionsRef.current.find(
+        m => m.toolkit_name.toLowerCase() === detectedName,
+      );
+      if (committedMatch) {
+        const toolkit = {
+          id: committedMatch.toolkit_id,
+          project_id: committedMatch.project_id,
+          name: committedMatch.toolkit_name,
+          type: committedMatch.toolkit_type,
+          settings: committedMatch.toolkit_settings,
+        };
+        setCommittedMentions(prev => {
+          const next = prev.filter(
+            m => !(m.toolkit_id === committedMatch.toolkit_id && m.project_id === committedMatch.project_id),
+          );
+          committedMentionsRef.current = next;
+          return next;
+        });
+        setSelectedToolkit(toolkit);
+        lastToolkitRef.current = toolkit;
+        setToolkitQuery(fullMatch[1]);
+        setToolQuery(fullMatch[2]);
+        phaseRef.current = 'tool';
+        setPhase('tool');
+        setIsQueryFinal(false);
+      } else if (lastToolkitRef.current && lastToolkitRef.current.name.toLowerCase() === detectedName) {
+        // Fallback to lastToolkitRef for the most-recent toolkit (handles paste/backspace).
+        setSelectedToolkit(lastToolkitRef.current);
+        setToolkitQuery(fullMatch[1]);
+        setToolQuery(fullMatch[2]);
+        phaseRef.current = 'tool';
+        setPhase('tool');
+        setIsQueryFinal(false);
+      } else {
+        // Unknown toolkit name — enter toolkit phase, auto-select will resolve it.
+        pendingToolQueryRef.current = fullMatch[2];
+        setToolkitQuery(fullMatch[1]);
+        phaseRef.current = 'toolkit';
+        setPhase('toolkit');
+        setIsQueryFinal(true);
+      }
+      if (mentionAnchorRef.current === null) {
+        mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - fullMatch[0].length;
+      }
+    } else if (toolkitOnlyMatch) {
+      // Backspace into a mention or paste of a partial mention (no-space toolkit names).
+      // onKeyDown handles the normal '/' keypress — this covers backspace/paste only.
+      setToolkitQuery(toolkitOnlyMatch[1]);
+      phaseRef.current = 'toolkit';
+      setPhase('toolkit');
+      setIsQueryFinal(false);
+      if (mentionAnchorRef.current === null) {
+        mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - toolkitOnlyMatch[0].length;
+      }
+    } else {
+      // Partial committed mention check for space-containing toolkit names.
+      // Handles backspacing into a committed mention when the full name is no longer
+      // present — the committed-mention loop above only handles exact name matches,
+      // and the regexes can't match names containing spaces.
+      const lastSlashIdx = textToCursor.lastIndexOf('/');
+      if (lastSlashIdx !== -1) {
+        const afterSlash = textToCursor.slice(lastSlashIdx + 1);
+        if (afterSlash.length > 0 && !afterSlash.endsWith(' ')) {
+          for (const mention of committedMentionsRef.current) {
+            if (mention.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase())) {
+              const toolkit = {
+                id: mention.toolkit_id,
+                project_id: mention.project_id,
+                name: mention.toolkit_name,
+                type: mention.toolkit_type,
+                settings: mention.toolkit_settings,
+              };
+              setCommittedMentions(prev => {
+                const next = prev.filter(
+                  m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
+                );
+                committedMentionsRef.current = next;
+                return next;
+              });
+              lastToolkitRef.current = toolkit;
+              setToolkitQuery(afterSlash);
+              phaseRef.current = 'toolkit';
+              setPhase('toolkit');
+              setIsQueryFinal(false);
+              if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+              return;
+            }
+          }
+          // Fall back to lastToolkitRef when the committed mention was already removed
+          // (un-committed when first entering toolkit phase from an earlier backspace).
+          if (
+            lastToolkitRef.current &&
+            lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase())
+          ) {
+            setToolkitQuery(afterSlash);
+            phaseRef.current = 'toolkit';
+            setPhase('toolkit');
+            setIsQueryFinal(false);
+            if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+          }
+        }
+      }
+    }
+  }, []);
+
+  // ── Toolkit phase ────────────────────────────────────────────────────────────
+  const syncToolkitPhase = useCallback(
+    (textToCursor, cursorPos, fullMatch, toolkitOnlyMatch) => {
+      if (fullMatch) {
+        // Second slash appeared (typed or pasted) — toolkit name is final.
+        pendingToolQueryRef.current = fullMatch[2];
+        setToolkitQuery(fullMatch[1]);
+        setIsQueryFinal(true);
+      } else if (toolkitOnlyMatch) {
+        // Toolkit name is still being typed.
+        setToolkitQuery(toolkitOnlyMatch[1]);
+        setIsQueryFinal(false);
+      } else {
+        // Before dismissing, check if the partial text still prefixes a committed mention
+        // or the last selected toolkit (handles space-containing names the regex can't detect).
+        let kept = false;
+        if (mentionAnchorRef.current !== null) {
+          const fragment = textToCursor.slice(mentionAnchorRef.current);
+          if (fragment.startsWith('/') && fragment.length > 1) {
+            const afterSlash = fragment.slice(1);
+            if (!afterSlash.includes('/') && !afterSlash.endsWith(' ')) {
+              const partialCommit = committedMentionsRef.current.find(m =>
+                m.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase()),
+              );
+              const partialLast =
+                lastToolkitRef.current &&
+                lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase());
+              if (partialCommit || partialLast) {
+                setToolkitQuery(afterSlash);
+                setIsQueryFinal(false);
+                kept = true;
+              }
+            }
+          }
+        }
+        if (!kept) resetSlash();
+      }
+      // Set anchor on the first syncWithValue call in toolkit phase
+      // (covers fresh '/' pressed — onKeyDown enters toolkit but doesn't set anchor).
+      if (mentionAnchorRef.current === null && (fullMatch || toolkitOnlyMatch)) {
+        const match = fullMatch || toolkitOnlyMatch;
+        mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - match[0].length;
+      }
+    },
+    [resetSlash],
+  );
+
+  // ── Tool phase ───────────────────────────────────────────────────────────────
+  const syncToolPhase = useCallback(
+    textToCursor => {
+      if (!selectedToolkit) {
+        resetSlash();
+        return;
+      }
+      // Use textToCursor so editing a mention in the middle of the input is tracked
+      // correctly — the tool query is the portion from the prefix end to the cursor.
+      const toolkitPrefix = '/' + selectedToolkit.name + '/';
+      const prefixIdx = textToCursor.lastIndexOf(toolkitPrefix);
+
+      if (prefixIdx !== -1) {
+        const toolQueryPart = textToCursor.slice(prefixIdx + toolkitPrefix.length);
+        // A space or extra '/' after the prefix means the mention is finished.
+        if (/[\s/]/.test(toolQueryPart)) {
+          resetSlash();
+        } else {
+          setToolQuery(toolQueryPart);
+        }
+        return;
+      }
+
+      // Prefix not found — check if the separator '/' was just deleted.
+      const toolkitNameOnly = '/' + selectedToolkit.name;
+      const nameIdx = textToCursor.lastIndexOf(toolkitNameOnly);
+      const afterName = nameIdx !== -1 ? textToCursor.slice(nameIdx + toolkitNameOnly.length) : null;
+
+      if (afterName !== null && afterName.trim() === '') {
+        // Separator deleted — commit as toolkit-only mention (no specific tool).
+        setCommittedMentions(prev => {
+          const next = getCommitedMentions(prev, {
+            toolkit_id: selectedToolkit.id,
+            project_id: selectedToolkit.project_id,
+            toolkit_name: selectedToolkit.name,
+            toolkit_type: selectedToolkit.type,
+            toolkit_settings: selectedToolkit.settings,
+            tool_name: null,
+          });
+          committedMentionsRef.current = next;
+          return next;
+        });
+        resetSlash();
+        return;
+      }
+
+      // Check if user is backspacing through a space-containing toolkit name.
+      // Use mentionAnchorRef for precise fragment detection.
+      let reEntered = false;
+      if (mentionAnchorRef.current !== null) {
+        const fragment = textToCursor.slice(mentionAnchorRef.current);
+        if (fragment.startsWith('/') && fragment.length > 1) {
+          const afterSlash = fragment.slice(1);
+          if (
+            !afterSlash.includes('/') &&
+            !afterSlash.endsWith(' ') &&
+            selectedToolkit.name.toLowerCase().startsWith(afterSlash.toLowerCase())
+          ) {
+            // Partial toolkit name — user is backspacing into it. Re-enter toolkit phase.
+            setCommittedMentions(prev => {
+              const next = prev.filter(
+                m => !(m.toolkit_id === selectedToolkit.id && m.project_id === selectedToolkit.project_id),
+              );
+              committedMentionsRef.current = next;
+              return next;
+            });
+            setToolkitQuery(afterSlash);
+            phaseRef.current = 'toolkit';
+            setPhase('toolkit');
+            setIsQueryFinal(false);
+            reEntered = true;
+          }
+        }
+      }
+      if (!reEntered) resetSlash();
+    },
+    [resetSlash, selectedToolkit, getCommitedMentions],
+  );
+
   /**
    * Sync hook state from the actual textarea value on every onChange.
    * This is the authoritative state update path — handles typing, backspace,
@@ -149,336 +453,43 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
       // /word (no second slash); also matches bare "/" (empty name)
       const toolkitOnlyMatch = !fullMatch && textToCursor.match(/\/([^/\s]*)$/);
 
-      // ── idle ───────────────────────────────────────────────────────────────────
-      if (currentPhase === 'idle') {
-        // Fast-path: iterate over ALL committed mentions (not just the last one) using
-        // literal prefix matching so toolkit names with spaces are handled correctly.
-        // This lets the user edit any earlier mention, not only the most recent one.
-        for (const mention of committedMentionsRef.current) {
-          const fullPrefix = '/' + mention.toolkit_name + '/';
-          const prefixIdx = textToCursor.lastIndexOf(fullPrefix);
-
-          if (prefixIdx !== -1) {
-            const toolQueryPart = textToCursor.slice(prefixIdx + fullPrefix.length);
-            if (!/[\s/]/.test(toolQueryPart)) {
-              // Cursor is within /toolkitName/toolQuery — re-enter tool phase.
-              const toolkit = {
-                id: mention.toolkit_id,
-                project_id: mention.project_id,
-                name: mention.toolkit_name,
-                type: mention.toolkit_type,
-                settings: mention.toolkit_settings,
-              };
-              setCommittedMentions(prev => {
-                const next = prev.filter(
-                  m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-                );
-                committedMentionsRef.current = next;
-                return next;
-              });
-              setSelectedToolkit(toolkit);
-              lastToolkitRef.current = toolkit;
-              setToolkitQuery(mention.toolkit_name);
-              setToolQuery(toolQueryPart);
-              phaseRef.current = 'tool';
-              setPhase('tool');
-              setIsQueryFinal(false);
-              if (mentionAnchorRef.current === null) mentionAnchorRef.current = prefixIdx;
-              return;
-            }
-          }
-
-          // Check toolkit-name-only form (no separator yet).
-          const nameOnly = '/' + mention.toolkit_name;
-          const nameIdx = textToCursor.lastIndexOf(nameOnly);
-          if (nameIdx !== -1 && /^[^\s/]*$/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
-            // Cursor is within /toolkitName (no separator) — re-enter toolkit phase.
-            const toolkit = {
-              id: mention.toolkit_id,
-              project_id: mention.project_id,
-              name: mention.toolkit_name,
-              type: mention.toolkit_type,
-              settings: mention.toolkit_settings,
-            };
-            setCommittedMentions(prev => {
-              const next = prev.filter(
-                m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-              );
-              committedMentionsRef.current = next;
-              return next;
-            });
-            lastToolkitRef.current = toolkit;
-            setToolkitQuery(mention.toolkit_name);
-            phaseRef.current = 'toolkit';
-            setPhase('toolkit');
-            setIsQueryFinal(false);
-            if (mentionAnchorRef.current === null) mentionAnchorRef.current = nameIdx;
-            return;
-          }
-        }
-
-        // Regex-based detection: handles paste and backspace for no-space toolkit names.
-        if (fullMatch) {
-          const detectedName = fullMatch[1].toLowerCase();
-          // Check committed mentions first so re-editing an earlier mention goes directly
-          // to tool phase with the stored toolkit settings (no API round-trip needed).
-          const committedMatch = committedMentionsRef.current.find(
-            m => m.toolkit_name.toLowerCase() === detectedName,
-          );
-          if (committedMatch) {
-            const toolkit = {
-              id: committedMatch.toolkit_id,
-              project_id: committedMatch.project_id,
-              name: committedMatch.toolkit_name,
-              type: committedMatch.toolkit_type,
-              settings: committedMatch.toolkit_settings,
-            };
-            setCommittedMentions(prev => {
-              const next = prev.filter(
-                m =>
-                  !(m.toolkit_id === committedMatch.toolkit_id && m.project_id === committedMatch.project_id),
-              );
-              committedMentionsRef.current = next;
-              return next;
-            });
-            setSelectedToolkit(toolkit);
-            lastToolkitRef.current = toolkit;
-            setToolkitQuery(fullMatch[1]);
-            setToolQuery(fullMatch[2]);
-            phaseRef.current = 'tool';
-            setPhase('tool');
-            setIsQueryFinal(false);
-          } else if (lastToolkitRef.current && lastToolkitRef.current.name.toLowerCase() === detectedName) {
-            // Fallback to lastToolkitRef for the most-recent toolkit (handles paste/backspace).
-            setSelectedToolkit(lastToolkitRef.current);
-            setToolkitQuery(fullMatch[1]);
-            setToolQuery(fullMatch[2]);
-            phaseRef.current = 'tool';
-            setPhase('tool');
-            setIsQueryFinal(false);
-          } else {
-            // Unknown toolkit name — enter toolkit phase, auto-select will resolve it.
-            pendingToolQueryRef.current = fullMatch[2];
-            setToolkitQuery(fullMatch[1]);
-            phaseRef.current = 'toolkit';
-            setPhase('toolkit');
-            setIsQueryFinal(true);
-          }
-          if (mentionAnchorRef.current === null) {
-            mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - fullMatch[0].length;
-          }
-        } else if (toolkitOnlyMatch) {
-          // Backspace into a mention or paste of a partial mention (no-space toolkit names).
-          // onKeyDown handles the normal '/' keypress — this covers backspace/paste only.
-          setToolkitQuery(toolkitOnlyMatch[1]);
-          phaseRef.current = 'toolkit';
-          setPhase('toolkit');
-          setIsQueryFinal(false);
-          if (mentionAnchorRef.current === null) {
-            mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - toolkitOnlyMatch[0].length;
-          }
-        } else {
-          // Partial committed mention check for space-containing toolkit names.
-          // Handles backspacing into a committed mention when the full name is no longer
-          // present — the committed-mention loop above only handles exact name matches,
-          // and the regexes can't match names containing spaces.
-          const lastSlashIdx = textToCursor.lastIndexOf('/');
-          if (lastSlashIdx !== -1) {
-            const afterSlash = textToCursor.slice(lastSlashIdx + 1);
-            if (afterSlash.length > 0 && !afterSlash.endsWith(' ')) {
-              for (const mention of committedMentionsRef.current) {
-                if (mention.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase())) {
-                  const toolkit = {
-                    id: mention.toolkit_id,
-                    project_id: mention.project_id,
-                    name: mention.toolkit_name,
-                    type: mention.toolkit_type,
-                    settings: mention.toolkit_settings,
-                  };
-                  setCommittedMentions(prev => {
-                    const next = prev.filter(
-                      m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-                    );
-                    committedMentionsRef.current = next;
-                    return next;
-                  });
-                  lastToolkitRef.current = toolkit;
-                  setToolkitQuery(afterSlash);
-                  phaseRef.current = 'toolkit';
-                  setPhase('toolkit');
-                  setIsQueryFinal(false);
-                  if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
-                  return;
-                }
-              }
-              // Fall back to lastToolkitRef when the committed mention was already removed
-              // (un-committed when first entering toolkit phase from an earlier backspace).
-              if (
-                lastToolkitRef.current &&
-                lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase())
-              ) {
-                setToolkitQuery(afterSlash);
-                phaseRef.current = 'toolkit';
-                setPhase('toolkit');
-                setIsQueryFinal(false);
-                if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
-              }
-            }
-          }
-        }
-        return;
-      }
-
-      // ── toolkit ────────────────────────────────────────────────────────────────
-      if (currentPhase === 'toolkit') {
-        if (fullMatch) {
-          // Second slash appeared (typed or pasted) — toolkit name is final.
-          pendingToolQueryRef.current = fullMatch[2];
-          setToolkitQuery(fullMatch[1]);
-          setIsQueryFinal(true);
-        } else if (toolkitOnlyMatch) {
-          // Toolkit name is still being typed.
-          setToolkitQuery(toolkitOnlyMatch[1]);
-          setIsQueryFinal(false);
-        } else {
-          // Before dismissing, check if the partial text still prefixes a committed mention
-          // or the last selected toolkit (handles space-containing names the regex can't detect).
-          let kept = false;
-          if (mentionAnchorRef.current !== null) {
-            const fragment = textToCursor.slice(mentionAnchorRef.current);
-            if (fragment.startsWith('/') && fragment.length > 1) {
-              const afterSlash = fragment.slice(1);
-              if (!afterSlash.includes('/') && !afterSlash.endsWith(' ')) {
-                const partialCommit = committedMentionsRef.current.find(m =>
-                  m.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase()),
-                );
-                const partialLast =
-                  lastToolkitRef.current &&
-                  lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase());
-                if (partialCommit || partialLast) {
-                  setToolkitQuery(afterSlash);
-                  setIsQueryFinal(false);
-                  kept = true;
-                }
-              }
-            }
-          }
-          if (!kept) resetSlash();
-        }
-        // Set anchor on the first syncWithValue call in toolkit phase
-        // (covers fresh '/' pressed — onKeyDown enters toolkit but doesn't set anchor).
-        if (mentionAnchorRef.current === null && (fullMatch || toolkitOnlyMatch)) {
-          const match = fullMatch || toolkitOnlyMatch;
-          mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - match[0].length;
-        }
-        return;
-      }
-
-      // ── tool ───────────────────────────────────────────────────────────────────
-      if (currentPhase === 'tool') {
-        if (!selectedToolkit) {
-          resetSlash();
-          return;
-        }
-        // Use textToCursor so editing a mention in the middle of the input is tracked
-        // correctly — the tool query is the portion from the prefix end to the cursor.
-        const toolkitPrefix = '/' + selectedToolkit.name + '/';
-        const prefixIdx = textToCursor.lastIndexOf(toolkitPrefix);
-
-        if (prefixIdx !== -1) {
-          const toolQueryPart = textToCursor.slice(prefixIdx + toolkitPrefix.length);
-          // A space or extra '/' after the prefix means the mention is finished.
-          if (/[\s/]/.test(toolQueryPart)) {
-            resetSlash();
-          } else {
-            setToolQuery(toolQueryPart);
-          }
-        } else {
-          // Prefix not found — check if the separator '/' was just deleted.
-          const toolkitNameOnly = '/' + selectedToolkit.name;
-          const nameIdx = textToCursor.lastIndexOf(toolkitNameOnly);
-          const afterName = nameIdx !== -1 ? textToCursor.slice(nameIdx + toolkitNameOnly.length) : null;
-          if (afterName !== null && afterName.trim() === '') {
-            // Separator deleted — commit as toolkit-only mention (no specific tool).
-            setCommittedMentions(prev => {
-              const next = getCommitedMentions(prev, {
-                toolkit_id: selectedToolkit.id,
-                project_id: selectedToolkit.project_id,
-                toolkit_name: selectedToolkit.name,
-                toolkit_type: selectedToolkit.type,
-                toolkit_settings: selectedToolkit.settings,
-                tool_name: null,
-              });
-              committedMentionsRef.current = next;
-              return next;
-            });
-            resetSlash();
-          } else {
-            // Check if user is backspacing through a space-containing toolkit name.
-            // Use mentionAnchorRef for precise fragment detection.
-            let reEntered = false;
-            if (mentionAnchorRef.current !== null) {
-              const fragment = textToCursor.slice(mentionAnchorRef.current);
-              if (fragment.startsWith('/') && fragment.length > 1) {
-                const afterSlash = fragment.slice(1);
-                if (
-                  !afterSlash.includes('/') &&
-                  !afterSlash.endsWith(' ') &&
-                  selectedToolkit.name.toLowerCase().startsWith(afterSlash.toLowerCase())
-                ) {
-                  // Partial toolkit name — user is backspacing into it. Re-enter toolkit phase.
-                  setCommittedMentions(prev => {
-                    const next = prev.filter(
-                      m =>
-                        !(m.toolkit_id === selectedToolkit.id && m.project_id === selectedToolkit.project_id),
-                    );
-                    committedMentionsRef.current = next;
-                    return next;
-                  });
-                  setToolkitQuery(afterSlash);
-                  phaseRef.current = 'toolkit';
-                  setPhase('toolkit');
-                  setIsQueryFinal(false);
-                  reEntered = true;
-                }
-              }
-            }
-            if (!reEntered) resetSlash();
-          }
-        }
-      }
+      if (currentPhase === 'idle') return syncIdlePhase(textToCursor, cursorPos, fullMatch, toolkitOnlyMatch);
+      if (currentPhase === 'toolkit')
+        return syncToolkitPhase(textToCursor, cursorPos, fullMatch, toolkitOnlyMatch);
+      if (currentPhase === 'tool') return syncToolPhase(textToCursor);
     },
-    // selectedToolkit is only read when currentPhase === 'tool', which is safe.
-    // committedMentionsRef is a ref — no dep needed.
-    [resetSlash, selectedToolkit],
+    [syncIdlePhase, syncToolkitPhase, syncToolPhase],
   );
 
   /**
    * Called when the user selects a toolkit from the dropdown.
    * Advances to 'tool' phase so the user can optionally narrow to a specific tool.
    */
-  const selectToolkit = useCallback(toolkit => {
-    lastToolkitRef.current = toolkit;
-    setSelectedToolkit(toolkit);
-    phaseRef.current = 'tool';
-    setPhase('tool');
-    // Seed toolQuery from whatever was typed after the second '/' (may be '').
-    setToolQuery(pendingToolQueryRef.current);
-    pendingToolQueryRef.current = '';
-    setIsQueryFinal(false);
-    setCommittedMentions(prev => {
-      const next = getCommitedMentions(prev, {
-        toolkit_id: toolkit.id,
-        project_id: toolkit.project_id,
-        toolkit_name: toolkit.name,
-        toolkit_type: toolkit.type,
-        toolkit_settings: toolkit.settings,
-        tool_name: null,
+  const selectToolkit = useCallback(
+    toolkit => {
+      lastToolkitRef.current = toolkit;
+      setSelectedToolkit(toolkit);
+      phaseRef.current = 'tool';
+      setPhase('tool');
+      // Seed toolQuery from whatever was typed after the second '/' (may be '').
+      setToolQuery(pendingToolQueryRef.current);
+      pendingToolQueryRef.current = '';
+      setIsQueryFinal(false);
+      setCommittedMentions(prev => {
+        const next = getCommitedMentions(prev, {
+          toolkit_id: toolkit.id,
+          project_id: toolkit.project_id,
+          toolkit_name: toolkit.name,
+          toolkit_type: toolkit.type,
+          toolkit_settings: toolkit.settings,
+          tool_name: null,
+        });
+        committedMentionsRef.current = next;
+        return next;
       });
-      committedMentionsRef.current = next;
-      return next;
-    });
-  }, []);
+    },
+    [getCommitedMentions],
+  );
 
   /**
    * Commits the current mention.
@@ -503,7 +514,7 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
       });
       resetSlash();
     },
-    [selectedToolkit, resetSlash],
+    [selectedToolkit, resetSlash, getCommitedMentions],
   );
 
   /** Remove a specific mention by index (e.g., user clicks × on a chip). */

--- a/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js
@@ -1,5 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
 
+/** Pure utility: convert a committed mention entry to a toolkit object. */
+const toolkitFromMention = mention => ({
+  id: mention.toolkit_id,
+  project_id: mention.project_id,
+  name: mention.toolkit_name,
+  type: mention.toolkit_type,
+  settings: mention.toolkit_settings,
+});
+
 /**
  * Manages "/" slash-mention state in the chat input.
  *
@@ -112,103 +121,82 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
     [resetSlash],
   );
 
-  // ── Idle phase ───────────────────────────────────────────────────────────────
-  //
-  // Three strategies to re-enter toolkit/tool phase from idle:
-  //   1. Committed-mention literal prefix loop (handles space-containing names)
-  //   2. Regex full match: /toolkitName/toolQuery
-  //   3. Regex toolkit-only match: /toolkitName
-  //   4. lastSlashIdx fallback (space-containing names partially backspaced)
-  const syncIdlePhase = useCallback((textToCursor, cursorPos, fullMatch, toolkitOnlyMatch) => {
-    // Fast-path: iterate over ALL committed mentions using literal prefix matching
-    // so toolkit names with spaces are handled correctly.
-    // This lets the user edit any earlier mention, not only the most recent one.
-    for (const mention of committedMentionsRef.current) {
+  // ── Idle phase helpers ───────────────────────────────────────────────────────
+
+  /** Remove a mention from state+ref by toolkit identity. */
+  const uncommitMention = useCallback((toolkitId, projectId) => {
+    setCommittedMentions(prev => {
+      const next = prev.filter(m => !(m.toolkit_id === toolkitId && m.project_id === projectId));
+      committedMentionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  /**
+   * Handles /toolkitName/toolQuery — re-enters tool phase from a committed mention.
+   * Returns true if it handled the case.
+   */
+  const tryReEnterToolPhaseFromMention = useCallback(
+    (textToCursor, mention) => {
       const fullPrefix = '/' + mention.toolkit_name + '/';
       const prefixIdx = textToCursor.lastIndexOf(fullPrefix);
+      if (prefixIdx === -1) return false;
 
-      if (prefixIdx !== -1) {
-        const toolQueryPart = textToCursor.slice(prefixIdx + fullPrefix.length);
-        if (!/[\s/]/.test(toolQueryPart)) {
-          // Cursor is within /toolkitName/toolQuery — re-enter tool phase.
-          const toolkit = {
-            id: mention.toolkit_id,
-            project_id: mention.project_id,
-            name: mention.toolkit_name,
-            type: mention.toolkit_type,
-            settings: mention.toolkit_settings,
-          };
-          setCommittedMentions(prev => {
-            const next = prev.filter(
-              m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-            );
-            committedMentionsRef.current = next;
-            return next;
-          });
-          setSelectedToolkit(toolkit);
-          lastToolkitRef.current = toolkit;
-          setToolkitQuery(mention.toolkit_name);
-          setToolQuery(toolQueryPart);
-          phaseRef.current = 'tool';
-          setPhase('tool');
-          setIsQueryFinal(false);
-          if (mentionAnchorRef.current === null) mentionAnchorRef.current = prefixIdx;
-          return;
-        }
-      }
+      const toolQueryPart = textToCursor.slice(prefixIdx + fullPrefix.length);
+      if (/[\s/]/.test(toolQueryPart)) return false;
 
-      // Check toolkit-name-only form (no separator yet).
+      const toolkit = toolkitFromMention(mention);
+      uncommitMention(mention.toolkit_id, mention.project_id);
+      setSelectedToolkit(toolkit);
+      lastToolkitRef.current = toolkit;
+      setToolkitQuery(mention.toolkit_name);
+      setToolQuery(toolQueryPart);
+      phaseRef.current = 'tool';
+      setPhase('tool');
+      setIsQueryFinal(false);
+      if (mentionAnchorRef.current === null) mentionAnchorRef.current = prefixIdx;
+      return true;
+    },
+    [uncommitMention],
+  );
+
+  /**
+   * Handles /toolkitName (no separator) — re-enters toolkit phase from a committed mention.
+   * Returns true if it handled the case.
+   */
+  const tryReEnterToolkitPhaseFromMention = useCallback(
+    (textToCursor, mention) => {
       const nameOnly = '/' + mention.toolkit_name;
       const nameIdx = textToCursor.lastIndexOf(nameOnly);
-      if (nameIdx !== -1 && /^[^\s/]*$/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
-        // Cursor is within /toolkitName (no separator) — re-enter toolkit phase.
-        const toolkit = {
-          id: mention.toolkit_id,
-          project_id: mention.project_id,
-          name: mention.toolkit_name,
-          type: mention.toolkit_type,
-          settings: mention.toolkit_settings,
-        };
-        setCommittedMentions(prev => {
-          const next = prev.filter(
-            m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-          );
-          committedMentionsRef.current = next;
-          return next;
-        });
-        lastToolkitRef.current = toolkit;
-        setToolkitQuery(mention.toolkit_name);
-        phaseRef.current = 'toolkit';
-        setPhase('toolkit');
-        setIsQueryFinal(false);
-        if (mentionAnchorRef.current === null) mentionAnchorRef.current = nameIdx;
-        return;
-      }
-    }
+      if (nameIdx === -1) return false;
+      if (!/^[^\s/]*$/.test(textToCursor.slice(nameIdx + nameOnly.length))) return false;
 
-    // Regex-based detection: handles paste and backspace for no-space toolkit names.
-    if (fullMatch) {
+      uncommitMention(mention.toolkit_id, mention.project_id);
+      lastToolkitRef.current = toolkitFromMention(mention);
+      setToolkitQuery(mention.toolkit_name);
+      phaseRef.current = 'toolkit';
+      setPhase('toolkit');
+      setIsQueryFinal(false);
+      if (mentionAnchorRef.current === null) mentionAnchorRef.current = nameIdx;
+      return true;
+    },
+    [uncommitMention],
+  );
+
+  /**
+   * Handles the regex full-match path (/toolkitName/toolQuery) when no committed
+   * mention loop matched. Resolves via committed mention, lastToolkitRef, or unknown.
+   */
+  const syncIdleHandleFullMatch = useCallback(
+    (textToCursor, cursorPos, fullMatch) => {
       const detectedName = fullMatch[1].toLowerCase();
-      // Check committed mentions first so re-editing an earlier mention goes directly
-      // to tool phase with the stored toolkit settings (no API round-trip needed).
       const committedMatch = committedMentionsRef.current.find(
         m => m.toolkit_name.toLowerCase() === detectedName,
       );
+
       if (committedMatch) {
-        const toolkit = {
-          id: committedMatch.toolkit_id,
-          project_id: committedMatch.project_id,
-          name: committedMatch.toolkit_name,
-          type: committedMatch.toolkit_type,
-          settings: committedMatch.toolkit_settings,
-        };
-        setCommittedMentions(prev => {
-          const next = prev.filter(
-            m => !(m.toolkit_id === committedMatch.toolkit_id && m.project_id === committedMatch.project_id),
-          );
-          committedMentionsRef.current = next;
-          return next;
-        });
+        const toolkit = toolkitFromMention(committedMatch);
+        uncommitMention(committedMatch.toolkit_id, committedMatch.project_id);
         setSelectedToolkit(toolkit);
         lastToolkitRef.current = toolkit;
         setToolkitQuery(fullMatch[1]);
@@ -217,7 +205,7 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
         setPhase('tool');
         setIsQueryFinal(false);
       } else if (lastToolkitRef.current && lastToolkitRef.current.name.toLowerCase() === detectedName) {
-        // Fallback to lastToolkitRef for the most-recent toolkit (handles paste/backspace).
+        // Fallback to lastToolkitRef (handles paste/backspace for most-recent toolkit).
         setSelectedToolkit(lastToolkitRef.current);
         setToolkitQuery(fullMatch[1]);
         setToolQuery(fullMatch[2]);
@@ -225,76 +213,101 @@ export const useSlashCommandHandler = ({ setInputContent }) => {
         setPhase('tool');
         setIsQueryFinal(false);
       } else {
-        // Unknown toolkit name — enter toolkit phase, auto-select will resolve it.
+        // Unknown toolkit name — enter toolkit phase; auto-select will resolve it.
         pendingToolQueryRef.current = fullMatch[2];
         setToolkitQuery(fullMatch[1]);
         phaseRef.current = 'toolkit';
         setPhase('toolkit');
         setIsQueryFinal(true);
       }
+
       if (mentionAnchorRef.current === null) {
         mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - fullMatch[0].length;
       }
-    } else if (toolkitOnlyMatch) {
-      // Backspace into a mention or paste of a partial mention (no-space toolkit names).
-      // onKeyDown handles the normal '/' keypress — this covers backspace/paste only.
-      setToolkitQuery(toolkitOnlyMatch[1]);
-      phaseRef.current = 'toolkit';
-      setPhase('toolkit');
-      setIsQueryFinal(false);
-      if (mentionAnchorRef.current === null) {
-        mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - toolkitOnlyMatch[0].length;
-      }
-    } else {
-      // Partial committed mention check for space-containing toolkit names.
-      // Handles backspacing into a committed mention when the full name is no longer
-      // present — the committed-mention loop above only handles exact name matches,
-      // and the regexes can't match names containing spaces.
-      const lastSlashIdx = textToCursor.lastIndexOf('/');
-      if (lastSlashIdx !== -1) {
-        const afterSlash = textToCursor.slice(lastSlashIdx + 1);
-        if (afterSlash.length > 0 && !afterSlash.endsWith(' ')) {
-          for (const mention of committedMentionsRef.current) {
-            if (mention.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase())) {
-              const toolkit = {
-                id: mention.toolkit_id,
-                project_id: mention.project_id,
-                name: mention.toolkit_name,
-                type: mention.toolkit_type,
-                settings: mention.toolkit_settings,
-              };
-              setCommittedMentions(prev => {
-                const next = prev.filter(
-                  m => !(m.toolkit_id === mention.toolkit_id && m.project_id === mention.project_id),
-                );
-                committedMentionsRef.current = next;
-                return next;
-              });
-              lastToolkitRef.current = toolkit;
-              setToolkitQuery(afterSlash);
-              phaseRef.current = 'toolkit';
-              setPhase('toolkit');
-              setIsQueryFinal(false);
-              if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
-              return;
-            }
-          }
-          // Fall back to lastToolkitRef when the committed mention was already removed
-          // (un-committed when first entering toolkit phase from an earlier backspace).
-          if (
-            lastToolkitRef.current &&
-            lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase())
-          ) {
-            setToolkitQuery(afterSlash);
-            phaseRef.current = 'toolkit';
-            setPhase('toolkit');
-            setIsQueryFinal(false);
-            if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
-          }
-        }
-      }
+    },
+    [uncommitMention],
+  );
+
+  /**
+   * Handles the regex toolkit-only match (/toolkitName, no separator).
+   * Covers backspace/paste; normal '/' keypress is handled in onKeyDown.
+   */
+  const syncIdleHandleToolkitOnlyMatch = useCallback((textToCursor, cursorPos, toolkitOnlyMatch) => {
+    setToolkitQuery(toolkitOnlyMatch[1]);
+    phaseRef.current = 'toolkit';
+    setPhase('toolkit');
+    setIsQueryFinal(false);
+    if (mentionAnchorRef.current === null) {
+      mentionAnchorRef.current = (cursorPos ?? textToCursor.length) - toolkitOnlyMatch[0].length;
     }
   }, []);
+
+  /**
+   * Last-resort fallback for space-containing toolkit names being partially backspaced.
+   * Uses the position of the last '/' to find a matching committed mention or lastToolkitRef.
+   */
+  const syncIdleHandleLastSlashFallback = useCallback(
+    textToCursor => {
+      const lastSlashIdx = textToCursor.lastIndexOf('/');
+      if (lastSlashIdx === -1) return;
+
+      const afterSlash = textToCursor.slice(lastSlashIdx + 1);
+      if (afterSlash.length === 0 || afterSlash.endsWith(' ')) return;
+
+      for (const mention of committedMentionsRef.current) {
+        if (mention.toolkit_name.toLowerCase().startsWith(afterSlash.toLowerCase())) {
+          uncommitMention(mention.toolkit_id, mention.project_id);
+          lastToolkitRef.current = toolkitFromMention(mention);
+          setToolkitQuery(afterSlash);
+          phaseRef.current = 'toolkit';
+          setPhase('toolkit');
+          setIsQueryFinal(false);
+          if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+          return;
+        }
+      }
+
+      // Committed mention already removed — fall back to lastToolkitRef.
+      if (
+        lastToolkitRef.current &&
+        lastToolkitRef.current.name.toLowerCase().startsWith(afterSlash.toLowerCase())
+      ) {
+        setToolkitQuery(afterSlash);
+        phaseRef.current = 'toolkit';
+        setPhase('toolkit');
+        setIsQueryFinal(false);
+        if (mentionAnchorRef.current === null) mentionAnchorRef.current = lastSlashIdx;
+      }
+    },
+    [uncommitMention],
+  );
+
+  // ── Idle phase ───────────────────────────────────────────────────────────────
+  //
+  // Four strategies to re-enter toolkit/tool phase from idle:
+  //   1. Committed-mention literal prefix loop (handles space-containing names)
+  //   2. Regex full match: /toolkitName/toolQuery
+  //   3. Regex toolkit-only match: /toolkitName
+  //   4. lastSlashIdx fallback (space-containing names partially backspaced)
+  const syncIdlePhase = useCallback(
+    (textToCursor, cursorPos, fullMatch, toolkitOnlyMatch) => {
+      for (const mention of committedMentionsRef.current) {
+        if (tryReEnterToolPhaseFromMention(textToCursor, mention)) return;
+        if (tryReEnterToolkitPhaseFromMention(textToCursor, mention)) return;
+      }
+
+      if (fullMatch) return syncIdleHandleFullMatch(textToCursor, cursorPos, fullMatch);
+      if (toolkitOnlyMatch) return syncIdleHandleToolkitOnlyMatch(textToCursor, cursorPos, toolkitOnlyMatch);
+      syncIdleHandleLastSlashFallback(textToCursor);
+    },
+    [
+      tryReEnterToolPhaseFromMention,
+      tryReEnterToolkitPhaseFromMention,
+      syncIdleHandleFullMatch,
+      syncIdleHandleToolkitOnlyMatch,
+      syncIdleHandleLastSlashFallback,
+    ],
+  );
 
   // ── Toolkit phase ────────────────────────────────────────────────────────────
   const syncToolkitPhase = useCallback(

--- a/src/[fsd]/features/chat/lib/hooks/useSlashHighlights.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashHighlights.hooks.js
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+/**
+ * Computes highlight ranges for committed slash mentions within the current input text.
+ *
+ * Returns an array of {start, end} character positions (sorted, non-overlapping)
+ * for every committed mention token found in the input.
+ *
+ * Longer tokens are checked first so that `/toolkit/tool` shadows `/toolkit`
+ * when both appear at the same position.
+ *
+ * @param {string} inputContent - current text in the chat input
+ * @param {Array}  committedMentions - from useSlashCommandHandler; each entry
+ *                 must have { toolkit_name, tool_name }
+ * @returns {Array<{start: number, end: number}>}
+ */
+export const useSlashHighlights = (inputContent, committedMentions) =>
+  useMemo(() => {
+    if (!committedMentions?.length || !inputContent) return [];
+
+    // Build unique token strings; sort longest-first to prevent sub-match shadowing.
+    const tokens = [
+      ...new Set(
+        committedMentions.map(m =>
+          m.tool_name ? `/${m.toolkit_name}/${m.tool_name}` : `/${m.toolkit_name}`,
+        ),
+      ),
+    ].sort((a, b) => b.length - a.length);
+
+    const ranges = [];
+
+    for (const token of tokens) {
+      let idx = inputContent.indexOf(token);
+      while (idx !== -1) {
+        const end = idx + token.length;
+        // Skip if this range overlaps any already-recorded range.
+        if (!ranges.some(r => idx < r.end && end > r.start)) {
+          ranges.push({ start: idx, end });
+        }
+        idx = inputContent.indexOf(token, idx + 1);
+      }
+    }
+
+    return ranges.sort((a, b) => a.start - b.start);
+  }, [inputContent, committedMentions]);

--- a/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
@@ -68,11 +68,11 @@ export const useSlashMention = ({ chatInput, activeConversation }) => {
         // toolkit name and tool query, e.g. "/name|/toolQuery").
         const hasSeparatorAtCursor = !hasSeparatorInFragment && content[cursorPos] === '/';
         const hasSeparator = hasSeparatorInFragment || hasSeparatorAtCursor;
-        const replaceEnd = hasSeparatorInFragment
-          ? anchor + separatorIdx + 1
-          : hasSeparatorAtCursor
-            ? cursorPos + 1
-            : cursorPos;
+
+        let replaceEnd = cursorPos;
+        if (hasSeparatorInFragment) replaceEnd = anchor + separatorIdx + 1;
+        else if (hasSeparatorAtCursor) replaceEnd = cursorPos + 1;
+
         const replacement = hasSeparator ? '/' + toolkit.name + '/' : '/' + toolkit.name;
         chatInput.current.replaceRange(anchor, replaceEnd, replacement);
         // replaceRange bypasses onChange, so sync local inputContent manually so that

--- a/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { ChatParticipantType } from '@/common/constants';
+
+import { useSlashCommandHandler } from './useSlashCommandHandler.hooks';
+import { useSlashHighlights } from './useSlashHighlights.hooks';
+
+/**
+ * Higher-level hook that combines slash-mention state management with
+ * chat-input text manipulation. Shared by NewConversationView and ChatBox.
+ *
+ * @param {object} params
+ * @param {React.RefObject} params.chatInput - ref to the chat input component
+ * @param {object|null}     params.activeConversation - current conversation object
+ */
+export const useSlashMention = ({ chatInput, activeConversation }) => {
+  // Track a copy of the current input text so highlight ranges can be computed
+  // without reading the DOM imperative ref on every render.
+  const [inputContent, setInputContent] = useState('');
+
+  const {
+    phase: slashPhase,
+    toolkitQuery: slashToolkitQuery,
+    toolQuery: slashToolQuery,
+    selectedToolkit: slashSelectedToolkit,
+    committedMentions,
+    isQueryFinal: slashIsQueryFinal,
+    onKeyDown: slashOnKeyDown,
+    syncWithValue: slashSyncWithValue,
+    selectToolkit: slashSelectToolkit,
+    commitMention: slashCommitMention,
+    clearMentions,
+    resetSlash,
+    mentionAnchorRef,
+  } = useSlashCommandHandler({ setInputContent });
+
+  // IDs of toolkit participants in the current conversation, used by SlashSuggestionList
+  // to filter the autosuggest to only those already added (AC1).
+  const participantToolkitIds = useMemo(
+    () =>
+      (activeConversation?.participants || [])
+        .filter(p => p.entity_name === ChatParticipantType.Toolkits)
+        .map(p => ({ id: p.entity_meta.id, project_id: p.entity_meta.project_id })),
+    [activeConversation?.participants],
+  );
+
+  // Replace the typed "/query" or "/query/" fragment with "/toolkit.name" in the input.
+  // Uses mentionAnchorRef so that editing an earlier mention in the middle of the text
+  // replaces only the correct fragment (not the last mention in the string).
+  const onSlashSelectToolkit = useCallback(
+    toolkit => {
+      if (chatInput.current) {
+        const content = chatInput.current.getInputContent();
+        const anchor = mentionAnchorRef.current ?? content.length;
+        // Use cursor position as the fragment end instead of whitespace search.
+        // Whitespace search breaks for toolkit names that contain spaces — it stops
+        // at the first space inside the name rather than at the end of the typed fragment.
+        const cursorPos = chatInput.current.getCursorPosition() ?? content.length;
+        // Fragment is text from anchor up to (but not including) the cursor.
+        const afterAnchor = content.slice(anchor, cursorPos);
+        // When the fragment already contains the separator '/' (e.g. "/typedname/"),
+        // include it in both the replaced range and the replacement so that:
+        //   • the separator is preserved in the text, and
+        //   • replaceRange places the cursor AFTER the separator (not before it).
+        const separatorIdx = afterAnchor.indexOf('/', 1); // skip the leading '/'
+        const hasSeparatorInFragment = separatorIdx !== -1;
+        // Also check if the separator sits immediately at the cursor (cursor between
+        // toolkit name and tool query, e.g. "/name|/toolQuery").
+        const hasSeparatorAtCursor = !hasSeparatorInFragment && content[cursorPos] === '/';
+        const hasSeparator = hasSeparatorInFragment || hasSeparatorAtCursor;
+        const replaceEnd = hasSeparatorInFragment
+          ? anchor + separatorIdx + 1
+          : hasSeparatorAtCursor
+            ? cursorPos + 1
+            : cursorPos;
+        const replacement = hasSeparator ? '/' + toolkit.name + '/' : '/' + toolkit.name;
+        chatInput.current.replaceRange(anchor, replaceEnd, replacement);
+        // replaceRange bypasses onChange, so sync local inputContent manually so that
+        // useSlashHighlights can compute highlight ranges without waiting for a keystroke.
+        setInputContent(content.slice(0, anchor) + replacement + content.slice(replaceEnd));
+      }
+      slashSelectToolkit(toolkit);
+    },
+    // mentionAnchorRef is a ref — stable, no dep needed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [slashSelectToolkit],
+  );
+
+  // Replace the "/toolkit[/toolQuery]" fragment with the final mention token.
+  // Uses mentionAnchorRef for precise bounds so that committing an earlier mention
+  // never overwrites text that follows it. Handles both null and non-null toolName.
+  const onSlashCommitMention = useCallback(
+    toolName => {
+      if (chatInput.current && slashSelectedToolkit) {
+        const content = chatInput.current.getInputContent();
+        const anchor = mentionAnchorRef.current ?? 0;
+        // Locate mention end using the toolkit name directly so that toolkit names
+        // containing spaces are handled correctly (whitespace search would truncate early).
+        const toolkitPrefix = '/' + slashSelectedToolkit.name + '/';
+        let mentionEnd;
+        if (content.startsWith(toolkitPrefix, anchor)) {
+          // /toolkitName/ is present — advance past the separator then skip the tool query.
+          const afterPrefix = content.slice(anchor + toolkitPrefix.length);
+          const endIdx = afterPrefix.search(/[\s/]/);
+          mentionEnd = anchor + toolkitPrefix.length + (endIdx === -1 ? afterPrefix.length : endIdx);
+        } else {
+          // No separator yet — mention ends right after the toolkit name.
+          mentionEnd = anchor + ('/' + slashSelectedToolkit.name).length;
+        }
+        const mentionToken = toolName
+          ? `/${slashSelectedToolkit.name}/${toolName}`
+          : `/${slashSelectedToolkit.name}`;
+        const replacement = mentionToken + ' ';
+        chatInput.current.replaceRange(anchor, mentionEnd, replacement);
+        // replaceRange bypasses onChange; sync local inputContent so the highlight
+        // mirror stays aligned immediately (before the next keystroke fires onChange).
+        setInputContent(content.slice(0, anchor) + replacement + content.slice(mentionEnd));
+      }
+      slashCommitMention(toolName);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [slashCommitMention, slashSelectedToolkit],
+  );
+
+  const onSlashInputChange = useCallback(
+    value => {
+      setInputContent(value);
+      if (!value) {
+        clearMentions();
+        resetSlash();
+        return;
+      }
+      const cursorPos = chatInput.current?.getCursorPosition() ?? null;
+      slashSyncWithValue(value, cursorPos);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [slashSyncWithValue, clearMentions, resetSlash],
+  );
+
+  // Character ranges within inputContent that correspond to committed mention tokens.
+  // Passed to UserInput so it can render the backdrop highlight.
+
+  const slashHighlightRanges = useSlashHighlights(inputContent, committedMentions);
+
+  return {
+    slashPhase,
+    slashToolkitQuery,
+    slashToolQuery,
+    slashSelectedToolkit,
+    committedMentions,
+    slashIsQueryFinal,
+    slashOnKeyDown,
+    participantToolkitIds,
+    resetSlash,
+    clearMentions,
+    onSlashSelectToolkit,
+    onSlashCommitMention,
+    onSlashInputChange,
+    slashHighlightRanges,
+  };
+};

--- a/src/[fsd]/features/chat/ui/highlighted-text/HighlightedText.jsx
+++ b/src/[fsd]/features/chat/ui/highlighted-text/HighlightedText.jsx
@@ -1,0 +1,44 @@
+import { memo } from 'react';
+
+import { Typography } from '@mui/material';
+
+/** @type {MuiSx} */
+const getStyles = () => ({
+  highlightText: {
+    color: ({ palette }) => palette.primary.main,
+    borderRadius: '.25rem',
+  },
+});
+
+const HighlightedText = memo(props => {
+  const { text, ranges } = props;
+  const styles = getStyles();
+
+  if (!ranges?.length || !text) return null;
+
+  const children = [];
+  let lastIndex = 0;
+
+  for (const { start, end } of ranges) {
+    if (start > lastIndex) children.push(text.slice(lastIndex, start));
+    children.push(
+      <Typography
+        key={start}
+        component="span"
+        variant="labelMedium"
+        sx={styles.highlightText}
+      >
+        {text.slice(start, end)}
+      </Typography>,
+    );
+    lastIndex = end;
+  }
+
+  if (lastIndex < text.length) children.push(text.slice(lastIndex));
+
+  return children;
+});
+
+HighlightedText.displayName = 'HighlightedText';
+
+export default HighlightedText;

--- a/src/[fsd]/features/chat/ui/index.js
+++ b/src/[fsd]/features/chat/ui/index.js
@@ -3,3 +3,4 @@ export * as ChatModal from './chat-modal';
 export * as ChatAttachment from './chat-attachment';
 export { ChatContinue } from './chat-continue';
 export { ChatHitlActions } from './chat-hitl-actions';
+export { SlashSuggestionList } from './slash-suggestion-list';

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
@@ -2,28 +2,15 @@ import { memo, useEffect, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { Box, ClickAwayListener, Typography } from '@mui/material';
-
 import { ChatParticipantType, PAGE_SIZE } from '@/common/constants';
-import useValidateToolkit from '@/hooks/application/useValidateToolkit';
 import useParticipants from '@/hooks/chat/useParticipants';
 import NewParticipantList from '@/pages/NewChat/Recommendations/NewParticipantList';
 
-/**
- * Renders nothing but triggers validation for one toolkit.
- * Skips the API call when validation data already exists in Redux so we
- * don't re-validate on every render; RTK Query handles caching for the rest.
- */
-const ToolkitValidator = memo(({ toolkitId, projectId }) => {
-  const selectorKey = `${projectId}_${toolkitId}`;
-  const hasValidationData = useSelector(state => selectorKey in state.chat.toolkitValidationInfo);
-  useValidateToolkit({ toolkitId, projectId, forceSkip: hasValidationData });
-  return null;
-});
-ToolkitValidator.displayName = 'ToolkitValidator';
+import ToolList from './ToolList';
+import ToolkitValidator from './ToolkitValidator';
 
-const SlashSuggestionList = memo(
-  ({
+const SlashSuggestionList = memo(props => {
+  const {
     phase,
     toolkitQuery,
     toolQuery,
@@ -33,234 +20,123 @@ const SlashSuggestionList = memo(
     onSelectTool,
     onClose,
     participantToolkitIds,
-  }) => {
-    const toolkitValidationInfo = useSelector(state => state.chat.toolkitValidationInfo);
+  } = props;
 
-    const { participants, isLoading, isFetching, onLoadMore, total } = useParticipants({
-      sortBy: 'name',
-      sortOrder: 'asc',
-      pageSize: PAGE_SIZE,
-      query: toolkitQuery,
-      types: [ChatParticipantType.Toolkits],
-      projectFilter: 'all',
-      forceSkip: phase !== 'toolkit',
+  const toolkitValidationInfo = useSelector(state => state.chat.toolkitValidationInfo);
+
+  const { participants, isLoading, isFetching, onLoadMore, total } = useParticipants({
+    sortBy: 'name',
+    sortOrder: 'asc',
+    pageSize: PAGE_SIZE,
+    query: toolkitQuery,
+    types: [ChatParticipantType.Toolkits],
+    projectFilter: 'all',
+    forceSkip: phase !== 'toolkit',
+  });
+
+  // Only show toolkits that are added as conversation participants (AC1)
+  // and are properly configured (AC2).
+  // Name filtering is done client-side for instant response (no debounce lag).
+  const filteredParticipants = useMemo(() => {
+    if (!participantToolkitIds?.length) return [];
+    const idKeys = new Set(participantToolkitIds.map(p => `${p.project_id}_${p.id}`));
+    return participants.filter(p => {
+      const key = `${p.project_id}_${p.id}`;
+      if (!idKeys.has(key)) return false;
+      const validationInfo = toolkitValidationInfo?.[key];
+      if (validationInfo?.length) return false;
+      if (toolkitQuery && !p.name.toLowerCase().includes(toolkitQuery.toLowerCase())) return false;
+      return true;
     });
+  }, [participants, participantToolkitIds, toolkitValidationInfo, toolkitQuery]);
 
-    // Only show toolkits that are added as conversation participants (AC1)
-    // and are properly configured (AC2).
-    // Name filtering is done client-side for instant response (no debounce lag).
-    const filteredParticipants = useMemo(() => {
-      if (!participantToolkitIds?.length) return [];
-      const idKeys = new Set(participantToolkitIds.map(p => `${p.project_id}_${p.id}`));
-      return participants.filter(p => {
-        const key = `${p.project_id}_${p.id}`;
-        if (!idKeys.has(key)) return false;
-        const validationInfo = toolkitValidationInfo?.[key];
-        if (validationInfo?.length) return false;
-        if (toolkitQuery && !p.name.toLowerCase().includes(toolkitQuery.toLowerCase())) return false;
-        return true;
-      });
-    }, [participants, participantToolkitIds, toolkitValidationInfo, toolkitQuery]);
-
-    const availableTools = useMemo(() => {
-      if (!selectedToolkit?.settings) return [];
-      const isMcp = selectedToolkit.type === 'mcp' || selectedToolkit.type?.startsWith('mcp_');
-      if (isMcp) {
-        return (selectedToolkit.settings.available_mcp_tools || []).map(item => ({
-          name: item.value || item.label,
-          description: item.description || '',
-        }));
-      }
-      return (selectedToolkit.settings.selected_tools || []).map(name => ({ name, description: '' }));
-    }, [selectedToolkit]);
-
-    const filteredTools = useMemo(
-      () =>
-        availableTools.filter(
-          tool => !toolQuery || tool.name.toLowerCase().includes(toolQuery.toLowerCase()),
-        ),
-      [availableTools, toolQuery],
-    );
-
-    useEffect(() => {
-      if (phase !== 'toolkit' || !isQueryFinal || isFetching) return;
-
-      const match = filteredParticipants.find(p =>
-        p.name.toLowerCase().startsWith(toolkitQuery.toLowerCase()),
-      );
-      if (match && (match.project_id !== selectedToolkit?.project_id || match.id !== selectedToolkit?.id)) {
-        onSelectToolkit({
-          id: match.id,
-          project_id: match.project_id,
-          name: match.name,
-          type: match.type,
-          settings: match.settings,
-        });
-      } else {
-        onClose();
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [phase, isQueryFinal, isFetching, toolkitQuery, filteredParticipants]);
-
-    // Render one validator per participant toolkit. Each mounts when the slash menu
-    // opens and fires the validation API only when no data exists yet in Redux.
-    const validators = participantToolkitIds?.map(({ id, project_id }) => (
-      <ToolkitValidator
-        key={`${project_id}_${id}`}
-        toolkitId={id}
-        projectId={project_id}
-      />
-    ));
-
-    if (phase === 'idle') return null;
-
-    if (phase === 'toolkit') {
-      return (
-        <>
-          {validators}
-          <NewParticipantList
-            onSelectParticipant={participant =>
-              onSelectToolkit({
-                id: participant.id,
-                project_id: participant.project_id,
-                name: participant.name,
-                type: participant.type,
-                settings: participant.settings,
-              })
-            }
-            isLoading={isLoading}
-            isFetching={isFetching}
-            participants={filteredParticipants}
-            existingParticipantUids={[]}
-            onClose={onClose}
-            onLoadMore={onLoadMore}
-            total={total}
-            title="Mention toolkit"
-          />
-        </>
-      );
+  const availableTools = useMemo(() => {
+    if (!selectedToolkit?.settings) return [];
+    const isMcp = selectedToolkit.type === 'mcp' || selectedToolkit.type?.startsWith('mcp_');
+    if (isMcp) {
+      return (selectedToolkit.settings.available_mcp_tools || []).map(item => ({
+        name: item.value || item.label,
+        description: item.description || '',
+      }));
     }
+    return (selectedToolkit.settings.selected_tools || []).map(name => ({ name, description: '' }));
+  }, [selectedToolkit]);
 
-    // phase === 'tool' — hide the list entirely when the filter matches nothing
-    if (toolQuery && filteredTools.length === 0) return null;
+  const filteredTools = useMemo(
+    () =>
+      availableTools.filter(tool => !toolQuery || tool.name.toLowerCase().includes(toolQuery.toLowerCase())),
+    [availableTools, toolQuery],
+  );
+
+  useEffect(() => {
+    if (phase !== 'toolkit' || !isQueryFinal || isFetching) return;
+
+    const match = filteredParticipants.find(p => p.name.toLowerCase().startsWith(toolkitQuery.toLowerCase()));
+    if (match && (match.project_id !== selectedToolkit?.project_id || match.id !== selectedToolkit?.id)) {
+      onSelectToolkit({
+        id: match.id,
+        project_id: match.project_id,
+        name: match.name,
+        type: match.type,
+        settings: match.settings,
+      });
+    } else {
+      onClose();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, isQueryFinal, isFetching, toolkitQuery, filteredParticipants]);
+
+  // Render one validator per participant toolkit. Each mounts when the slash menu
+  // opens and fires the validation API only when no data exists yet in Redux.
+  const validators = participantToolkitIds?.map(({ id, project_id }) => (
+    <ToolkitValidator
+      key={`${project_id}_${id}`}
+      toolkitId={id}
+      projectId={project_id}
+    />
+  ));
+
+  if (phase === 'idle') return null;
+
+  if (phase === 'toolkit') {
     return (
-      <ToolList
-        tools={filteredTools}
-        toolkitName={selectedToolkit?.name}
-        onSelectTool={onSelectTool}
-      />
+      <>
+        {validators}
+        <NewParticipantList
+          onSelectParticipant={participant =>
+            onSelectToolkit({
+              id: participant.id,
+              project_id: participant.project_id,
+              name: participant.name,
+              type: participant.type,
+              settings: participant.settings,
+            })
+          }
+          isLoading={isLoading}
+          isFetching={isFetching}
+          participants={filteredParticipants}
+          existingParticipantUids={[]}
+          onClose={onClose}
+          onLoadMore={onLoadMore}
+          total={total}
+          title="Mention toolkit"
+        />
+      </>
     );
-  },
-);
+  }
+
+  // phase === 'tool' — hide the list entirely when the filter matches nothing
+  if (toolQuery && filteredTools.length === 0) return null;
+
+  return (
+    <ToolList
+      tools={filteredTools}
+      toolkitName={selectedToolkit?.name}
+      onSelectTool={onSelectTool}
+    />
+  );
+});
 
 SlashSuggestionList.displayName = 'SlashSuggestionList';
 
 export default SlashSuggestionList;
-
-const ToolList = memo(({ tools, toolkitName, onSelectTool }) => {
-  const content = (
-    <Box sx={toolListStyles.container}>
-      <Box sx={toolListStyles.header}>
-        <Typography
-          variant="subtitle"
-          color="text.primary"
-        >
-          {toolkitName} available tools
-        </Typography>
-      </Box>
-
-      {tools.map(tool => (
-        <ToolItem
-          key={tool.name}
-          label={tool.name}
-          description={tool.description}
-          onClick={() => onSelectTool(tool.name)}
-        />
-      ))}
-    </Box>
-  );
-  return <ClickAwayListener onClickAway={() => onSelectTool(null)}>{content}</ClickAwayListener>;
-});
-
-ToolList.displayName = 'ToolList';
-
-const ToolItem = memo(({ label, description, onClick }) => {
-  return (
-    <Box
-      onClick={onClick}
-      sx={toolItemStyles.container}
-    >
-      <Typography
-        variant="headingSmall"
-        color="text.secondary"
-        sx={toolItemStyles.label}
-      >
-        {label}
-      </Typography>
-      {description && (
-        <Typography
-          variant="bodySmall"
-          color="text.default"
-          sx={toolItemStyles.description}
-        >
-          {description}
-        </Typography>
-      )}
-    </Box>
-  );
-});
-
-ToolItem.displayName = 'ToolItem';
-
-/** @type {MuiSx} */
-const toolListStyles = {
-  container: ({ palette }) => ({
-    border: `1px solid ${palette.border.lines}`,
-    width: '100%',
-    maxWidth: '100%',
-    maxHeight: '15.4375rem',
-    borderRadius: '1rem',
-    boxSizing: 'border-box',
-    padding: '0.75rem',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.5rem',
-    background: palette.background.secondary,
-    overflowY: 'auto',
-  }),
-  header: {
-    position: 'sticky',
-    top: '-0.75rem',
-    zIndex: 1,
-    height: '1rem',
-    display: 'flex',
-    alignItems: 'center',
-    padding: '1rem .75rem',
-    margin: '-0.75rem -0.75rem 0',
-    background: 'inherit',
-  },
-};
-
-/** @type {MuiSx} */
-const toolItemStyles = {
-  container: ({ palette }) => ({
-    display: 'flex',
-    flexDirection: 'column',
-    padding: '0.5rem 0.75rem',
-    borderRadius: '0.5rem',
-    cursor: 'pointer',
-    background: palette.background.userInputBackground,
-    '&:hover': { background: palette.background.userInputBackgroundActive },
-  }),
-  label: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  description: {
-    overflow: 'hidden',
-    display: '-webkit-box',
-    WebkitBoxOrient: 'vertical',
-    WebkitLineClamp: 1,
-  },
-};

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
@@ -1,0 +1,266 @@
+import { memo, useEffect, useMemo } from 'react';
+
+import { useSelector } from 'react-redux';
+
+import { Box, ClickAwayListener, Typography } from '@mui/material';
+
+import { ChatParticipantType, PAGE_SIZE } from '@/common/constants';
+import useValidateToolkit from '@/hooks/application/useValidateToolkit';
+import useParticipants from '@/hooks/chat/useParticipants';
+import NewParticipantList from '@/pages/NewChat/Recommendations/NewParticipantList';
+
+/**
+ * Renders nothing but triggers validation for one toolkit.
+ * Skips the API call when validation data already exists in Redux so we
+ * don't re-validate on every render; RTK Query handles caching for the rest.
+ */
+const ToolkitValidator = memo(({ toolkitId, projectId }) => {
+  const selectorKey = `${projectId}_${toolkitId}`;
+  const hasValidationData = useSelector(state => selectorKey in state.chat.toolkitValidationInfo);
+  useValidateToolkit({ toolkitId, projectId, forceSkip: hasValidationData });
+  return null;
+});
+ToolkitValidator.displayName = 'ToolkitValidator';
+
+const SlashSuggestionList = memo(
+  ({
+    phase,
+    toolkitQuery,
+    toolQuery,
+    selectedToolkit,
+    isQueryFinal,
+    onSelectToolkit,
+    onSelectTool,
+    onClose,
+    participantToolkitIds,
+  }) => {
+    const toolkitValidationInfo = useSelector(state => state.chat.toolkitValidationInfo);
+
+    const { participants, isLoading, isFetching, onLoadMore, total } = useParticipants({
+      sortBy: 'name',
+      sortOrder: 'asc',
+      pageSize: PAGE_SIZE,
+      query: toolkitQuery,
+      types: [ChatParticipantType.Toolkits],
+      projectFilter: 'all',
+      forceSkip: phase !== 'toolkit',
+    });
+
+    // Only show toolkits that are added as conversation participants (AC1)
+    // and are properly configured (AC2).
+    // Name filtering is done client-side for instant response (no debounce lag).
+    const filteredParticipants = useMemo(() => {
+      if (!participantToolkitIds?.length) return [];
+      const idKeys = new Set(participantToolkitIds.map(p => `${p.project_id}_${p.id}`));
+      return participants.filter(p => {
+        const key = `${p.project_id}_${p.id}`;
+        if (!idKeys.has(key)) return false;
+        const validationInfo = toolkitValidationInfo?.[key];
+        if (validationInfo?.length) return false;
+        if (toolkitQuery && !p.name.toLowerCase().includes(toolkitQuery.toLowerCase())) return false;
+        return true;
+      });
+    }, [participants, participantToolkitIds, toolkitValidationInfo, toolkitQuery]);
+
+    const availableTools = useMemo(() => {
+      if (!selectedToolkit?.settings) return [];
+      const isMcp = selectedToolkit.type === 'mcp' || selectedToolkit.type?.startsWith('mcp_');
+      if (isMcp) {
+        return (selectedToolkit.settings.available_mcp_tools || []).map(item => ({
+          name: item.value || item.label,
+          description: item.description || '',
+        }));
+      }
+      return (selectedToolkit.settings.selected_tools || []).map(name => ({ name, description: '' }));
+    }, [selectedToolkit]);
+
+    const filteredTools = useMemo(
+      () =>
+        availableTools.filter(
+          tool => !toolQuery || tool.name.toLowerCase().includes(toolQuery.toLowerCase()),
+        ),
+      [availableTools, toolQuery],
+    );
+
+    useEffect(() => {
+      if (phase !== 'toolkit' || !isQueryFinal || isFetching) return;
+
+      const match = filteredParticipants.find(p =>
+        p.name.toLowerCase().startsWith(toolkitQuery.toLowerCase()),
+      );
+      if (match && (match.project_id !== selectedToolkit?.project_id || match.id !== selectedToolkit?.id)) {
+        onSelectToolkit({
+          id: match.id,
+          project_id: match.project_id,
+          name: match.name,
+          type: match.type,
+          settings: match.settings,
+        });
+      } else {
+        onClose();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [phase, isQueryFinal, isFetching, toolkitQuery, filteredParticipants]);
+
+    // Render one validator per participant toolkit. Each mounts when the slash menu
+    // opens and fires the validation API only when no data exists yet in Redux.
+    const validators = participantToolkitIds?.map(({ id, project_id }) => (
+      <ToolkitValidator
+        key={`${project_id}_${id}`}
+        toolkitId={id}
+        projectId={project_id}
+      />
+    ));
+
+    if (phase === 'idle') return null;
+
+    if (phase === 'toolkit') {
+      return (
+        <>
+          {validators}
+          <NewParticipantList
+            onSelectParticipant={participant =>
+              onSelectToolkit({
+                id: participant.id,
+                project_id: participant.project_id,
+                name: participant.name,
+                type: participant.type,
+                settings: participant.settings,
+              })
+            }
+            isLoading={isLoading}
+            isFetching={isFetching}
+            participants={filteredParticipants}
+            existingParticipantUids={[]}
+            onClose={onClose}
+            onLoadMore={onLoadMore}
+            total={total}
+            title="Mention toolkit"
+          />
+        </>
+      );
+    }
+
+    // phase === 'tool' — hide the list entirely when the filter matches nothing
+    if (toolQuery && filteredTools.length === 0) return null;
+    return (
+      <ToolList
+        tools={filteredTools}
+        toolkitName={selectedToolkit?.name}
+        onSelectTool={onSelectTool}
+      />
+    );
+  },
+);
+
+SlashSuggestionList.displayName = 'SlashSuggestionList';
+
+export default SlashSuggestionList;
+
+const ToolList = memo(({ tools, toolkitName, onSelectTool }) => {
+  const content = (
+    <Box sx={toolListStyles.container}>
+      <Box sx={toolListStyles.header}>
+        <Typography
+          variant="subtitle"
+          color="text.primary"
+        >
+          {toolkitName} available tools
+        </Typography>
+      </Box>
+
+      {tools.map(tool => (
+        <ToolItem
+          key={tool.name}
+          label={tool.name}
+          description={tool.description}
+          onClick={() => onSelectTool(tool.name)}
+        />
+      ))}
+    </Box>
+  );
+  return <ClickAwayListener onClickAway={() => onSelectTool(null)}>{content}</ClickAwayListener>;
+});
+
+ToolList.displayName = 'ToolList';
+
+const ToolItem = memo(({ label, description, onClick }) => {
+  return (
+    <Box
+      onClick={onClick}
+      sx={toolItemStyles.container}
+    >
+      <Typography
+        variant="headingSmall"
+        color="text.secondary"
+        sx={toolItemStyles.label}
+      >
+        {label}
+      </Typography>
+      {description && (
+        <Typography
+          variant="bodySmall"
+          color="text.default"
+          sx={toolItemStyles.description}
+        >
+          {description}
+        </Typography>
+      )}
+    </Box>
+  );
+});
+
+ToolItem.displayName = 'ToolItem';
+
+/** @type {MuiSx} */
+const toolListStyles = {
+  container: ({ palette }) => ({
+    border: `1px solid ${palette.border.lines}`,
+    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '15.4375rem',
+    borderRadius: '1rem',
+    boxSizing: 'border-box',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    background: palette.background.secondary,
+    overflowY: 'auto',
+  }),
+  header: {
+    position: 'sticky',
+    top: '-0.75rem',
+    zIndex: 1,
+    height: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '1rem .75rem',
+    margin: '-0.75rem -0.75rem 0',
+    background: 'inherit',
+  },
+};
+
+/** @type {MuiSx} */
+const toolItemStyles = {
+  container: ({ palette }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.5rem',
+    cursor: 'pointer',
+    background: palette.background.userInputBackground,
+    '&:hover': { background: palette.background.userInputBackgroundActive },
+  }),
+  label: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  description: {
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 1,
+  },
+};

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolItem.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolItem.jsx
@@ -1,0 +1,58 @@
+import { memo } from 'react';
+
+import { Box, Typography } from '@mui/material';
+
+const ToolItem = memo(props => {
+  const { label, description, onClick } = props;
+  return (
+    <Box
+      onClick={onClick}
+      sx={toolItemStyles.container}
+    >
+      <Typography
+        variant="headingSmall"
+        color="text.secondary"
+        sx={toolItemStyles.label}
+      >
+        {label}
+      </Typography>
+      {description && (
+        <Typography
+          variant="bodySmall"
+          color="text.default"
+          sx={toolItemStyles.description}
+        >
+          {description}
+        </Typography>
+      )}
+    </Box>
+  );
+});
+
+ToolItem.displayName = 'ToolItem';
+
+export default ToolItem;
+
+/** @type {MuiSx} */
+const toolItemStyles = {
+  container: ({ palette }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.5rem',
+    cursor: 'pointer',
+    background: palette.background.userInputBackground,
+    '&:hover': { background: palette.background.userInputBackgroundActive },
+  }),
+  label: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  description: {
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 1,
+  },
+};

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolList.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolList.jsx
@@ -1,0 +1,66 @@
+import { memo } from 'react';
+
+import { Box, ClickAwayListener, Typography } from '@mui/material';
+
+import ToolItem from './ToolItem';
+
+const ToolList = memo(props => {
+  const { tools, toolkitName, onSelectTool } = props;
+
+  const content = (
+    <Box sx={toolListStyles.container}>
+      <Box sx={toolListStyles.header}>
+        <Typography
+          variant="subtitle"
+          color="text.primary"
+        >
+          {toolkitName} available tools
+        </Typography>
+      </Box>
+
+      {tools.map(tool => (
+        <ToolItem
+          key={tool.name}
+          label={tool.name}
+          description={tool.description}
+          onClick={() => onSelectTool(tool.name)}
+        />
+      ))}
+    </Box>
+  );
+
+  return <ClickAwayListener onClickAway={() => onSelectTool(null)}>{content}</ClickAwayListener>;
+});
+
+ToolList.displayName = 'ToolList';
+
+export default ToolList;
+
+/** @type {MuiSx} */
+const toolListStyles = {
+  container: ({ palette }) => ({
+    border: `1px solid ${palette.border.lines}`,
+    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '15.4375rem',
+    borderRadius: '1rem',
+    boxSizing: 'border-box',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    background: palette.background.secondary,
+    overflowY: 'auto',
+  }),
+  header: {
+    position: 'sticky',
+    top: '-0.75rem',
+    zIndex: 1,
+    height: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '1rem .75rem',
+    margin: '-0.75rem -0.75rem 0',
+    background: 'inherit',
+  },
+};

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolkitValidator.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/ToolkitValidator.jsx
@@ -1,0 +1,22 @@
+import { memo } from 'react';
+
+import { useSelector } from 'react-redux';
+
+import useValidateToolkit from '@/hooks/application/useValidateToolkit';
+
+/**
+ * Renders nothing but triggers validation for one toolkit.
+ * Skips the API call when validation data already exists in Redux so we
+ * don't re-validate on every render; RTK Query handles caching for the rest.
+ */
+const ToolkitValidator = memo(props => {
+  const { toolkitId, projectId } = props;
+  const selectorKey = `${projectId}_${toolkitId}`;
+  const hasValidationData = useSelector(state => selectorKey in state.chat.toolkitValidationInfo);
+  useValidateToolkit({ toolkitId, projectId, forceSkip: hasValidationData });
+  return null;
+});
+
+ToolkitValidator.displayName = 'ToolkitValidator';
+
+export default ToolkitValidator;

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/index.js
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/index.js
@@ -1,0 +1,1 @@
+export { default as SlashSuggestionList } from './SlashSuggestionList';

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -16,6 +16,8 @@ import { Box } from '@mui/system';
 
 import { LATEST_VERSION_NAME } from '@/[fsd]/entities/version/lib/constants';
 import { ChatHelpers, NewConversationHelpers } from '@/[fsd]/features/chat/lib/helpers';
+import { useSlashMention } from '@/[fsd]/features/chat/lib/hooks';
+import { SlashSuggestionList } from '@/[fsd]/features/chat/ui';
 import { McpAuthHelpers } from '@/[fsd]/features/mcp/lib/helpers';
 import {
   DEFAULT_MAX_TOKENS,
@@ -763,6 +765,22 @@ const ChatBox = forwardRef((props, boxRef) => {
     }
   };
 
+  const {
+    slashPhase,
+    slashToolkitQuery,
+    slashToolQuery,
+    slashSelectedToolkit,
+    slashIsQueryFinal,
+    slashOnKeyDown,
+    participantToolkitIds,
+    resetSlash,
+    clearMentions,
+    onSlashSelectToolkit,
+    onSlashCommitMention,
+    onSlashInputChange,
+    slashHighlightRanges,
+  } = useSlashMention({ chatInput, activeConversation });
+
   const onPredictStream = useCallback(
     async question => {
       // Before sending a new message, add any pending MCP server (that required auth) to ignored list
@@ -892,7 +910,11 @@ const ChatBox = forwardRef((props, boxRef) => {
           sendResult?.createdConversation?.uuid ||
           activeConversation?.uuid;
         if (conversationUuid) {
-          emit({ ...eventPayload, conversation_uuid: conversationUuid });
+          emit({
+            ...eventPayload,
+            conversation_uuid: conversationUuid,
+          });
+          clearMentions();
         }
 
         // If a brand-new conversation was just created and the user had set a custom steps_limit
@@ -928,6 +950,7 @@ const ChatBox = forwardRef((props, boxRef) => {
       attachments,
       avatar,
       chat_history,
+      clearMentions,
       conversationEdit,
       emit,
       getPayload,
@@ -1293,6 +1316,8 @@ const ChatBox = forwardRef((props, boxRef) => {
 
   const onSendMessage = useCallback(
     async question => {
+      resetSlash();
+
       if (hasPendingHitlInterrupt && !hitlEditMode) {
         return;
       }
@@ -1305,12 +1330,20 @@ const ChatBox = forwardRef((props, boxRef) => {
 
       return onPredictStream(question);
     },
-    [hasPendingHitlInterrupt, hitlEditMode, onHitlResume, onPredictStream],
+    [hasPendingHitlInterrupt, hitlEditMode, onHitlResume, onPredictStream, resetSlash],
   );
 
   const { onKeyDown, isProcessingSymbols, query, stopProcessingSymbols } = useNewInputKeyDownHandler({
     disableHashtagDetection: isAgentsPage,
   });
+
+  const combinedKeyDown = useCallback(
+    event => {
+      onKeyDown(event);
+      slashOnKeyDown(event);
+    },
+    [onKeyDown, slashOnKeyDown],
+  );
 
   const onSelectParticipant = selectedParticipant => {
     const isSearchParticipant = isProcessingSymbols;
@@ -1846,13 +1879,27 @@ const ChatBox = forwardRef((props, boxRef) => {
               }}
             />
           )}
+          {slashPhase !== 'idle' && (
+            <SlashSuggestionList
+              phase={slashPhase}
+              toolkitQuery={slashToolkitQuery}
+              toolQuery={slashToolQuery}
+              selectedToolkit={slashSelectedToolkit}
+              isQueryFinal={slashIsQueryFinal}
+              onSelectToolkit={onSlashSelectToolkit}
+              onSelectTool={onSlashCommitMention}
+              onClose={resetSlash}
+              participantToolkitIds={participantToolkitIds}
+            />
+          )}
           <NewChatInput
             placeholder={inputPlaceholder}
             ref={chatInput}
             onSend={onSendMessage}
             isLoading={isInputLoading}
             disabledSend={isInputDisabled}
-            onNormalKeyDown={onKeyDown}
+            onNormalKeyDown={combinedKeyDown}
+            onInputChange={onSlashInputChange}
             shouldHandleEnter
             tooltipOfSendButton=""
             onShowParticipantsList={onShowParticipantsList}
@@ -1903,6 +1950,7 @@ const ChatBox = forwardRef((props, boxRef) => {
             onInternalToolsConfigChange={onInternalToolsConfigChange}
             internal_tools={activeConversation?.meta?.internal_tools || []}
             projectId={projectId}
+            slashHighlights={slashHighlightRanges}
           />
         </Box>
       </ChatBodyContainer>

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -23,6 +23,7 @@ const NewChatInput = forwardRef((props, ref) => {
     placeholder = '',
     clearInputAfterSubmit = true,
     onNormalKeyDown,
+    onInputChange,
     tooltipOfSendButton,
     isCreatingConversation = false,
 
@@ -76,6 +77,8 @@ const NewChatInput = forwardRef((props, ref) => {
     onInternalToolsConfigChange,
     internal_tools = [],
     projectId,
+
+    slashHighlights = [],
   } = props;
   const theme = useTheme();
   const { toastError } = useToast();
@@ -292,12 +295,17 @@ const NewChatInput = forwardRef((props, ref) => {
           users,
           onMentionChange,
         },
+        highlight: {
+          ranges: slashHighlights,
+          color: theme.palette.primary.main,
+        },
       }}
       clearInputAfterSend={clearInputAfterSubmit}
       disabledSend={disabledSend}
       disabledInput={isLoading}
       onSend={onSend}
       onNormalKeyDown={onNormalKeyDown}
+      onInputChange={onInputChange}
       tooltipOfSendButton={tooltipOfSendButton}
       showLoading={isLoading}
       onFilePaste={handleFilePaste}

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -6,6 +6,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Box, Typography } from '@mui/material';
 
 import { NewConversationHelpers } from '@/[fsd]/features/chat/lib/helpers';
+import { useSlashMention } from '@/[fsd]/features/chat/lib/hooks';
+import { SlashSuggestionList } from '@/[fsd]/features/chat/ui';
 import { DEFAULT_STEPS_LIMIT } from '@/[fsd]/shared/lib/constants/llmSettings.constants';
 import { useSystemSenderName } from '@/[fsd]/shared/lib/hooks/useEnvironmentSettingByKey.hooks';
 import { cleanLLMSettings, generateLLMSettings } from '@/[fsd]/shared/lib/utils/llmSettings.utils';
@@ -161,6 +163,22 @@ const NewConversationView = forwardRef(
     );
     const { setConversationStreamingInfo } = useChatStreaming({ chatHistory: [] });
 
+    const {
+      slashPhase,
+      slashToolkitQuery,
+      slashToolQuery,
+      slashSelectedToolkit,
+      slashIsQueryFinal,
+      slashOnKeyDown,
+      participantToolkitIds,
+      resetSlash,
+      clearMentions,
+      onSlashSelectToolkit,
+      onSlashCommitMention,
+      onSlashInputChange,
+      slashHighlightRanges,
+    } = useSlashMention({ chatInput, activeConversation });
+
     const onPredictStream = useCallback(
       (question, specifiedParticipant, conversation) => {
         // Guard: ensure conversation and uuid exist before emitting
@@ -211,6 +229,7 @@ const NewConversationView = forwardRef(
             attachmentList: updatedAttachments || attachments,
           });
           emit(payload);
+          clearMentions();
           onClearAttachments?.();
           setActiveConversation(prev => ({
             ...prev,
@@ -233,6 +252,7 @@ const NewConversationView = forwardRef(
         onClearAttachments,
         setActiveConversation,
         dispatch,
+        clearMentions,
       ],
     );
     const onPredictStreamRef = useRef(onPredictStream);
@@ -299,6 +319,14 @@ const NewConversationView = forwardRef(
 
     const { onKeyDown, query, stopProcessingSymbols, isProcessingSymbols } =
       useNewStartConversationInputKeyDownHandler();
+
+    const combinedKeyDown = useCallback(
+      event => {
+        onKeyDown(event);
+        slashOnKeyDown(event);
+      },
+      [onKeyDown, slashOnKeyDown],
+    );
 
     const onClearSelectedParticipant = useCallback(() => {
       setSelectedParticipant(null);
@@ -532,6 +560,7 @@ const NewConversationView = forwardRef(
     ]);
 
     const onSend = async (question, inputContent) => {
+      resetSlash();
       setIsSending(true);
 
       // Need to keep input content for sending message after conversation is created
@@ -733,6 +762,19 @@ const NewConversationView = forwardRef(
               What can I do for you today?
             </Typography>
           </Box>
+          {slashPhase !== 'idle' && (
+            <SlashSuggestionList
+              phase={slashPhase}
+              toolkitQuery={slashToolkitQuery}
+              toolQuery={slashToolQuery}
+              selectedToolkit={slashSelectedToolkit}
+              isQueryFinal={slashIsQueryFinal}
+              onSelectToolkit={onSlashSelectToolkit}
+              onSelectTool={onSlashCommitMention}
+              onClose={resetSlash}
+              participantToolkitIds={participantToolkitIds}
+            />
+          )}
           <Box sx={styles.inputContainer}>
             <NewChatInput
               placeholder="Type your message. Use # to search and add AI assistants to conversation."
@@ -746,7 +788,8 @@ const NewConversationView = forwardRef(
                 totalValidationInfo?.length ||
                 toolkitValidationInfoList?.length
               }
-              onNormalKeyDown={onKeyDown}
+              onNormalKeyDown={combinedKeyDown}
+              onInputChange={onSlashInputChange}
               shouldHandleEnter
               tooltipOfSendButton={isConversationNameInvalid ? ConversationNameWarningMessage : ''}
               onShowParticipantsList={onShowParticipantsList}
@@ -777,6 +820,7 @@ const NewConversationView = forwardRef(
               disableAttachments={disableAttachments}
               onInternalToolsConfigChange={onInternalToolsConfigChange}
               internal_tools={internalTools}
+              slashHighlights={slashHighlightRanges}
             />
           </Box>
           <Box sx={styles.recommendationsContainer}>


### PR DESCRIPTION
# Issue #2925 — Slash-Mention Toolkit in Chat (Participants Only)

## Summary

The slash-mention (`/`) feature lets users type `/toolkit-name` or `/toolkit-name/tool-name` in the chat input to direct a message at a specific toolkit/tool.

**Story #2925 revised the behaviour to:**
- **AC1** — Only show toolkits that are **already added as Conversation Participants** in the current conversation.
- **AC2** — Exclude toolkits that are **misconfigured** (missing required credentials, bad settings, etc.) from the autocomplete list.

**No backend changes are needed.** Because the slash-mention feature is scoped exclusively to toolkits that are already participants of the conversation, the existing participant-based payload in `generate_toolkit_payload()` already handles them.

---

## Architecture

### Data Flow

```
Conversation opens
     │
     ▼
activeConversation.participants  (local React state)
  ├─ entities with entity_name === 'toolkits'
  └─ participantToolkitIds: [{id, project_id}, ...]  (derived in useSlashMention)
     │
User types "/" in chat input
     │
     ▼
useSlashCommandHandler  →  phase: 'toolkit'
  mentionAnchorRef set to index of '/' in the full input text (on first syncWithValue call)
     │
SlashSuggestionList (phase='toolkit'):
  1. Mounts ToolkitValidator for each participant toolkit
     └─ Calls useValidateToolkit (skips if toolkitValidationInfo already populated)
  2. Fetches toolkit data via useParticipants (query=toolkitQuery debounced 200ms, pageSize=PAGE_SIZE)
     └─ Client-side name filter on top of server-side for instant visual response
  3. filteredParticipants = participants ∩ participantToolkitIds − misconfigured − !nameMatch
  4. NewParticipantList always rendered (handles own loading/empty states)
     └─ Supports infinite scroll via onLoadMore/total from useParticipants
     │
User selects a toolkit  (or auto-selected when isQueryFinal + single match)
     │
     ▼
useSlashMention.onSlashSelectToolkit:
  - Uses cursor position to find fragment end (handles space-containing names)
  - Replaces "/typedFragment" in input with "/toolkitName[/]"
  - Detects separator '/' for phase transition to 'tool'
phase: 'tool'
  availableTools derived from selectedToolkit.settings
    ├─ MCP toolkit: settings.available_mcp_tools  →  [{name, description}, ...]
    └─ regular:     settings.selected_tools        →  [{name}, ...]
filteredTools = availableTools filtered by toolQuery
     │
User selects a tool (or clicks away to commit toolkit-only mention)
     │
     ▼
useSlashMention.onSlashCommitMention:
  - Uses mentionAnchorRef + toolkit name prefix to compute exact bounds
  - Replaces "/toolkitName[/toolQuery]" with "/ToolkitName[/toolName] " (trailing space)
committedMentions: [{toolkit_id, project_id, toolkit_name, toolkit_type, toolkit_settings, tool_name}]
  └─ Sent as mentioned_toolkits in socket payload
  └─ useSlashHighlights computes {start, end} ranges for backdrop highlight in UserInput
```

---

## Implementation Status: DONE ✓

## Files Changed

### New Files

| File | Description |
|---|---|
| `EliteaUI/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js` | Higher-level hook; shared by `NewConversationView` and `ChatBox` |
| `EliteaUI/src/[fsd]/features/chat/lib/hooks/useSlashCommandHandler.hooks.js` | Lower-level state machine for slash-mention phases |
| `EliteaUI/src/[fsd]/features/chat/lib/hooks/useSlashHighlights.hooks.js` | Computes character ranges for backdrop highlight of committed mentions |
| `EliteaUI/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx` | Autocomplete dropdown (toolkit phase + tool phase) |

### Modified Files

| File | Changes |
|---|---|
| `EliteaUI/src/pages/NewChat/NewConversationView.jsx` | Uses `useSlashMention`; passes slash props to `UserInput` and `SlashSuggestionList` |
| `EliteaUI/src/pages/NewChat/ChatBox.jsx` | Same as above |
| `EliteaUI/src/ComponentsLib/Chat/UserInput.jsx` | Added `HighlightedText` backdrop, `getCursorPosition()` / `replaceRange()` imperative handle; removed debug `console.log` statements |

---

## Implementation Details

### 1. `useSlashCommandHandler.hooks.js` — Phase State Machine

Manages the three-phase slash-mention lifecycle (`idle → toolkit → tool`) with a single source of truth: `syncWithValue()` parses the actual textarea text on every `onChange`. `onKeyDown()` only handles two cases that need immediate response before the textarea value updates: `/` (open dropdown immediately) and `Escape` (dismiss). No character accumulation is done in `onKeyDown`.

**Key state:**
- `phase` / `phaseRef` — current phase (`'idle' | 'toolkit' | 'tool'`); `phaseRef` mirrors `phase` so `onKeyDown`/`syncWithValue` always read the latest value without stale closures
- `toolkitQuery` / `toolQuery` — text being typed in each phase
- `selectedToolkit` — `{id, project_id, name, type, settings}` after toolkit is chosen
- `committedMentions` — array of fully committed mentions; `committedMentionsRef` mirrors it for sync reads in `syncWithValue`
- `mentionAnchorRef` — character index of the leading `/` of the currently-editing mention; enables editing an **earlier** mention in a multi-mention input without corrupting later text
- `lastToolkitRef` — remembers the last selected toolkit for fallback matching during backspace/paste
- `pendingToolQueryRef` — stores the tool-query fragment when a second `/` is detected while in toolkit phase, so `selectToolkit` can seed `toolQuery` correctly

**`syncWithValue(text, cursorPos)` — the authoritative state update path:**

Uses `textToCursor = text.slice(0, cursorPos)` so editing an earlier mention isn't confused by later text. Two regex patterns matched at end of `textToCursor`:
- `fullMatch` → `/toolkitName/toolQuery` (toolQuery may be empty)
- `toolkitOnlyMatch` → `/toolkitName` (no second slash yet); also matches bare `/`

**Space-containing toolkit names:** The regex patterns (`/([^/\s]+)/...`) cannot match names with spaces. `syncWithValue()` uses three strategies to re-open the dropdown:
1. **Committed mentions loop** (idle phase) — literal `lastIndexOf` prefix match against each `committedMentions` entry
2. **`mentionAnchorRef` fragment** (toolkit/tool phase) — slice from anchor to cursor, prefix-match against committed mentions and `lastToolkitRef`
3. **`lastIndexOf('/')` fallback** (idle phase) — `lastToolkitRef.name.startsWith(afterSlash)` for partial names when the committed mention was already removed

**`committedMentions` lifecycle:**
- Added by `selectToolkit()` (toolkit-only mention as soon as toolkit chosen)
- Updated by `commitMention(toolName)` (replaces same `toolkit_id/project_id` entry)
- Removed (un-committed) when user backspaces into a committed mention — the entry is filtered out before re-entering toolkit or tool phase
- Cleared by `clearMentions()` after a successful message send

**Exported API:**
```js
return {
  phase, toolkitQuery, toolQuery, selectedToolkit, committedMentions,
  isQueryFinal, onKeyDown, syncWithValue, selectToolkit, commitMention,
  removeMention, clearMentions, resetSlash, mentionAnchorRef,
};
```

---

### 2. `useSlashMention.hooks.js` — Higher-Level Hook

Wraps `useSlashCommandHandler` and handles input manipulation and state derivation. Used by both `NewConversationView` and `ChatBox`.

```js
export const useSlashMention = ({ chatInput, activeConversation }) => {
  const [inputContent, setInputContent] = useState('');

  // Destructure from useSlashCommandHandler, prefixed with 'slash' on return
  const { phase, ..., syncWithValue: slashSyncWithValue, selectToolkit: slashSelectToolkit,
    commitMention: slashCommitMention, clearMentions, resetSlash, mentionAnchorRef
  } = useSlashCommandHandler({ setInputContent });

  // Derived from activeConversation.participants (AC1 source of truth)
  const participantToolkitIds = useMemo(
    () => (activeConversation?.participants || [])
      .filter(p => p.entity_name === ChatParticipantType.Toolkits)
      .map(p => ({ id: p.entity_meta.id, project_id: p.entity_meta.project_id })),
    [activeConversation?.participants],
  );

  // Cursor-position-based replacement: uses getCursorPosition() as the fragment end.
  // This correctly handles toolkit names containing spaces (regex can't match them).
  const onSlashSelectToolkit = useCallback(toolkit => {
    const content = chatInput.current.getInputContent();
    const anchor = mentionAnchorRef.current ?? content.lastIndexOf('/');
    const cursorPos = chatInput.current.getCursorPosition() ?? content.length;
    const afterAnchor = content.slice(anchor, cursorPos);
    const hasSeparator = afterAnchor.includes('/') || afterAnchor.endsWith('/');
    const replacement = hasSeparator ? `/${toolkit.name}/` : `/${toolkit.name}`;
    const replaceEnd = anchor + afterAnchor.length;
    chatInput.current.replaceRange(anchor, replaceEnd, replacement);
    setInputContent(chatInput.current.getInputContent());
    slashSelectToolkit(toolkit);
  }, [slashSelectToolkit]);

  // Anchor-based commit: mentionAnchorRef + toolkit name prefix to find exact end.
  const onSlashCommitMention = useCallback(toolName => {
    const content = chatInput.current.getInputContent();
    const anchor = mentionAnchorRef.current ?? content.lastIndexOf('/');
    const prefix = `/${slashSelectedToolkit.name}`;
    const prefixEnd = anchor + prefix.length;
    const mentionEnd = toolName ? prefixEnd + 1 + toolName.length : prefixEnd;
    const replacement = toolName
      ? `/${slashSelectedToolkit.name}/${toolName} `
      : `/${slashSelectedToolkit.name} `;
    chatInput.current.replaceRange(anchor, mentionEnd, replacement);
    setInputContent(chatInput.current.getInputContent());
    slashCommitMention(toolName);
  }, [slashCommitMention, slashSelectedToolkit]);

  // Clears ALL mention state when input is emptied.
  const onSlashInputChange = useCallback(value => {
    setInputContent(value);
    if (!value) { clearMentions(); resetSlash(); return; }
    slashSyncWithValue(value, chatInput.current?.getCursorPosition());
  }, [slashSyncWithValue, clearMentions, resetSlash]);

  // Backdrop highlight ranges for committed mentions in UserInput.
  const slashHighlightRanges = useSlashHighlights(inputContent, committedMentions);

  return {
    slashPhase, slashToolkitQuery, slashToolQuery, slashSelectedToolkit,
    committedMentions, slashIsQueryFinal, slashOnKeyDown,
    participantToolkitIds, resetSlash, clearMentions,
    onSlashSelectToolkit, onSlashCommitMention, onSlashInputChange,
    slashHighlightRanges,
  };
};
```

---

### 3. `useSlashHighlights.hooks.js` — Backdrop Highlight Ranges

Pure `useMemo` hook. Builds unique token strings from `committedMentions` (`/toolkit` or `/toolkit/tool`), sorts longest-first to prevent sub-match shadowing (e.g. `/toolkit/tool` shadows `/toolkit`), then scans `inputContent` with `indexOf` to find all occurrences. Returns `[{start, end}, ...]` sorted by start position. Used by `UserInput` to render the backdrop `HighlightedText` layer.

---

### 4. `SlashSuggestionList.jsx` — Autocomplete Dropdown

#### `ToolkitValidator` — Proactive validation on slash menu open

Null-rendering component that calls `useValidateToolkit` for each participant toolkit when the slash menu mounts. Skips the API call if validation data already exists in Redux (`selectorKey in state.chat.toolkitValidationInfo`), preventing redundant requests on repeated opens.

**Important:** `toolkitValidationInfo` is only populated when a toolkit has **errors**. An absent key means "not yet validated" or "valid".

#### Data fetching

```js
const { participants, isLoading, isFetching, onLoadMore, total } = useParticipants({
  sortBy: 'name',
  sortOrder: 'asc',
  pageSize: PAGE_SIZE,
  query: toolkitQuery,          // server-side, debounced 200ms
  types: [ChatParticipantType.Toolkits],
  projectFilter: 'all',
  forceSkip: phase !== 'toolkit',
});
```

**Dual filtering strategy:**
- **Server-side** (`query: toolkitQuery`, 200ms debounce via `useParticipants`): reduces API result set, supports pagination
- **Client-side** (immediate in `filteredParticipants` useMemo): provides instant visual response during the debounce window

```js
// AC1 (participant filter) + AC2 (validation filter) + instant client-side name filter
const filteredParticipants = useMemo(() => {
  if (!participantToolkitIds?.length) return [];
  const idKeys = new Set(participantToolkitIds.map(p => `${p.project_id}_${p.id}`));
  return participants.filter(p => {
    const key = `${p.project_id}_${p.id}`;
    if (!idKeys.has(key)) return false;                                           // AC1
    if (toolkitValidationInfo?.[key]?.length) return false;                      // AC2
    if (toolkitQuery && !p.name.toLowerCase().includes(toolkitQuery.toLowerCase())) return false;
    return true;
  });
}, [participants, participantToolkitIds, toolkitValidationInfo, toolkitQuery]);
```

#### Pagination

`onLoadMore` and `total` from `useParticipants` are passed directly to `NewParticipantList`. `total` is the raw project-wide toolkit count (not the filtered count). The infinite loader pages through all project toolkits to find participant matches that may be on later pages.

#### Rendering

In `phase === 'toolkit'`, `NewParticipantList` is **always rendered** (no early return for empty `filteredParticipants`). `NewParticipantList` handles its own loading state (`isLoading` skeletons) and empty state. This is intentional — `isFetching` is `false` on page 0 due to `useLoadToolkitData` gating (`isToolkitsFetching: !!page && isToolkitFetching`), so `isLoading` is the correct guard for the initial load.

```jsx
// phase === 'toolkit' — always render NewParticipantList
if (phase === 'toolkit') {
  return (
    <>
      {validators}
      <NewParticipantList
        onSelectParticipant={...}
        isLoading={isLoading}
        isFetching={isFetching}
        participants={filteredParticipants}
        existingParticipantUids={[]}
        onClose={onClose}
        onLoadMore={onLoadMore}
        total={total}
        title="Mention toolkit"
      />
    </>
  );
}
```

#### Auto-select effect

When `isQueryFinal` is true (separator `/` was typed/detected) and fetch is complete, finds the first `filteredParticipants` entry whose name starts with `toolkitQuery`. If found and not already selected, calls `onSelectToolkit`. Otherwise calls `onClose`.

#### Tool phase

`availableTools` derived from `selectedToolkit.settings`:
- MCP: `settings.available_mcp_tools` → `[{name: item.value || item.label, description}]`
- Regular: `settings.selected_tools` → `[{name, description: ''}]`

`filteredTools` = `availableTools` filtered by `toolQuery`. When `toolQuery` is non-empty and nothing matches, renders nothing (no list shown). Tool list wrapped in `ClickAwayListener` that calls `onSelectTool(null)` to commit a toolkit-only mention.

---

### 5. Parent Component Changes (`NewConversationView`, `ChatBox`)

Both components:
- Use `useSlashMention({ chatInput, activeConversation })` (replacing manual state)
- Pass `participantToolkitIds` to `<SlashSuggestionList>`
- Pass `slashOnKeyDown` / `onSlashInputChange` to `UserInput`
- Pass `slashHighlightRanges` to `UserInput`'s `highlight` slotProp
- Pass `committedMentions` into the socket send payload as `mentioned_toolkits`
- Call `clearMentions()` after successful send

---

### 6. `UserInput.jsx` Changes

- **`HighlightedText`** component: positioned absolutely behind the textarea (z-index 0 vs textarea z-index 1). Textarea text is set to `transparent` with visible `caretColor` when highlights are active. The mirror div syncs `scrollTop` with the textarea on scroll.
- **`getCursorPosition()`** imperative handle: returns `inputRef.current.selectionStart`
- **`replaceRange(start, end, text)`** imperative handle: constructs new value, updates state, repositions cursor via `setTimeout`
- Removed debug `console.log` statements that fired on every render

---

## Redux State: `toolkitValidationInfo`

- **Location:** `state.chat.toolkitValidationInfo`
- **Key format:** `"${project_id}_${toolkit_id}"`
- **Populated by:** `useValidateToolkit` hook (writes errors array when toolkit is misconfigured)
- **Not populated for valid toolkits** — absent key means "not yet validated" or "valid"
- **Used by:** `SlashSuggestionList` to exclude misconfigured toolkits (AC2); `ToolkitValidator` to skip redundant API calls

---

## Acceptance Criteria Mapping

| AC | Requirement | Implementation |
|---|---|---|
| **AC1** | Only show toolkits added as conversation participants | `filteredParticipants` intersects `participants` with `participantToolkitIds` (from `activeConversation.participants`) |
| **AC2** | Exclude misconfigured toolkits | `filteredParticipants` excludes entries with `toolkitValidationInfo[key].length > 0`; `ToolkitValidator` fires validation when slash menu mounts |

---

## What Does NOT Change

- **Backend** — no changes needed. The toolkit is already a conversation participant; `generate_toolkit_payload()` handles it. No `mentioned_toolkits` field is needed at the backend level.
- The `#` hashtag flow for adding **persistent** participants — untouched
- The SDK (`alita-sdk`) — no changes

---

## Edge Cases

1. **Space-containing toolkit names** (`"My Toolkit Name"`): The regex `/([^/\s]+)/...` cannot match names with spaces. Handled via three fallback strategies in `syncWithValue()`: committed-mention literal prefix matching, `mentionAnchorRef` fragment matching, and `lastIndexOf('/')` with `lastToolkitRef`.

2. **Multi-mention editing**: User can type `/toolkitA/toolA /toolkitB/` and go back to edit `/toolkitA`. `mentionAnchorRef` stores the anchor position of the currently-editing mention so all text replacements target the correct range without corrupting later mentions.

3. **Empty input clears all state**: When the user deletes everything, both phase state (`resetSlash`) and `committedMentions` (`clearMentions`) are cleared in `onSlashInputChange`.

4. **Slash menu opens before participants panel is viewed**: `ToolkitValidator` handles this — fires validation for each participant toolkit the moment the slash menu mounts.

5. **Toolkit becomes misconfigured after slash menu opened once**: `ToolkitValidator` skips re-validation if `toolkitValidationInfo[key]` already exists. Stale validation resolves on next page load.

6. **Conversation with no toolkit participants**: `participantToolkitIds` is empty → `filteredParticipants` returns `[]` → `NewParticipantList` renders with no items.

7. **MCP vs regular toolkit tools**: MCP uses `settings.available_mcp_tools` (array of `{value/label, description}`); regular uses `settings.selected_tools` (array of strings).

8. **Initial load — `isFetching` always false on page 0**: `useLoadToolkitData` returns `isToolkitsFetching: !!page && isToolkitFetching`, so `isFetching` from `useParticipants` is `false` during the initial fetch. `NewParticipantList` uses `isLoading` (RTK Query's "first fetch, no cache" flag) to show loading skeletons.

9. **Pagination and participant matching**: `total` passed to `NewParticipantList` is the raw project-wide toolkit count. The infinite loader pages through all toolkits; `filteredParticipants` then narrows to only conversation participants. This ensures participant toolkits on later pages are reachable.
