### PR TITLE
fix: [EL-4860] Fixed navigate to first page after clicking a new secret row

### DIFF
--- a/src/[fsd]/features/settings/ui/secrets/SecretsContent.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/SecretsContent.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSelector } from 'react-redux';
 import { useLocation, useSearchParams } from 'react-router-dom';
@@ -22,10 +22,6 @@ const SecretsContent = memo(() => {
   const sideBarCollapsed = useSelector(state => state.settings.sideBarCollapsed);
   const [search, setSearch] = useState('');
   const [rowModesModel, setRowModesModel] = useState({});
-  const [pageModel, setPageModel] = useState({
-    page: 0,
-    pageSize: 100,
-  });
   const [forceRender, setForceRender] = useState(0);
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -35,6 +31,7 @@ const SecretsContent = memo(() => {
 
   const [secretRows, setSecretRows] = useState([]);
   const { toastError } = useToast();
+  const resetPaginationRef = useRef(null);
 
   const {
     data: secrets = [],
@@ -75,7 +72,6 @@ const SecretsContent = memo(() => {
   // If navigated with ?createSecret=1, trigger creation of a new secret row
   useEffect(() => {
     if (shouldCreate) {
-      // Simulate AddSecretButton click by focusing a new row at current pagination start
       const id = `new-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
       let newRowId;
       setSecretRows(oldRows => {
@@ -84,38 +80,27 @@ const SecretsContent = memo(() => {
           const existingRows = [...oldRows];
           newRowId = oldRows[newRowIndex].id;
           existingRows.splice(newRowIndex, 1);
-          return [
-            ...existingRows.slice(0, pageModel.page * pageModel.pageSize),
-            oldRows[newRowIndex],
-            ...existingRows.slice(pageModel.page * pageModel.pageSize),
-          ];
+          return [oldRows[newRowIndex], ...existingRows];
         }
-        return [
-          ...oldRows.slice(0, pageModel.page * pageModel.pageSize),
-          { id, name: '', isNew: true },
-          ...oldRows.slice(pageModel.page * pageModel.pageSize),
-        ];
+        return [{ id, name: '', isNew: true }, ...oldRows];
       });
       setRowModesModel(oldModel => ({
         ...oldModel,
         [newRowId || id]: { mode: GridRowModes.Edit, fieldToFocus: 'name' },
       }));
+      resetPaginationRef.current?.();
       // Remove the flag from URL to avoid re-triggering
       const newParams = new URLSearchParams(location.search);
       newParams.delete('createSecret');
       setSearchParams(newParams, { replace: true });
     }
-  }, [location.search, pageModel.page, pageModel.pageSize, setSearchParams, shouldCreate]);
+  }, [location.search, setSearchParams, shouldCreate]);
 
   useEffect(() => {
     if (isError) {
       toastError(error?.status === 403 ? 'The access is not allowed' : buildErrorMessage(error));
     }
   }, [error, isError, toastError]);
-
-  const onPaginationModelChange = useCallback(newPageModel => {
-    setPageModel(newPageModel);
-  }, []);
 
   // Force re-render when sidebar state changes
   useEffect(() => {
@@ -128,7 +113,7 @@ const SecretsContent = memo(() => {
   }, [sideBarCollapsed]);
 
   const addSecretRow = useCallback(() => {
-    const id = `new-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`; // More stable ID for new rows
+    const id = `new-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
     let newRowId = undefined;
     setSecretRows(oldRows => {
       const newRowIndex = oldRows.findIndex(row => row.isNew);
@@ -136,23 +121,16 @@ const SecretsContent = memo(() => {
         const existingRows = [...oldRows];
         newRowId = oldRows[newRowIndex].id;
         existingRows.splice(newRowIndex, 1);
-        return [
-          ...existingRows.slice(0, pageModel.page * pageModel.pageSize),
-          oldRows[newRowIndex],
-          ...existingRows.slice(pageModel.page * pageModel.pageSize),
-        ];
+        return [oldRows[newRowIndex], ...existingRows];
       }
-      return [
-        ...oldRows.slice(0, pageModel.page * pageModel.pageSize),
-        { id, name: '', isNew: true },
-        ...oldRows.slice(pageModel.page * pageModel.pageSize),
-      ];
+      return [{ id, name: '', isNew: true }, ...oldRows];
     });
     setRowModesModel(oldModel => ({
       ...oldModel,
       [newRowId || id]: { mode: GridRowModes.Edit, fieldToFocus: 'name' },
     }));
-  }, [pageModel.page, pageModel.pageSize, setRowModesModel, setSecretRows]);
+    resetPaginationRef.current?.();
+  }, []);
 
   return (
     <>
@@ -187,8 +165,9 @@ const SecretsContent = memo(() => {
             isFetching={isFetching}
             refetch={refetch}
             projectId={projectId}
-            onPaginationModelChange={onPaginationModelChange}
-            pageModel={pageModel}
+            onResetPaginationReady={fn => {
+              resetPaginationRef.current = fn;
+            }}
           />
         </Box>
       </Box>

--- a/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
@@ -56,7 +56,16 @@ const SECRETS_COLUMNS = [
 ];
 
 const SecretsTable = memo(props => {
-  const { isFetching, rows, setRows, setRowModesModel, rowModesModel, projectId, refetch } = props;
+  const {
+    isFetching,
+    rows,
+    setRows,
+    setRowModesModel,
+    rowModesModel,
+    projectId,
+    refetch,
+    onResetPaginationReady,
+  } = props;
 
   const { windowWidth } = useGetWindowWidth();
   const isSafariBrowser = isSafari();
@@ -146,7 +155,11 @@ const SecretsTable = memo(props => {
     pageSizeOptions: SECRETS_TABLE_CONFIG.PAGE_SIZE_OPTIONS,
   });
 
-  const { paginateData } = pagination;
+  const { paginateData, handlePageChange } = pagination;
+
+  useEffect(() => {
+    onResetPaginationReady?.(() => handlePageChange(0));
+  }, [onResetPaginationReady, handlePageChange]);
   const paginatedRows = useMemo(() => paginateData(sortedRows), [paginateData, sortedRows]);
 
   // Custom hooks for business logic


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4860

## Files Changed

| File | Changes |
|------|---------|
| SecretsContent.jsx | Added `useRef` to store pagination callback; removed unused `pageModel` state; pass `onResetPaginationReady` to SecretsTable; call `resetPaginationRef.current()` when adding new row |
| SecretsTable.jsx | Accept `onResetPaginationReady` prop; expose `handlePageChange(0)` to parent via useEffect |

## Root Cause

**`pageModel` prop from parent was completely ignored.** SecretsTable uses its own internal `usePagination` hook with independent state — the `pageModel` and `onPaginationModelChange` props passed from SecretsContent were never consumed.

## What Was Done

1. **Removed dead code** — `pageModel` state and `onPaginationModelChange` callback in SecretsContent were unused
2. **Created callback bridge** — `onResetPaginationReady` passes `handlePageChange(0)` function from child to parent
3. **Navigate to first page on add** — When user clicks "+", `handlePageChange(0)` is called to show page 1 while preserving current `pageSize`
4. **Fixed deprecated API** — Changed `substr(2, 9)` to `slice(2, 11)`

## Why

**Problem:** When on page 2+ and clicking "Create new secret", the new input row was inserted at the beginning of the data array, but the DataGrid stayed on the current page — user had to manually navigate back to page 1 to see the input.

**Solution:** Automatically navigate to page 0 when adding a new secret row, so the user immediately sees the input field.

<img width="1403" height="995" alt="Screenshot 2026-05-06 162314" src="https://github.com/user-attachments/assets/e807023c-f6ef-40e3-b149-5b85bc333bfc" />
<img width="1409" height="1005" alt="Screenshot 2026-05-06 162319" src="https://github.com/user-attachments/assets/008f456b-7bc1-4572-a0ea-4e39b727986c" />

