### PR TITLE
fix: [EL-4833] Fixed timestamp updated after regenerating click

### DIFF
--- a/src/common/convertChatConversationMessages.js
+++ b/src/common/convertChatConversationMessages.js
@@ -113,6 +113,7 @@ export const convertToAIAnswer = (message_group, message_groups, participants) =
     content,
     message_items = [],
     created_at,
+    updated_at,
     reply_to_id,
     uuid,
     is_streaming,
@@ -240,12 +241,14 @@ export const convertToAIAnswer = (message_group, message_groups, participants) =
       });
     }
   }) || [];
+
+  const displayTime = updated_at || created_at;
   return {
     id: uuid,
     role: ROLES.Assistant,
     message_items: [...message_items].sort((a, b) => a.id - b.id),
     content: is_streaming ? '...' : content,
-    created_at: new Date(convertTime(created_at)).getTime(),
+    created_at: new Date(convertTime(displayTime)).getTime(),
     participant_id: author_participant_id,
     question_id: foundQuestion?.uuid || foundQuestion?.id,
     replyTo: foundQuestion,

--- a/src/components/Chat/CreatedTimeInfo.jsx
+++ b/src/components/Chat/CreatedTimeInfo.jsx
@@ -9,6 +9,8 @@ const CreatedTimeInfo = props => {
   const [time, setTime] = useState(formatDistanceToNow(new Date(created_at)) + ' ago');
 
   useEffect(() => {
+    setTime(formatDistanceToNow(new Date(created_at)) + ' ago');
+
     const intervalId = setInterval(() => {
       setTime(formatDistanceToNow(new Date(created_at)) + ' ago');
     }, 30000);

--- a/src/components/Chat/hooks.js
+++ b/src/components/Chat/hooks.js
@@ -212,7 +212,8 @@ const addMessageToChatHistory = ({
       })
     : setChatHistoryRef.current?.(prevState => {
         const newState = [...prevState]; // Create new array first
-        if (!newState[msgIndex].participant) {
+        const existingMessage = newState[msgIndex];
+        if (!existingMessage.participant) {
           const theParticipant = participantsRef.current?.find(
             participant => participant.id === participant_id,
           );
@@ -220,7 +221,7 @@ const addMessageToChatHistory = ({
         }
         // Preserve SwarmChild toolActions from current state that may have been added
         // by socket events not yet reflected in chatHistoryRef (stale ref issue)
-        const existingSwarmChildren = (newState[msgIndex]?.toolActions || []).filter(
+        const existingSwarmChildren = (existingMessage?.toolActions || []).filter(
           a => a.type === TOOL_ACTION_TYPES.SwarmChild,
         );
         if (existingSwarmChildren.length > 0) {
@@ -229,7 +230,7 @@ const addMessageToChatHistory = ({
           );
           msg.toolActions = [...nonSwarmChildren, ...existingSwarmChildren];
         }
-        newState[msgIndex] = msg;
+        newState[msgIndex] = { ...existingMessage, ...msg };
         return newState;
       });
 };
@@ -393,6 +394,7 @@ export const useChatSocket = ({
           if (!isContinuing) {
             msg.content = '';
             msg.references = [];
+            msg.created_at = new Date().getTime();
           }
           msg.task_id = task_id;
           msg.participant_id = participant_id;

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1057,6 +1057,7 @@ const ChatBox = forwardRef((props, boxRef) => {
                 exception: undefined,
                 toolActions: [],
                 isRegenerating: true,
+                created_at: new Date().getTime(),
               },
         );
       });


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4833

-  Fixed timestamp updated after regenerating click
- Added optimistic updating

| File | Change | Why |
|------|--------|-----|
| `src/components/Chat/CreatedTimeInfo.jsx:11-13` | Added `setTime()` call at the start of `useEffect` before interval setup | `useState` initializer only runs on mount. When `created_at` prop changes, state wasn't updating until next interval tick (30s). Now updates immediately. |
| `src/common/convertChatConversationMessages.js:245,251` | Added `updated_at` to destructuring; use `updated_at \|\| created_at` for `displayTime` | Backend updates `updated_at` on regenerate. Without this, time resets to original `created_at` after page reload. |
| `src/pages/NewChat/ChatBox.jsx:1060` | Added `created_at: new Date().getTime()` in `onRegenerateAnswer` | Optimistic update — UI shows new time instantly on click, before server responds. |
| `src/components/Chat/hooks.js:397` | Added `msg.created_at = new Date().getTime()` in StartTask handler | Sets time for new messages (when `msgIndex === -1`) that don't have optimistic update yet. |
| `src/components/Chat/hooks.js:233` | Changed `newState[msgIndex] = msg` to `newState[msgIndex] = { ...existingMessage, ...msg }` | Merge instead of replace. Socket `msg` doesn't include `created_at`, so full replacement was overwriting the optimistic value with `undefined`. |

<img width="498" height="407" alt="Screenshot 2026-05-05 155925" src="https://github.com/user-attachments/assets/fc44789a-968c-497f-a958-f0bc6978f472" />
