### PR TITLE
feat: [EL-4698] show not-found dialog for deleted index and bucket URLs

### DIFF
--- a/src/[fsd]/features/toolkits/indexes/ui/IndexesContainer.jsx
+++ b/src/[fsd]/features/toolkits/indexes/ui/IndexesContainer.jsx
@@ -20,6 +20,7 @@ import { actions, selectIndexesList } from '@/[fsd]/features/toolkits/indexes/mo
 import { IndexDetails, IndexesList } from '@/[fsd]/features/toolkits/indexes/ui';
 import { Modal } from '@/[fsd]/shared/ui';
 import { SearchParams } from '@/common/constants';
+import AlertDialog from '@/components/AlertDialog';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 
@@ -52,6 +53,7 @@ const IndexesContainer = memo(props => {
   const [currentIndex, setCurrentIndex] = useState(null);
 
   const [deleteIndexModal, setDeleteIndexModal] = useState(false);
+  const [indexNotFoundOpen, setIndexNotFoundOpen] = useState(false);
 
   const { data: indexesList, isLoading, isFetching } = useSelector(selectIndexesList);
 
@@ -63,13 +65,16 @@ const IndexesContainer = memo(props => {
 
     const targetIndex = indexesList.find(idx => idx.metadata?.collection === indexNameFromUrl);
 
-    if (targetIndex) {
-      setCurrentIndex(targetIndex);
-      hasSelectedFromUrlRef.current = true;
+    hasSelectedFromUrlRef.current = true;
 
+    if (targetIndex) {
       const newSearchParams = new URLSearchParams(searchParams);
       newSearchParams.delete(SearchParams.IndexName);
       setSearchParams(newSearchParams, { replace: true });
+      setCurrentIndex(targetIndex);
+    } else {
+      // Keep URL until user dismisses the dialog so they can see which item is missing
+      setIndexNotFoundOpen(true);
     }
   }, [indexNameFromUrl, indexesList, isLoading, isFetching, searchParams, setSearchParams]);
 
@@ -150,6 +155,12 @@ const IndexesContainer = memo(props => {
   }, [refetch, toolkitId, projectId]);
 
   const closeDeleteIndexModal = () => setDeleteIndexModal(false);
+  const handleCloseIndexNotFound = useCallback(() => {
+    setIndexNotFoundOpen(false);
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.delete(SearchParams.IndexName);
+    setSearchParams(newSearchParams, { replace: true });
+  }, [searchParams, setSearchParams]);
   const handleDeleteIndex = useCallback(() => setDeleteIndexModal(true), []);
 
   const confirmIndexDeleting = useCallback(async () => {
@@ -205,6 +216,15 @@ const IndexesContainer = memo(props => {
           onConfirm={confirmIndexDeleting}
         />
       )}
+      <AlertDialog
+        open={indexNotFoundOpen}
+        title="Item no longer exists"
+        alertContent="This item was deleted and can't be opened."
+        confirmButtonText="Got it"
+        cancelButtonText=""
+        onClose={handleCloseIndexNotFound}
+        onConfirm={handleCloseIndexNotFound}
+      />
     </Box>
   );
 });

--- a/src/pages/Artifacts/Artifacts.jsx
+++ b/src/pages/Artifacts/Artifacts.jsx
@@ -55,6 +55,8 @@ export default function Artifacts() {
   const sideBarCollapsed = useSelector(state => state.settings.sideBarCollapsed);
 
   const [showUnsavedChangesAlert, setShowUnsavedChangesAlert] = useState(false);
+  const [bucketNotFoundOpen, setBucketNotFoundOpen] = useState(false);
+  const [notFoundBucketName, setNotFoundBucketName] = useState('');
   const [pendingFileSelection, setPendingFileSelection] = useState(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
@@ -410,6 +412,12 @@ export default function Artifacts() {
     setPendingFileSelection(null);
   }, []);
 
+  const handleCloseBucketNotFound = useCallback(() => {
+    setBucketNotFoundOpen(false);
+    setNotFoundBucketName('');
+    setSearchParams({});
+  }, [setSearchParams]);
+
   const [isHandlingNavigationState, setIsHandlingNavigationState] = useState(false);
 
   // Calculate available table width for responsive column management
@@ -467,9 +475,16 @@ export default function Artifacts() {
         const bucketFromUrl = searchParams.get('bucket');
         if (bucketFromUrl) {
           bucketToSelect = allBuckets.find(b => b.name === bucketFromUrl);
+
+          // Bucket from URL not found — show dialog, keep URL until user dismisses
+          if (!bucketToSelect) {
+            setNotFoundBucketName(bucketFromUrl);
+            setBucketNotFoundOpen(true);
+            return;
+          }
         }
 
-        // Fallback: select most recent if URL bucket not found
+        // Fallback: select most recent if no bucket in URL
         if (!bucketToSelect) {
           const sortedBuckets = sortBucketsByRecent(allBuckets);
           bucketToSelect = sortedBuckets[0];
@@ -688,6 +703,16 @@ export default function Artifacts() {
         onClose={handleUnsavedChangesCancel}
         onCancel={handleUnsavedChangesCancel}
         onConfirm={handleUnsavedChangesConfirm}
+      />
+
+      <AlertDialog
+        open={bucketNotFoundOpen}
+        title="Bucket not found"
+        alertContent={`The bucket "${notFoundBucketName}" no longer exists or you don't have access to it.`}
+        confirmButtonText="Got it"
+        cancelButtonText=""
+        onClose={handleCloseBucketNotFound}
+        onConfirm={handleCloseBucketNotFound}
       />
 
       <AlertDialogV2


### PR DESCRIPTION
- Show AlertDialog when index_name URL param does not match any loaded index in IndexesContainer (e.g. from notification deep-link)
- Show AlertDialog when bucket URL param does not match any loaded bucket in Artifacts page (e.g. from notification deep-link)
- Keep URL unchanged while dialog is open so user can see which item is missing; clear it only on dismiss
- Use bucket name in dialog message for better context



**Description:** When navigating to an artifact bucket or toolkit index via a deep-link (e.g. from a
notification) that no longer exists, users now see a clear dialog instead of a silent fallback selection.




<img width="1158" height="654" alt="Image" src="https://github.com/user-attachments/assets/00432fd9-de7d-4749-b57e-93ed64dd5cec" />

<img width="1165" height="662" alt="Image" src="https://github.com/user-attachments/assets/11b5f5ff-6034-445b-96f7-c8314e635438" />