### PR TITLE
fix: [EL-4842] Fixed double approve for discard click

### DIFF
--- a/src/[fsd]/pages/settings/CreatePersonalToken.jsx
+++ b/src/[fsd]/pages/settings/CreatePersonalToken.jsx
@@ -1,10 +1,10 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFormik } from 'formik';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { Box, CircularProgress, Button as MuiButton, TextField, Tooltip } from '@mui/material';
+import { Box, CircularProgress, TextField, Tooltip } from '@mui/material';
 
 import { DrawerPage, DrawerPageHeader } from '@/[fsd]/features/settings/ui/drawer-page';
 import { GeneratedTokenDialog } from '@/[fsd]/features/settings/ui/personal-tokes';
@@ -22,6 +22,7 @@ const validationSchema = yup.object({
 const CreatePersonalToken = memo(() => {
   const navigate = useNavigate();
   const [data, setData] = useState({});
+  const [wantToCancel, setWantToCancel] = useState(false);
   const [openTokenDialog, setOpenTokenDialog] = useState(false);
   const [createToken, { isLoading: isGenerating }] = useTokenCreateMutation();
   const { refetch } = useTokenListQuery({ skip: true });
@@ -48,6 +49,7 @@ const CreatePersonalToken = memo(() => {
       }
     },
   });
+
   const hasChanged = useMemo(() => {
     return (
       JSON.stringify({
@@ -59,8 +61,12 @@ const CreatePersonalToken = memo(() => {
   }, [formik.values]);
 
   const onCancel = useCallback(() => {
-    navigate(-1);
-  }, [navigate]);
+    setWantToCancel(true);
+  }, []);
+
+  useEffect(() => {
+    if (wantToCancel) navigate(-1);
+  }, [navigate, wantToCancel]);
 
   const onChangeExpiration = useCallback(
     event => {
@@ -71,7 +77,7 @@ const CreatePersonalToken = memo(() => {
   );
 
   useNavBlocker({
-    blockCondition: !data.uuid && hasChanged,
+    blockCondition: !data.uuid && hasChanged && !wantToCancel,
   });
 
   const styles = createPersonalTokenStyles();
@@ -90,7 +96,7 @@ const CreatePersonalToken = memo(() => {
               placement="bottom"
             >
               <Box component="span">
-                <MuiButton
+                <Button.BaseBtn
                   variant="elitea"
                   color="primary"
                   disabled={!formik.values.name || isGenerating || !!data.uuid}
@@ -103,7 +109,7 @@ const CreatePersonalToken = memo(() => {
                       sx={styles.loadingIndicator}
                     />
                   )}
-                </MuiButton>
+                </Button.BaseBtn>
               </Box>
             </Tooltip>
             <Button.DiscardButton

--- a/src/[fsd]/shared/ui/button/DiscardButton.jsx
+++ b/src/[fsd]/shared/ui/button/DiscardButton.jsx
@@ -2,9 +2,9 @@ import { memo, useCallback, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { Button } from '@mui/material';
-
 import AlertDialog from '@/components/AlertDialog';
+
+import BaseBtn from './BaseBtn';
 
 const DiscardButton = memo(props => {
   const {
@@ -31,14 +31,14 @@ const DiscardButton = memo(props => {
 
   return (
     <>
-      <Button
+      <BaseBtn
         disabled={disabled || isSaving}
         variant="elitea"
         color={color}
         onClick={() => setOpenAlert(true)}
       >
         {title}
-      </Button>
+      </BaseBtn>
       <AlertDialog
         alarm
         title="Warning"

--- a/src/[fsd]/shared/ui/button/index.js
+++ b/src/[fsd]/shared/ui/button/index.js
@@ -1,3 +1,4 @@
+export { default as BaseBtn } from './BaseBtn';
 export { default as OneClickButton } from './OneClickButton';
 export { default as DiscardButton } from './DiscardButton';
 export { default as CopyToClipboardButton } from './CopyToClipboardButton';


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4842

## Summary of Changes

### 1. CreatePersonalToken.jsx — Navigation Blocker Fix
**File:** `EliteaUI/src/[fsd]/pages/settings/CreatePersonalToken.jsx`
**Changes:**
- Added `wantToCancel` state flag
- Changed `onCancel` handler to set flag instead of calling `navigate()` directly
- Added `useEffect` to perform navigation when `wantToCancel` becomes true
- Updated `blockCondition` to include `&& !wantToCancel`

**Why:** Fix double-dialog issue (GitHub #4842) — Discard button showed UnsavedDialog twice due to race condition between Redux state update and `useBlocker` ref timing

### 2. CreatePersonalToken.jsx — Button Migration
**File:** `EliteaUI/src/[fsd]/pages/settings/CreatePersonalToken.jsx`
**Changes:** Replaced `MuiButton` with `Button.BaseBtn`; removed MUI Button import
**Why:** Consistent usage of custom button component across the project

### 3. DiscardButton.jsx
**File:** `EliteaUI/src/[fsd]/shared/ui/button/DiscardButton.jsx`
**Changes:** Replaced `Button` from `@mui/material` with `BaseBtn` from `./BaseBtn`
**Why:** Migrate from direct MUI import to custom wrapper component

### 4. button/index.js
**File:** `EliteaUI/src/[fsd]/shared/ui/button/index.js`
**Changes:** Added `export { default as BaseBtn } from './BaseBtn'`
**Why:** Enable `Button.BaseBtn` access through the shared/ui barrel export

<img width="1409" height="956" alt="image" src="https://github.com/user-attachments/assets/97f2a4a9-9ba0-42d2-bec3-a01ac87cda77" />
