### PR TITLE
fix(chat): [EL-4164] display fallback message when error content is empty

### DIFF
--- a/src/components/Chat/ApplicationAnswer.jsx
+++ b/src/components/Chat/ApplicationAnswer.jsx
@@ -553,7 +553,7 @@ const ApplicationAnswer = React.forwardRef((props, ref) => {
               )}
               {!!exception && (
                 <>
-                  <Box sx={styles.errorWrapper}>{realAnswer}</Box>
+                  <Box sx={styles.errorWrapper}>{realAnswer || 'Unknown error'}</Box>
 
                   {realAnswer !== exception && (
                     <Box sx={styles.errorStackTrace}>


### PR DESCRIPTION
Show "Unknown error" in the error box when the error message is undefined or empty. Detailed error information remains accessible in the "Error debugging info" dropdown.