### PR TITLE
feat: [EL-4374] show Conversation not found dialog for inaccessible chat URLs

### DIFF
--- a/src/components/AlertDialog.jsx
+++ b/src/components/AlertDialog.jsx
@@ -60,17 +60,20 @@ export default function AlertDialog({
         </StyledDialogContentText>
       </DialogContent>
       <StyledDialogActions>
+        {cancelButtonText && (
+          <Button
+            variant="elitea"
+            color="secondary"
+            onClick={onCancel}
+            autoFocus
+            disableRipple
+          >
+            {cancelButtonText}
+          </Button>
+        )}
         <Button
-          variant="elitea"
-          color="secondary"
-          onClick={onCancel}
-          autoFocus
           disableRipple
-        >
-          {cancelButtonText}
-        </Button>
-        <Button
-          disableRipple
+          autoFocus={!cancelButtonText}
           variant="elitea"
           color={alarm ? 'alarm' : 'primary'}
           onClick={onConfirm}

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -118,6 +118,7 @@ const NewChat = props => {
 
   const [activeFolder, setActiveFolder] = useState(dummyFolder);
   const [folders, setFolders] = useState([]);
+  const [conversationNotFound, setConversationNotFound] = useState(false);
   const isPlayback = useMemo(() => activeConversation?.isPlayback, [activeConversation]);
   const isNewConversation = useMemo(
     () =>
@@ -306,6 +307,11 @@ const NewChat = props => {
 
   const { conversationIdFromUrl, clearUrlConversation, changeUrlByConversation } =
     useConversationNavigation();
+
+  const handleNotFoundAcknowledge = useCallback(() => {
+    setConversationNotFound(false);
+    clearUrlConversation();
+  }, [clearUrlConversation]);
 
   const interaction_uuid = useChatInteractionUUID(activeConversation?.id);
   const { listenCanvasEditorsChangeEvent, stopListenCanvasEditorsChangeEvent } = useChatCanvasEditorsChange({
@@ -563,6 +569,7 @@ const NewChat = props => {
       isCreatingConversation ||
       activeConversation?.isNew ||
       activeConversation?.id ||
+      Boolean(conversationIdFromUrl) ||
       Boolean(searchParams.get(SearchParams.SharedChat)),
   });
 
@@ -939,13 +946,22 @@ const NewChat = props => {
   );
 
   useEffect(() => {
+    if (!conversationIdFromUrl) {
+      setConversationNotFound(false);
+      return;
+    }
     const folderConversations = folders?.map(folder => folder.conversations) || [];
     const conversationList = [...conversations, ...folderConversations.flat()];
     const conversationFromUrl = conversationList.find(
       conversation => conversation.id == conversationIdFromUrl,
     );
-    if (!isLoadMoreConversations && conversationIdFromUrl && conversationFromUrl && !activeConversation?.id) {
-      onSelectConversation(conversationFromUrl);
+    if (!isLoadMoreConversations) {
+      if (conversationFromUrl && !activeConversation?.id) {
+        setConversationNotFound(false);
+        onSelectConversation(conversationFromUrl);
+      } else if (!conversationFromUrl && !activeConversation?.id) {
+        setConversationNotFound(true);
+      }
     }
   }, [
     activeConversation?.id,
@@ -1489,6 +1505,15 @@ const NewChat = props => {
         onCancel={handleVersionChangeCancel}
         onConfirm={handleVersionChangeConfirm}
         confirmButtonText="Discard Changes"
+      />
+      <AlertDialog
+        open={conversationNotFound}
+        title="Conversation not found"
+        alertContent="The conversation you are looking for does not exist in your project or you don't have access to it. For sharing links, please use the Share option in the conversation menu."
+        confirmButtonText="Got it"
+        cancelButtonText=""
+        onClose={handleNotFoundAcknowledge}
+        onConfirm={handleNotFoundAcknowledge}
       />
     </>
   );


### PR DESCRIPTION


- Add conversationNotFound state to detect unresolvable conversation IDs in URL
- Skip selectConversationIfNeeded auto-redirect when conversationIdFromUrl is set, preventing URL from changing before not-found detection runs
- Rewrite conversationIdFromUrl useEffect: reset state when no ID in URL, set not-found when loading is done and conversation is absent from user's list
- Add AlertDialog (single "Got it" button) shown when conversation is not found; on confirm clears URL and triggers redirect to user's last available chat
- Make AlertDialog cancel button conditional on cancelButtonText; confirm button receives autoFocus when cancel is hidden (keyboard accessibility)

<img width="1204" height="652" alt="image" src="https://github.com/user-attachments/assets/dd330553-5f4b-4787-b2f2-5861a25f428d" />

## Summary

When a user opens a direct chat URL (e.g. a copied link) pointing to a conversation they do not have access to
or that no longer exists, the app previously silently redirected them to their last active chat with no
explanation.

This PR shows a **"Conversation not found"** warning dialog instead, informing the user of the issue. Clicking
**Got it** dismisses the dialog and redirects to their last available chat.

## Changes

### `src/pages/NewChat/NewChat.jsx`

- **`conversationNotFound` state** — tracks whether the URL points to an inaccessible or non-existent
  conversation.
- **`skipSetConversation` updated** — added `Boolean(conversationIdFromUrl)` so that `useQueryFoldersList`
  does not auto-redirect to the last selected conversation while a specific conversation ID is present in the
  URL.
- **`conversationIdFromUrl` `useEffect` rewritten**:
  - Resets `conversationNotFound` when no ID is in the URL.
  - Sets `conversationNotFound = true` once loading completes and the conversation is not found in the user's
    list.
  - Selects the conversation normally when it is found.
- **`handleNotFoundAcknowledge`** — callback that clears the not-found state and calls
  `clearUrlConversation()`, which triggers the standard redirect to the last available chat.
- **`AlertDialog`** added at the bottom of the render tree, shown when `conversationNotFound` is `true`.
  Single "Got it" button; all close paths (button click, Escape, backdrop click) call
  `handleNotFoundAcknowledge`.

### `src/components/AlertDialog.jsx`

- Cancel button is now **conditionally rendered** — only shown when `cancelButtonText` is truthy. Passing
  `cancelButtonText=""` produces a single-button dialog without breaking existing usages (all pass the default
  `'Cancel'`).
- Confirm button receives **`autoFocus`** when the cancel button is hidden, preserving keyboard accessibility.

## Behaviour

| Scenario                                           | Before                          | After                                                                    |
| -------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------ |
| URL with valid conversation ID                     | Opens conversation              | Opens conversation (unchanged)                                           |
| URL with inaccessible/deleted conversation ID      | Silently redirects to last chat | Shows "Conversation not found" dialog; on dismiss redirects to last chat |
| URL with `?shared_chat=1` (existing share feature) | Already handled separately      | Unchanged                                                                |

## Testing

1. Copy a chat URL from a project you have access to.
2. Open it in a browser logged in a different project (or after the conversation is deleted).
3. Verify the **"Conversation not found"** dialog appears with the correct message.
4. Click **Got it** — dialog closes and you are redirected to your last chat.
5. Verify that opening a valid chat URL still works as before.

