### PR TITLE
feat: [EL-4167] handle ChatUserMentioned notification and scroll to message

### DIFF
--- a/src/[fsd]/entities/notifications/lib/helpers/notification.helpers.js
+++ b/src/[fsd]/entities/notifications/lib/helpers/notification.helpers.js
@@ -14,10 +14,14 @@ export const resolveHref = (eventType, meta, projectId) => {
     case NotificationType.PersonalAccessTokenExpiring:
       return `${base}${RouteDefinitions.SettingsWithTab.replace(':tab', 'tokens')}`;
 
-    case NotificationType.ChatUserAdded: {
+    case NotificationType.ChatUserAdded:
+    case NotificationType.ChatUserMentioned: {
       const convId = meta?.conversation_id;
+      const messageId = meta?.message_id;
       const route = `${base}/${projectId}${RouteDefinitions.Chat}`;
-      return convId ? `${route}?${SearchParams.Conversation}=${convId}` : route;
+      if (!convId) return route;
+      const url = `${route}?${SearchParams.Conversation}=${convId}`;
+      return messageId ? `${url}&${SearchParams.MessageId}=${messageId}` : url;
     }
 
     case NotificationType.IndexDataChanged: {

--- a/src/components/Chat/ChatMessageList.jsx
+++ b/src/components/Chat/ChatMessageList.jsx
@@ -11,7 +11,7 @@ import ApplicationAnswer from '@/components/Chat/ApplicationAnswer';
 import { MessageList } from '@/components/Chat/StyledComponents';
 import UserMessage from '@/components/Chat/UserMessage';
 import { isParticipantStillActive } from '@/hooks/chat/useParticipantName';
-import { actions as chatActions } from '@/slices/chat';
+import { actions as chatActions, selectMessageIdToView } from '@/slices/chat';
 
 const isEditAPIReady = false;
 
@@ -48,6 +48,7 @@ const ChatMessageList = memo(props => {
   const listRef = useRef();
   const listRefs = useRef([]);
   const messagesEndRef = useRef();
+  const messageIdToView = useSelector(selectMessageIdToView);
 
   // Simplified autoscroll: scroll new message to top of viewport
   const [bottomSpacer, setBottomSpacer] = useState(0);
@@ -116,6 +117,15 @@ const ChatMessageList = memo(props => {
       messagesEndRef.current?.scrollIntoView({ block: 'end' });
     }
   }, [activeConversation?.id, askingQuestionId]);
+
+  useEffect(() => {
+    if (!messageIdToView || !chat_history?.length) return;
+    const index = chat_history.findIndex(msg => msg.id === messageIdToView || msg.uuid === messageIdToView);
+    if (index !== -1) {
+      listRefs.current[index]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      dispatch(chatActions.setMessageIdToView({ messageIdToView: '' }));
+    }
+  }, [messageIdToView, chat_history, dispatch]);
 
   useEffect(() => {
     const scrollEl = listRef.current?.getScrollElement();

--- a/src/components/NotificationListItem.jsx
+++ b/src/components/NotificationListItem.jsx
@@ -25,6 +25,7 @@ export const getIcon = (type, theme, notification) => {
     case NotificationType.PromptOfSomeProjectWasPublished:
     case NotificationType.NewPromptVersionOfSomeProjectWasPublished:
     case NotificationType.ChatUserAdded:
+    case NotificationType.ChatUserMentioned:
     case NotificationType.PrivateProjectCreated:
       return <SuccessIcon fill={theme.palette.status.published} />;
 

--- a/src/hooks/chat/useHighlightUserMessage.js
+++ b/src/hooks/chat/useHighlightUserMessage.js
@@ -4,13 +4,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useMatch } from 'react-router-dom';
 
 import RouteDefinitions from '@/routes';
-import { actions as chatActions } from '@/slices/chat';
+import { actions as chatActions, selectMessageIdToView } from '@/slices/chat';
 
 const HIGHLIGHT_DURATION = 2000;
 
 const useHighlightUserMessage = messageId => {
   const dispatch = useDispatch();
-  const messageIdToView = useSelector(state => state.chat.messageIdToView);
+  const messageIdToView = useSelector(selectMessageIdToView);
   const [highLightMe, setHighLightMe] = useState(false);
   const isChatPage = useMatch({ path: RouteDefinitions.ChatConversation });
 

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -975,6 +975,14 @@ const NewChat = props => {
     onSelectConversation,
   ]);
 
+  const messageIdFromUrl = searchParams.get(SearchParams.MessageId);
+
+  useEffect(() => {
+    if (messageIdFromUrl && activeConversation?.id) {
+      dispatch(chatActions.setMessageIdToView({ messageIdToView: messageIdFromUrl }));
+    }
+  }, [activeConversation?.id, dispatch, messageIdFromUrl]);
+
   const onParticipantsCollapsed = useCallback(() => {
     setCollapsedParticipants(prev => !prev);
   }, []);

--- a/src/slices/chat.js
+++ b/src/slices/chat.js
@@ -64,3 +64,5 @@ const chatSlice = createSlice({
 
 export const { name, actions } = chatSlice;
 export default chatSlice.reducer;
+
+export const selectMessageIdToView = state => state.chat.messageIdToView;


### PR DESCRIPTION
<img width="1191" height="707" alt="image" src="https://github.com/user-attachments/assets/b306ff6b-ff5f-426e-863b-df9e115c810a" />

## What

- Notification links for `ChatUserMentioned` events now navigate directly to the specific message in the
  conversation (via `?message_id=` query param).
- When the conversation loads, the chat list automatically scrolls to that message.

## Changes

### `src/[fsd]/entities/notifications/lib/helpers/notification.helpers.js`

- Added `ChatUserMentioned` as a handled case alongside `ChatUserAdded`.
- Built the notification link with both `conversation_id` and `message_id` params when available.

### `src/components/Chat/ChatMessageList.jsx`

- Read `messageIdToView` via `selectMessageIdToView` selector.
- Added `useEffect` to scroll the target message into view (smooth, centered) once chat history is loaded.
- Clears `messageIdToView` immediately after scrolling to prevent re-triggering on subsequent `chat_history`
  updates during streaming.

### `src/hooks/chat/useHighlightUserMessage.js`

- Switched from inline `state => state.chat.messageIdToView` selector to the shared `selectMessageIdToView`.

### `src/slices/chat.js`

- Exported `selectMessageIdToView` selector so all consumers use a single, stable selector reference.

### `src/components/NotificationListItem.jsx`

- Added `ChatUserMentioned` to the success-icon case so the notification renders with the correct icon.

### `src/pages/NewChat/NewChat.jsx`

- Added `useEffect` to read `message_id` from the URL and dispatch `setMessageIdToView` once the active
  conversation is set.

## Testing

1. Tag a user in a chat message.
2. Open the notification — the conversation should open and scroll to the tagged message.
