### PR TITLE
feat: [EL-3589] disable delete confirmation via project secret

### DIFF
--- a/src/[fsd]/shared/lib/hooks/index.js
+++ b/src/[fsd]/shared/lib/hooks/index.js
@@ -13,3 +13,4 @@ export * from './useProjectType.hooks';
 export * from './useContextExecutionEntity.hooks';
 export * from './useEnvironmentSettingByKey.hooks';
 export * from './useShowRunHistoryFromUrl.hooks';
+export * from './useDeleteConfirmationDisabled.hooks';

--- a/src/[fsd]/shared/lib/hooks/useDeleteConfirmationDisabled.hooks.js
+++ b/src/[fsd]/shared/lib/hooks/useDeleteConfirmationDisabled.hooks.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+import { useLazySecretShowQuery, useSecretsListQuery } from '@/api/secrets';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+
+const SECRET_NAME = 'disable_confirmation_delete_mode';
+
+export const useDeleteConfirmationDisabled = () => {
+  const [isDisabled, setIsDisabled] = useState(false);
+  const projectId = useSelectedProjectId();
+
+  const { data: secrets = [] } = useSecretsListQuery(projectId, {
+    skip: !projectId,
+  });
+
+  const [showSecret] = useLazySecretShowQuery();
+
+  useEffect(() => {
+    const checkSecret = async () => {
+      const secret = secrets.find(s => s.name === SECRET_NAME);
+
+      if (!secret) {
+        setIsDisabled(false);
+        return;
+      }
+
+      try {
+        const { data, error } = await showSecret({ projectId, name: SECRET_NAME });
+
+        if (error) {
+          setIsDisabled(false);
+          return;
+        }
+
+        setIsDisabled((data?.value || '').toLowerCase() === 'true');
+      } catch {
+        setIsDisabled(false);
+      }
+    };
+
+    if (projectId && secrets.length > 0) {
+      checkSecret();
+    } else {
+      setIsDisabled(false);
+    }
+  }, [secrets, projectId, showSecret]);
+
+  return isDisabled;
+};

--- a/src/components/DataRowAction.jsx
+++ b/src/components/DataRowAction.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { IconButton, Menu, MenuItem, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 
+import { useDeleteConfirmationDisabled } from '@/[fsd]/shared/lib/hooks';
 import { Modal } from '@/[fsd]/shared/ui';
 import { useDeleteApplicationMutation } from '@/api/applications';
 import { useDeleteConfigurationMutation } from '@/api/configurations';
@@ -42,11 +43,17 @@ BasicMenuItem.displayName = 'BasicMenuItem';
 const ActionWithDialog = memo(props => {
   const { icon, label, name, onConfirm, closeMenu } = props;
   const [open, setOpen] = useState(false);
+  const skipConfirmation = useDeleteConfirmationDisabled();
 
   const openDialog = useCallback(() => {
+    if (skipConfirmation) {
+      onConfirm?.();
+      closeMenu();
+      return;
+    }
     closeMenu();
     setOpen(true);
-  }, [closeMenu]);
+  }, [closeMenu, skipConfirmation, onConfirm]);
 
   const onClose = useCallback(() => {
     closeMenu();

--- a/src/components/DeleteEntityButton.jsx
+++ b/src/components/DeleteEntityButton.jsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useState } from 'react';
 import { Box, IconButton, Typography } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
+import { useDeleteConfirmationDisabled } from '@/[fsd]/shared/lib/hooks';
 import { Modal } from '@/[fsd]/shared/ui';
 import { PERMISSIONS } from '@/common/constants';
 import { StyledCircleProgress } from '@/components/Chat/StyledComponents';
@@ -33,11 +34,19 @@ const DeleteEntityButton = memo(props => {
   const theme = useTheme();
   const [openAlert, setOpenAlert] = useState(false);
   const { checkPermission } = useCheckPermission();
+  const skipConfirmation = useDeleteConfirmationDisabled();
 
-  const onClickButton = useCallback(event => {
-    event.stopPropagation();
-    setOpenAlert(true);
-  }, []);
+  const onClickButton = useCallback(
+    event => {
+      event.stopPropagation();
+      if (skipConfirmation && shouldRequestInputName) {
+        onDelete && onDelete();
+      } else {
+        setOpenAlert(true);
+      }
+    },
+    [skipConfirmation, shouldRequestInputName, onDelete],
+  );
 
   const onClose = useCallback(
     event => {

--- a/src/components/DotMenu.jsx
+++ b/src/components/DotMenu.jsx
@@ -4,6 +4,7 @@ import { Box, Divider, IconButton, ListItemIcon, Menu, MenuItem } from '@mui/mat
 import ListItemText from '@mui/material/ListItemText';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
+import { useDeleteConfirmationDisabled } from '@/[fsd]/shared/lib/hooks';
 import { Modal } from '@/[fsd]/shared/ui';
 import CheckedIcon from '@/assets/checked-icon.svg?react';
 import AlertDialogV2 from '@/components/AlertDialogV2';
@@ -22,6 +23,7 @@ const BasicMenuItem = ({
   isSelected,
   showCheckIcon,
   setActiveDialog,
+  skipConfirmation,
 }) => {
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState(null);
@@ -125,6 +127,7 @@ const BasicMenuItem = ({
                 shouldRequestInputName={subMenuItem.shouldRequestInputName}
                 setActiveDialog={setActiveDialog}
                 dialogKey={subMenuItem.key || subMenuItem.label}
+                skipConfirmation={skipConfirmation}
               />
             ) : (
               <BasicMenuItem
@@ -161,10 +164,16 @@ const ActionWithDialog = ({
   modalSx,
   setActiveDialog,
   dialogKey,
+  skipConfirmation,
 }) => {
   const openDialog = useCallback(
     event => {
       event.stopPropagation();
+      if (skipConfirmation && entityName && shouldRequestInputName) {
+        onConfirm?.();
+        closeMenu();
+        return;
+      }
       setActiveDialog({
         key: dialogKey,
         props: {
@@ -198,6 +207,7 @@ const ActionWithDialog = ({
       extraContent,
       inlineExtraContent,
       modalSx,
+      skipConfirmation,
     ],
   );
 
@@ -236,6 +246,7 @@ export default function DotMenu({
   const [anchorEl, setAnchorEl] = useState(null);
   const [activeDialog, setActiveDialog] = useState(null);
   const open = useMemo(() => Boolean(anchorEl), [anchorEl]);
+  const skipConfirmation = useDeleteConfirmationDisabled();
 
   const onClickMenu = useCallback(
     event => {
@@ -385,6 +396,7 @@ export default function DotMenu({
                     modalSx={item.modalSx}
                     setActiveDialog={setActiveDialog}
                     dialogKey={item.key || item.label}
+                    skipConfirmation={skipConfirmation}
                   />
                 </TooltipWrapper>
               ) : (
@@ -397,6 +409,7 @@ export default function DotMenu({
                     onClick={withClose(item.onClick)}
                     onCloseSubMenu={handleClose}
                     setActiveDialog={setActiveDialog}
+                    skipConfirmation={skipConfirmation}
                   />
                 </TooltipWrapper>
               );
@@ -441,6 +454,7 @@ export default function DotMenu({
                         modalSx={item.modalSx}
                         setActiveDialog={setActiveDialog}
                         dialogKey={item.key || item.label}
+                        skipConfirmation={skipConfirmation}
                       />
                     </TooltipWrapper>
                   ) : (


### PR DESCRIPTION
Add useDeleteConfirmationDisabled hook that reads the project secret disable_confirmation_delete_mode. When set to true, delete actions bypass the DeleteEntityModal name-typing confirmation and execute immediately.

Affected components: DeleteEntityButton, DotMenu (ActionWithDialog), and DataRowAction. AlertDialog-based confirmations (version delete, embedding model change) remain unaffected.

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/3589