### PR TITLE
feat: [EL-4770] add application request catalog

### DIFF
--- a/src/[fsd]/app/routes/ProtectedRoutes.jsx
+++ b/src/[fsd]/app/routes/ProtectedRoutes.jsx
@@ -23,6 +23,7 @@ import { useLazyPermissionListQuery, useLazyPublicPermissionListQuery } from '@/
 import { useLazyAuthorDetailsQuery } from '@/api/social.js';
 import {
   ApplicationsTabs,
+  AppsTabs,
   CredentialsTabs,
   MISSING_ENVS,
   ModerationTabs,
@@ -178,7 +179,7 @@ const ProtectedRoutes = () => {
       { path: RouteDefinitions.MCPDetail, element: <EditToolkit isMCP={true} /> },
 
       /* apps */
-      { path: RouteDefinitions.Apps, element: getIndexElement(ToolkitsTabs[0]) },
+      { path: RouteDefinitions.Apps, element: getIndexElement(AppsTabs[0]) },
       { path: RouteDefinitions.CreateApp, element: <CreateToolkit isApplication={true} /> },
       { path: RouteDefinitions.CreateAppType, element: <CreateToolkit isApplication={true} /> },
       { path: RouteDefinitions.AppsWithTab, element: <Apps /> },

--- a/src/[fsd]/features/apps/lib/constants/applicationCatalog.constants.js
+++ b/src/[fsd]/features/apps/lib/constants/applicationCatalog.constants.js
@@ -1,0 +1,26 @@
+export const APPLICATION_REQUEST_SUPPORT_EMAIL = 'SupportAlita@epam.com';
+
+export const APPLICATION_CATALOG = [
+  {
+    type: 'deepwiki_Deepwiki',
+    name: 'DeepWiki',
+    shortDescription:
+      'Generate searchable wiki pages from repository code and keep architecture context close to delivery work.',
+    description:
+      'DeepWiki turns a code repository into navigable documentation with architecture summaries, source-linked explanations, and project Q&A support.',
+    capabilities: ['Repository wiki generation', 'Architecture summaries', 'Code-aware Q&A'],
+    bestFor:
+      'Teams that need onboarding material, implementation context, or durable knowledge for active repositories.',
+  },
+  {
+    type: 'inventory',
+    name: 'Inventory',
+    shortDescription:
+      'Explore services, ownership, dependencies, and technical inventory across project repositories.',
+    description:
+      'Inventory helps teams inspect the code estate, map important components, and understand relationships before planning changes.',
+    capabilities: ['Component inventory', 'Dependency discovery', 'Ownership context'],
+    bestFor:
+      'Teams coordinating modernization, impact analysis, service discovery, or engineering governance.',
+  },
+];

--- a/src/[fsd]/features/apps/lib/hooks/index.js
+++ b/src/[fsd]/features/apps/lib/hooks/index.js
@@ -1,1 +1,2 @@
 export { useAppDetail } from './useAppDetail.hooks';
+export { useApplicationCatalogState } from './useApplicationCatalogState.hooks';

--- a/src/[fsd]/features/apps/lib/hooks/useApplicationCatalogState.hooks.js
+++ b/src/[fsd]/features/apps/lib/hooks/useApplicationCatalogState.hooks.js
@@ -12,6 +12,13 @@ import {
   APPLICATION_REQUEST_SUPPORT_EMAIL,
 } from '../constants/applicationCatalog.constants';
 
+const getApplicationStatusLabel = (isConfigured, canCreate) => {
+  if (isConfigured) return 'Configured';
+  if (canCreate) return 'Available';
+
+  return 'By request';
+};
+
 export const useApplicationCatalogState = () => {
   const theme = useTheme();
   const projectId = useSelectedProjectId();
@@ -43,7 +50,7 @@ export const useApplicationCatalogState = () => {
       const typeLabel = schema?.metadata?.label || application.name;
       const canCreate = Boolean(schema);
       const isConfigured = configuredTypes.has(application.type);
-      const statusLabel = canCreate ? 'Available' : isConfigured ? 'Configured' : 'By request';
+      const statusLabel = getApplicationStatusLabel(isConfigured, canCreate);
       const icon = getToolIconByType(application.type, theme, { toolSchema: schema, isAppAll: true });
 
       return {

--- a/src/[fsd]/features/apps/lib/hooks/useApplicationCatalogState.hooks.js
+++ b/src/[fsd]/features/apps/lib/hooks/useApplicationCatalogState.hooks.js
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+
+import { useTheme } from '@mui/material';
+
+import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
+import { useListToolkitTypesQuery } from '@/api/toolkits';
+import { getToolIconByType } from '@/common/toolkitUtils';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+
+import {
+  APPLICATION_CATALOG,
+  APPLICATION_REQUEST_SUPPORT_EMAIL,
+} from '../constants/applicationCatalog.constants';
+
+export const useApplicationCatalogState = () => {
+  const theme = useTheme();
+  const projectId = useSelectedProjectId();
+
+  const { toolkitSchemas, isFetching: isFetchingToolkitSchemas } = useGetCurrentToolkitSchemas();
+  const { data: configuredTypesData, isFetching: isFetchingConfiguredTypes } = useListToolkitTypesQuery(
+    { projectId, params: { application: true } },
+    { skip: !projectId },
+  );
+
+  const applicationSchemas = useMemo(() => {
+    return Object.entries(toolkitSchemas || {}).reduce((acc, [type, schema]) => {
+      if (schema?.metadata?.application === true) {
+        acc[type] = schema;
+      }
+
+      return acc;
+    }, {});
+  }, [toolkitSchemas]);
+
+  const configuredTypes = useMemo(
+    () => new Set(configuredTypesData?.rows || []),
+    [configuredTypesData?.rows],
+  );
+
+  const applications = useMemo(() => {
+    return APPLICATION_CATALOG.map(application => {
+      const schema = applicationSchemas[application.type];
+      const typeLabel = schema?.metadata?.label || application.name;
+      const canCreate = Boolean(schema);
+      const isConfigured = configuredTypes.has(application.type);
+      const statusLabel = canCreate ? 'Available' : isConfigured ? 'Configured' : 'By request';
+      const icon = getToolIconByType(application.type, theme, { toolSchema: schema, isAppAll: true });
+
+      return {
+        ...application,
+        id: application.type,
+        typeLabel,
+        schema,
+        description: application.shortDescription,
+        icon,
+        icon_meta: {
+          component: icon,
+        },
+        author: {
+          id: 'application-support',
+          name: 'EliteA Support',
+        },
+        tags: [
+          {
+            id: `${application.type}-status`,
+            name: statusLabel,
+          },
+          {
+            id: `${application.type}-type`,
+            name: typeLabel,
+          },
+        ],
+        canCreate,
+        canRequest: !canCreate && !isConfigured,
+        isConfigured,
+        statusLabel,
+        supportEmail: APPLICATION_REQUEST_SUPPORT_EMAIL,
+      };
+    });
+  }, [applicationSchemas, configuredTypes, theme]);
+
+  return {
+    applications,
+    isLoading: isFetchingToolkitSchemas || isFetchingConfiguredTypes,
+  };
+};

--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
@@ -1,0 +1,286 @@
+import { memo, useCallback, useState } from 'react';
+
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { Box, Typography } from '@mui/material';
+
+import { useApplicationCatalogState } from '@/[fsd]/features/apps/lib/hooks';
+import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
+import { AppsTabs, ContentType, URL_PARAMS_KEY_TAGS, ViewMode } from '@/common/constants';
+import EntityCard from '@/components/Card';
+import CardList from '@/components/CardList';
+import ArrowRightIcon from '@/components/Icons/ArrowRightIcon';
+import PlusIcon from '@/components/Icons/PlusIcon';
+import RouteDefinitions from '@/routes';
+
+import ApplicationDetailsModal from './ApplicationDetailsModal';
+import { applicationActionButtonStyles } from './applicationActionButton.styles';
+
+const APPLICATION_CATALOG_CARD_WIDTH = 'min(42rem, calc(100% - 1rem))';
+
+const ApplicationCatalog = memo(() => {
+  const styles = applicationCatalogStyles();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { applications, isLoading } = useApplicationCatalogState();
+  const [selectedApplication, setSelectedApplication] = useState(null);
+
+  const handleOpenDetails = useCallback(application => {
+    setSelectedApplication(application);
+  }, []);
+
+  const handleCloseDetails = useCallback(() => {
+    setSelectedApplication(null);
+  }, []);
+
+  const handleCreate = useCallback(
+    application => {
+      navigate(RouteDefinitions.CreateAppType.replace(':appType', application.type));
+    },
+    [navigate],
+  );
+
+  const handleViewConfigured = useCallback(
+    application => {
+      const searchParams = new URLSearchParams(location.search);
+      searchParams.delete(URL_PARAMS_KEY_TAGS);
+      searchParams.append(URL_PARAMS_KEY_TAGS, application.typeLabel);
+
+      navigate(
+        {
+          pathname: `${RouteDefinitions.Apps}/${AppsTabs[1]}`,
+          search: searchParams.toString(),
+        },
+        { state: location.state },
+      );
+    },
+    [location.search, location.state, navigate],
+  );
+
+  const handleCatalogTagClick = useCallback(event => {
+    event.stopPropagation();
+  }, []);
+
+  const handleLoadMore = useCallback(() => {}, []);
+
+  const renderApplicationCard = useCallback(
+    (application, cardType, index) => {
+      const handleCreateClick = event => {
+        event.stopPropagation();
+        handleCreate(application);
+      };
+
+      const handleViewConfiguredClick = event => {
+        event.stopPropagation();
+        handleViewConfigured(application);
+      };
+
+      return (
+        <EntityCard
+          data={application}
+          viewMode={ViewMode.Owner}
+          type={cardType}
+          index={index}
+          disableCardActions
+          hideCardBottom
+          customTagClickHandler={handleCatalogTagClick}
+          onCardClick={handleOpenDetails}
+          cardDetails={
+            <Box sx={styles.cardDetails}>
+              <Typography sx={styles.cardDescription}>{application.shortDescription}</Typography>
+
+              <Box sx={styles.cardMeta}>
+                <Typography sx={styles.metaText}>{application.typeLabel}</Typography>
+                <Box sx={styles.metaDivider} />
+                <Typography sx={styles.metaText}>{application.statusLabel}</Typography>
+              </Box>
+
+              <Box sx={styles.cardActions}>
+                {application.canCreate && (
+                  <BaseBtn
+                    variant={BUTTON_VARIANTS.contained}
+                    startIcon={<PlusIcon />}
+                    disabled={isLoading}
+                    sx={[styles.actionButton, styles.createActionButton]}
+                    onClick={handleCreateClick}
+                  >
+                    <Typography
+                      component="span"
+                      variant="labelSmall"
+                      sx={styles.actionButtonLabel}
+                    >
+                      Create App
+                    </Typography>
+                  </BaseBtn>
+                )}
+
+                {application.isConfigured && (
+                  <BaseBtn
+                    variant={BUTTON_VARIANTS.secondary}
+                    startIcon={<ArrowRightIcon />}
+                    sx={styles.actionButton}
+                    onClick={handleViewConfiguredClick}
+                  >
+                    <Typography
+                      component="span"
+                      variant="labelSmall"
+                      sx={styles.actionButtonLabel}
+                    >
+                      View Configured
+                    </Typography>
+                  </BaseBtn>
+                )}
+
+                {application.canRequest && (
+                  <Typography sx={styles.requestText}>
+                    Request through support at{' '}
+                    <Box
+                      component="span"
+                      sx={styles.supportEmail}
+                    >
+                      {application.supportEmail}
+                    </Box>
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+          }
+        />
+      );
+    },
+    [handleCatalogTagClick, handleCreate, handleOpenDetails, handleViewConfigured, isLoading, styles],
+  );
+
+  return (
+    <Box sx={styles.wrapper}>
+      <Box sx={styles.header}>
+        <Typography
+          component="h1"
+          variant="h5"
+          sx={styles.title}
+        >
+          Request an application
+        </Typography>
+        <Typography sx={styles.subtitle}>
+          Choose a ready application to configure for this project, or request access when it is not yet
+          available.
+        </Typography>
+      </Box>
+
+      <Box sx={styles.cards}>
+        <CardList
+          cardList={applications}
+          total={applications.length}
+          isLoading={isLoading}
+          isError={false}
+          renderCard={renderApplicationCard}
+          cardType={ContentType.AppAll}
+          loadMoreFunc={handleLoadMore}
+          isFullWidth
+          cardHeight="14rem"
+          cardWidthOverride={APPLICATION_CATALOG_CARD_WIDTH}
+          emptyListPlaceHolder={
+            <Typography component="span">No applications are available to request.</Typography>
+          }
+        />
+      </Box>
+
+      <ApplicationDetailsModal
+        open={Boolean(selectedApplication)}
+        application={selectedApplication}
+        isResolving={isLoading}
+        onClose={handleCloseDetails}
+        onCreate={handleCreate}
+        onViewConfigured={handleViewConfigured}
+      />
+    </Box>
+  );
+});
+
+ApplicationCatalog.displayName = 'ApplicationCatalog';
+
+/** @type {MuiSx} */
+const applicationCatalogStyles = () => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.5rem',
+    px: '1.5rem',
+    pt: '1rem',
+    pb: '2rem',
+  },
+  header: {
+    maxWidth: '48rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  title: ({ palette }) => ({
+    color: palette.text.primary,
+  }),
+  subtitle: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.875rem',
+    lineHeight: 1.5,
+  }),
+  cards: {
+    width: '100%',
+    ml: '-1.5rem',
+  },
+  cardDetails: {
+    minHeight: 0,
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    gap: '0.75rem',
+  },
+  cardDescription: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.8125rem',
+    lineHeight: 1.45,
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: '3',
+  }),
+  cardActions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '0.5rem',
+  },
+  ...applicationActionButtonStyles,
+  cardMeta: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    minWidth: 0,
+  },
+  metaText: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.75rem',
+    lineHeight: 1.35,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+  metaDivider: ({ palette }) => ({
+    width: '0.0625rem',
+    height: '0.875rem',
+    flexShrink: 0,
+    backgroundColor: palette.border.lines,
+  }),
+  requestText: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.8125rem',
+    lineHeight: 1.45,
+  }),
+  supportEmail: ({ palette }) => ({
+    color: palette.text.primary,
+    fontWeight: 600,
+    userSelect: 'text',
+  }),
+});
+
+export default ApplicationCatalog;

--- a/src/[fsd]/features/apps/ui/catalog/ApplicationDetailsModal.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationDetailsModal.jsx
@@ -1,0 +1,216 @@
+import { memo, useCallback } from 'react';
+
+import { Box, Chip, Typography } from '@mui/material';
+
+import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
+import BaseModal from '@/[fsd]/shared/ui/modal/BaseModal';
+import ArrowRightIcon from '@/components/Icons/ArrowRightIcon';
+import PlusIcon from '@/components/Icons/PlusIcon';
+
+import { applicationActionButtonStyles } from './applicationActionButton.styles';
+
+const ApplicationDetailsModal = memo(props => {
+  const { application, isResolving, onClose, onCreate, onViewConfigured, open } = props;
+  const styles = applicationDetailsModalStyles();
+
+  const handleCreate = useCallback(() => {
+    if (application) {
+      onCreate(application);
+    }
+  }, [application, onCreate]);
+
+  const handleViewConfigured = useCallback(() => {
+    if (application) {
+      onViewConfigured(application);
+    }
+  }, [application, onViewConfigured]);
+
+  if (!application) return null;
+
+  const hasActions = application.isConfigured || application.canCreate;
+
+  const content = (
+    <Box sx={styles.content}>
+      <Box sx={styles.summaryRow}>
+        <Box sx={styles.iconBox}>{application.icon}</Box>
+        <Box sx={styles.summaryText}>
+          <Typography sx={styles.description}>{application.description}</Typography>
+          <Typography sx={styles.bestFor}>{application.bestFor}</Typography>
+        </Box>
+      </Box>
+
+      <Box sx={styles.section}>
+        <Typography
+          component="h4"
+          variant="subtitle2"
+          sx={styles.sectionTitle}
+        >
+          What it includes
+        </Typography>
+        <Box sx={styles.capabilities}>
+          {application.capabilities.map(capability => (
+            <Chip
+              key={capability}
+              size="small"
+              label={capability}
+              sx={styles.capabilityChip}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      {application.canRequest && (
+        <Box sx={styles.requestInfo}>
+          <Typography sx={styles.requestText}>
+            To request this application for your environment, contact support at{' '}
+            <Box
+              component="span"
+              sx={styles.supportEmail}
+            >
+              {application.supportEmail}
+            </Box>
+            .
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+
+  const actions = hasActions ? (
+    <Box sx={styles.actions}>
+      {application.canCreate && (
+        <BaseBtn
+          variant={BUTTON_VARIANTS.contained}
+          startIcon={<PlusIcon />}
+          disabled={isResolving}
+          sx={[styles.actionButton, styles.createActionButton]}
+          onClick={handleCreate}
+        >
+          <Typography
+            component="span"
+            variant="labelSmall"
+            sx={styles.actionButtonLabel}
+          >
+            Create App
+          </Typography>
+        </BaseBtn>
+      )}
+
+      {application.isConfigured && (
+        <BaseBtn
+          variant={BUTTON_VARIANTS.secondary}
+          startIcon={<ArrowRightIcon />}
+          sx={styles.actionButton}
+          onClick={handleViewConfigured}
+        >
+          <Typography
+            component="span"
+            variant="labelSmall"
+            sx={styles.actionButtonLabel}
+          >
+            View Configured
+          </Typography>
+        </BaseBtn>
+      )}
+    </Box>
+  ) : null;
+
+  return (
+    <BaseModal
+      open={open}
+      title={application.name}
+      titleVariant="h5"
+      content={content}
+      actions={actions}
+      onClose={onClose}
+    />
+  );
+});
+
+ApplicationDetailsModal.displayName = 'ApplicationDetailsModal';
+
+/** @type {MuiSx} */
+const applicationDetailsModalStyles = () => ({
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.25rem',
+  },
+  summaryRow: {
+    display: 'flex',
+    gap: '1rem',
+  },
+  iconBox: ({ palette }) => ({
+    width: '3rem',
+    height: '3rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    borderRadius: '0.5rem',
+    backgroundColor: palette.background.secondary,
+    '& svg': {
+      width: '1.5rem',
+      height: '1.5rem',
+    },
+  }),
+  summaryText: {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+  },
+  description: ({ palette }) => ({
+    color: palette.text.primary,
+    lineHeight: 1.5,
+  }),
+  bestFor: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.875rem',
+    lineHeight: 1.45,
+  }),
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+  },
+  sectionTitle: ({ palette }) => ({
+    color: palette.text.primary,
+  }),
+  capabilities: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+  },
+  capabilityChip: ({ palette }) => ({
+    backgroundColor: palette.background.secondary,
+    color: palette.text.primary,
+  }),
+  actions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: '0.5rem',
+  },
+  ...applicationActionButtonStyles,
+  requestInfo: ({ palette }) => ({
+    borderRadius: '0.5rem',
+    backgroundColor: palette.background.tabPanel,
+    border: `0.0625rem solid ${palette.border.lines}`,
+    px: '0.875rem',
+    py: '0.75rem',
+  }),
+  requestText: ({ palette }) => ({
+    color: palette.text.secondary,
+    fontSize: '0.875rem',
+    lineHeight: 1.45,
+  }),
+  supportEmail: ({ palette }) => ({
+    color: palette.text.primary,
+    fontWeight: 600,
+    userSelect: 'text',
+  }),
+});
+
+export default ApplicationDetailsModal;

--- a/src/[fsd]/features/apps/ui/catalog/applicationActionButton.styles.js
+++ b/src/[fsd]/features/apps/ui/catalog/applicationActionButton.styles.js
@@ -1,0 +1,54 @@
+/** @type {MuiSx} */
+export const applicationActionButtonStyles = {
+  actionButton: {
+    height: '1.75rem',
+    minWidth: 'auto',
+    px: '0.75rem',
+    py: 0,
+    gap: '0.375rem',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    whiteSpace: 'nowrap',
+    '& .MuiButton-startIcon': {
+      margin: 0,
+      width: '1rem',
+      height: '1rem',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      lineHeight: 0,
+    },
+    '& .MuiButton-startIcon svg': {
+      display: 'block',
+    },
+  },
+  createActionButton: ({ palette }) => ({
+    color: palette.split.text.default,
+    background: palette.split.default,
+    '& .MuiButton-startIcon svg, & .MuiButton-startIcon path': {
+      fill: palette.text.createButton,
+    },
+    '&:hover': {
+      background: palette.split.hover,
+    },
+    '&:active': {
+      color: palette.split.text.pressed,
+      backgroundColor: palette.split.pressed,
+    },
+    '&.Mui-disabled': {
+      color: palette.split.text.disabled,
+      backgroundColor: palette.split.disabled,
+      '& .MuiButton-startIcon svg, & .MuiButton-startIcon path': {
+        fill: palette.text.disabled,
+      },
+    },
+  }),
+  actionButtonLabel: {
+    display: 'flex',
+    alignItems: 'center',
+    height: '1rem',
+    lineHeight: '1rem',
+  },
+};

--- a/src/[fsd]/features/apps/ui/catalog/index.js
+++ b/src/[fsd]/features/apps/ui/catalog/index.js
@@ -1,0 +1,1 @@
+export { default as ApplicationCatalog } from './ApplicationCatalog';

--- a/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
+++ b/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
@@ -25,6 +25,8 @@ const ToolkitsList = memo(props => {
   const {
     rightPanelOffset,
     cardContentType = ContentType.ToolkitAll,
+    disableEmptyRedirect = false,
+    emptyListPlaceHolder,
     isMCP = false,
     isApplication = false,
   } = props;
@@ -94,7 +96,15 @@ const ToolkitsList = memo(props => {
     const hasError = !!isToolkitsError;
     const hasQuery = !!(query && String(query).trim());
 
-    if (!isPublic && !loading && !hasError && !hasQuery && totalCount === 0 && selectedTypes?.length === 0) {
+    if (
+      !isPublic &&
+      !loading &&
+      !hasError &&
+      !disableEmptyRedirect &&
+      !hasQuery &&
+      totalCount === 0 &&
+      selectedTypes?.length === 0
+    ) {
       if (isApplication) {
         navigate(RouteDefinitions.CreateApp, { replace: true });
       } else {
@@ -110,6 +120,7 @@ const ToolkitsList = memo(props => {
     query,
     totalCount,
     navigate,
+    disableEmptyRedirect,
     isMCP,
     isApplication,
   ]);
@@ -173,10 +184,12 @@ const ToolkitsList = memo(props => {
       loadMoreFunc={loadMore}
       cardType={cardContentType}
       emptyListPlaceHolder={
-        <ToolkitsEmptyListPlaceHolder
-          query={query}
-          isMCP={isMCP}
-        />
+        emptyListPlaceHolder || (
+          <ToolkitsEmptyListPlaceHolder
+            query={query}
+            isMCP={isMCP}
+          />
+        )
       }
       setPage={setPage}
       page={page}

--- a/src/[fsd]/pages/apps/Apps.jsx
+++ b/src/[fsd]/pages/apps/Apps.jsx
@@ -1,33 +1,92 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+import { Typography } from '@mui/material';
+
+import { ApplicationCatalog } from '@/[fsd]/features/apps/ui/catalog';
 import ToolkitsList from '@/[fsd]/features/toolkits/ui/list/ToolkitsList';
-import { ContentType } from '@/common/constants';
+import { AppsTabs, ContentType } from '@/common/constants';
 import StickyTabs from '@/components/StickyTabs';
 import ViewToggle from '@/components/ViewToggle';
+import useShouldCollapseRightToolbar from '@/hooks/useShouldCollapseRightToolbar';
+import RouteDefinitions from '@/routes';
+
+const LEGACY_APPS_TABS = {
+  all: AppsTabs[1],
+};
+
+const APP_TAB_INDEX_BY_KEY = AppsTabs.reduce((acc, tab, index) => {
+  acc[tab] = index;
+  return acc;
+}, {});
+
+const CONFIGURED_APPS_EMPTY_PLACEHOLDER = (
+  <Typography component="span">
+    No configured applications yet. Use the Request App tab to request or create one for this project.
+  </Typography>
+);
 
 const Apps = memo(() => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { tab = AppsTabs[0] } = useParams();
+  const { shouldCollapseRightToolbar } = useShouldCollapseRightToolbar();
+
+  const normalizedTab =
+    LEGACY_APPS_TABS[tab] || (APP_TAB_INDEX_BY_KEY[tab] === undefined ? AppsTabs[0] : tab);
+  const selectedTab = APP_TAB_INDEX_BY_KEY[normalizedTab] ?? APP_TAB_INDEX_BY_KEY[AppsTabs[0]];
+  const isConfiguredTab = selectedTab === APP_TAB_INDEX_BY_KEY[AppsTabs[1]];
+
+  useEffect(() => {
+    if (normalizedTab === tab) return;
+
+    navigate(`${RouteDefinitions.Apps}/${normalizedTab}${location.search}`, {
+      replace: true,
+      state: location.state,
+    });
+  }, [location.search, location.state, navigate, normalizedTab, tab]);
+
+  const handleChangeTab = useCallback(
+    nextTabIndex => {
+      const nextTab = AppsTabs[nextTabIndex] || AppsTabs[0];
+      navigate(`${RouteDefinitions.Apps}/${nextTab}${location.search}`, {
+        state: location.state,
+      });
+    },
+    [location.search, location.state, navigate],
+  );
+
   const tabs = useMemo(
     () => [
       {
+        label: 'Request App',
+        content: <ApplicationCatalog />,
+      },
+      {
+        label: 'Configured',
         content: (
           <ToolkitsList
             isApplication={true}
             cardContentType={ContentType.AppAll}
+            disableEmptyRedirect={true}
+            emptyListPlaceHolder={CONFIGURED_APPS_EMPTY_PLACEHOLDER}
           />
         ),
       },
     ],
     [],
   );
+
   return (
     <StickyTabs
       tabs={tabs}
-      value={0}
-      showTitleAndSwitchBySelect
-      title="Apps"
+      value={selectedTab}
       containerStyle={{ padding: '0 1.5rem 0 0' }}
       tabBarStyle={{ padding: '0 0.5rem 0 1.5rem' }}
-      middleTabComponent={<ViewToggle />}
+      noRightPanel={!isConfiguredTab || shouldCollapseRightToolbar}
+      middleTabComponent={isConfiguredTab ? <ViewToggle /> : undefined}
+      onChangeTab={handleChangeTab}
     />
   );
 });

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -486,6 +486,7 @@ export const publicTabs = ['latest', 'my-liked', 'trending'];
 export const ModerationTabs = ['all', 'agents'];
 export const ApplicationsTabs = ['latest', 'my-liked', 'trending', 'admin'];
 export const ToolkitsTabs = ['all', 'my-liked', 'trending', 'admin'];
+export const AppsTabs = ['request', 'configured'];
 
 export const CredentialsTabs = ['all'];
 

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -27,7 +27,17 @@ import useDataViewMode from '@/hooks/useDataViewMode';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
 const Card = memo(props => {
-  const { data = {}, viewMode: pageViewMode, type, index = 0, customTagClickHandler } = props;
+  const {
+    data = {},
+    viewMode: pageViewMode,
+    type,
+    index = 0,
+    customTagClickHandler,
+    cardDetails,
+    disableCardActions = false,
+    hideCardBottom = false,
+    onCardClick,
+  } = props;
 
   const projectId = useSelectedProjectId();
   const { data: supportAssistantConfig } = useGetSupportAssistantConfigQuery({ enabled: false });
@@ -111,6 +121,15 @@ const Card = memo(props => {
     [assistantRef],
   );
 
+  const handleCardClick = useCallback(() => {
+    if (onCardClick) {
+      onCardClick(data);
+      return;
+    }
+
+    doNavigate();
+  }, [data, doNavigate, onCardClick]);
+
   // Monitor MCP token changes for both remote and pre-built MCP toolkits
   // For remote MCPs, use serverUrl; for pre-built MCPs, use toolkitType
   const mcpTokenOptions = useMemo(() => {
@@ -125,7 +144,10 @@ const Card = memo(props => {
 
   const { isLoggedIn: hasMcpLoggedIn } = useMcpTokenChange(mcpTokenOptions);
 
-  const styles = cardStyles;
+  const hasCardDetails = Boolean(cardDetails);
+  const showCardBottom = !hideCardBottom;
+  const isWholeCardClickable = hasCardDetails && Boolean(onCardClick);
+  const styles = cardStyles(hasCardDetails, showCardBottom, isWholeCardClickable);
 
   return (
     <Box
@@ -134,11 +156,14 @@ const Card = memo(props => {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <MuiCard sx={styles.card}>
+      <MuiCard
+        sx={styles.card}
+        onClick={isWholeCardClickable ? handleCardClick : undefined}
+      >
         <CardContent sx={styles.cardContent}>
           <Box
             sx={styles.cardTopSection}
-            onClick={doNavigate}
+            onClick={isWholeCardClickable ? undefined : handleCardClick}
           >
             <EntityIcon
               icon={data.icon_meta}
@@ -182,104 +207,111 @@ const Card = memo(props => {
               </Typography>
             </StyledTooltip>
           </Box>
-          <Box sx={styles.cardBottomSection}>
-            <Box sx={styles.bottomLeftSection}>
-              <StyledTooltip
-                key={`nameAuthor-tooltip-${authorsTooltipText}-${id}`}
-                placement="top"
-                title={authorsTooltipText}
-              >
-                <Box>
-                  <AuthorContainer
-                    authors={cardAuthors}
-                    showName={false}
-                    style={styles.authorContainer}
-                  />
-                </Box>
-              </StyledTooltip>
-              {data?.tags?.length > 0 && (
-                <Divider
-                  orientation="vertical"
-                  flexItem
-                  sx={styles.sectionDivider}
-                />
-              )}
-              <CardTagSection
-                tags={processedTags}
-                allTags={data.tags}
-                extraTagsCount={extraTagsCount}
-                disableClickTags={
-                  type === ContentType.ModerationSpaceApplication ||
-                  type === ContentType.ModerationSpacePipeline
-                }
-                dynamic={false}
-                customTagClickHandler={customTagClickHandler}
-              />
-            </Box>
-            <Box sx={styles.bottomRightSection}>
-              {(status === 'published' || status === 'embedded') && isApplicationCard(type) && (
+          {hasCardDetails && <Box sx={styles.cardDetailsSection}>{cardDetails}</Box>}
+          {showCardBottom && (
+            <Box sx={styles.cardBottomSection}>
+              <Box sx={styles.bottomLeftSection}>
                 <StyledTooltip
+                  key={`nameAuthor-tooltip-${authorsTooltipText}-${id}`}
                   placement="top"
-                  title={status === 'embedded' ? 'Embedded' : 'Published'}
+                  title={authorsTooltipText}
                 >
-                  <Box sx={styles.publishIconContainer}>
-                    <PublishIcon sx={{ fontSize: '1rem' }} />
+                  <Box>
+                    <AuthorContainer
+                      authors={cardAuthors}
+                      showName={false}
+                      style={styles.authorContainer}
+                    />
                   </Box>
                 </StyledTooltip>
-              )}
-              {isSupportAssistant && (
-                <IconButton
-                  disableRipple
-                  onClick={handleAssistantClick}
-                  sx={styles.supportAssistantIconContainer}
-                >
-                  <Box
-                    component={EliteaAssistantIcon}
-                    sx={{ width: '1.45rem', height: '1.45rem' }}
+                {data?.tags?.length > 0 && (
+                  <Divider
+                    orientation="vertical"
+                    flexItem
+                    sx={styles.sectionDivider}
                   />
-                </IconButton>
-              )}
-              <PinButton
-                entityId={id}
-                entityType={type}
-                initialPinned={isPinned}
-                alwaysVisible={isCardHovered}
-                onPinChange={handlePinChange}
-              />
-              {pageViewMode !== ViewMode.Owner && (
-                <Box sx={styles.likeContainer}>
-                  <Like
-                    viewMode={pageViewMode}
-                    type={type}
-                    data={data}
-                  />
-                </Box>
-              )}
-              {isForked && (
-                <IconLinkWithToolTip
-                  tooltip={name}
-                  meta={meta}
-                  type={getEntityTypeByCardType(type)}
+                )}
+                <CardTagSection
+                  tags={processedTags}
+                  allTags={data.tags}
+                  extraTagsCount={extraTagsCount}
+                  disableClickTags={
+                    type === ContentType.ModerationSpaceApplication ||
+                    type === ContentType.ModerationSpacePipeline
+                  }
+                  dynamic={false}
+                  customTagClickHandler={customTagClickHandler}
                 />
-              )}
-              {(type === ContentType.MCPAdmin || type === ContentType.MCPAll) && (
-                <StyledTooltip
-                  placement="top"
-                  title={data.online || hasMcpLoggedIn ? 'Connected' : 'Disconnected'}
-                >
-                  {data.online || hasMcpLoggedIn ? (
-                    <Box sx={styles.mcpIconOnline}>
-                      <OnlineIcon />
-                    </Box>
-                  ) : (
-                    <Box sx={styles.mcpIconOffline}>
-                      <OfflineIcon />
-                    </Box>
-                  )}
-                </StyledTooltip>
-              )}
+              </Box>
+              <Box sx={styles.bottomRightSection}>
+                {!disableCardActions && (
+                  <>
+                    {(status === 'published' || status === 'embedded') && isApplicationCard(type) && (
+                      <StyledTooltip
+                        placement="top"
+                        title={status === 'embedded' ? 'Embedded' : 'Published'}
+                      >
+                        <Box sx={styles.publishIconContainer}>
+                          <PublishIcon sx={{ fontSize: '1rem' }} />
+                        </Box>
+                      </StyledTooltip>
+                    )}
+                    {isSupportAssistant && (
+                      <IconButton
+                        disableRipple
+                        onClick={handleAssistantClick}
+                        sx={styles.supportAssistantIconContainer}
+                      >
+                        <Box
+                          component={EliteaAssistantIcon}
+                          sx={{ width: '1.45rem', height: '1.45rem' }}
+                        />
+                      </IconButton>
+                    )}
+                    <PinButton
+                      entityId={id}
+                      entityType={type}
+                      initialPinned={isPinned}
+                      alwaysVisible={isCardHovered}
+                      onPinChange={handlePinChange}
+                    />
+                    {pageViewMode !== ViewMode.Owner && (
+                      <Box sx={styles.likeContainer}>
+                        <Like
+                          viewMode={pageViewMode}
+                          type={type}
+                          data={data}
+                        />
+                      </Box>
+                    )}
+                    {isForked && (
+                      <IconLinkWithToolTip
+                        tooltip={name}
+                        meta={meta}
+                        type={getEntityTypeByCardType(type)}
+                      />
+                    )}
+                    {(type === ContentType.MCPAdmin || type === ContentType.MCPAll) && (
+                      <StyledTooltip
+                        placement="top"
+                        title={data.online || hasMcpLoggedIn ? 'Connected' : 'Disconnected'}
+                      >
+                        {data.online || hasMcpLoggedIn ? (
+                          <Box sx={styles.mcpIconOnline}>
+                            <OnlineIcon />
+                          </Box>
+                        ) : (
+                          <Box sx={styles.mcpIconOffline}>
+                            <OfflineIcon />
+                          </Box>
+                        )}
+                      </StyledTooltip>
+                    )}
+                  </>
+                )}
+              </Box>
             </Box>
-          </Box>
+          )}
         </CardContent>
       </MuiCard>
     </Box>
@@ -301,14 +333,22 @@ const lineClamp = lines => ({
 });
 
 /** @type {MuiSx} */
-const cardStyles = {
+const cardStyles = (hasCardDetails, showCardBottom, isWholeCardClickable) => ({
   wrapper: {
     width: '100%',
+    ...(hasCardDetails ? { height: '100%' } : {}),
   },
   card: {
     margin: '0.625rem 1.375rem',
-    display: 'inline',
+    display: hasCardDetails ? 'block' : 'inline',
     boxSizing: 'border-box',
+    cursor: isWholeCardClickable ? 'pointer' : 'default',
+    ...(hasCardDetails
+      ? {
+          height: 'calc(100% - 1.25rem)',
+          overflow: 'hidden',
+        }
+      : {}),
     '& :last-child': {
       paddingBottom: '0 !important',
     },
@@ -321,11 +361,11 @@ const cardStyles = {
     height: '100%',
   },
   cardTopSection: {
-    maxHeight: '4.5rem',
-    height: '4.5rem',
+    maxHeight: hasCardDetails ? '3.75rem' : '4.5rem',
+    height: hasCardDetails ? '3.75rem' : '4.5rem',
     cursor: 'pointer',
     width: '100%',
-    padding: '1.25rem',
+    padding: hasCardDetails ? '1rem 1.25rem 0.75rem' : '1.25rem',
     boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'row',
@@ -344,9 +384,17 @@ const cardStyles = {
   descriptionTooltip: {
     ...lineClamp(4),
   },
+  cardDetailsSection: {
+    px: '1.25rem',
+    pb: showCardBottom ? '0.75rem' : '1rem',
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
   cardBottomSection: {
-    height: '2.5rem',
-    padding: '0 0.75rem 0 1.125rem',
+    height: hasCardDetails ? '2.25rem' : '2.5rem',
+    padding: hasCardDetails ? '0 0.75rem 0.75rem 1.125rem' : '0 0.75rem 0 1.125rem',
     boxSizing: 'border-box',
     display: 'flex',
     justifyContent: 'space-between',
@@ -415,6 +463,6 @@ const cardStyles = {
       height: '1rem',
     },
   },
-};
+});
 
 export default Card;

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import DataTable from '@/[fsd]/widgets/DataTable';
 import EmptyListBox from '@/components/EmptyListBox';
 import useIsTableView from '@/hooks/useIsTableView';
+import useShouldCollapseRightToolbar from '@/hooks/useShouldCollapseRightToolbar';
 
 import DataCards from './DataCards';
 import RightPanel from './RightPanel';
@@ -16,12 +17,18 @@ const CardList = props => {
     isError,
     headerHeight = '70px',
     emptyListSX,
+    isFullWidth = false,
+    cardHeight,
+    cardWidthOverride,
     resetPageOnSort,
     ...rest
   } = props;
 
   const isTableView = useIsTableView();
+  const { shouldCollapseRightToolbar } = useShouldCollapseRightToolbar();
   const isEmptyList = useMemo(() => cardList.length === 0, [cardList.length]);
+  const shouldShowRightPanel = Boolean(rightPanelContent) && !shouldCollapseRightToolbar;
+  const isListFullWidth = isFullWidth || !shouldShowRightPanel;
 
   return (
     <>
@@ -30,13 +37,13 @@ const CardList = props => {
           emptyListPlaceHolder={emptyListPlaceHolder}
           headerHeight={headerHeight}
           showErrorMessage={!!isError}
-          isFullWidth={!rightPanelContent}
+          isFullWidth={isListFullWidth}
           sx={emptyListSX}
         />
       ) : isTableView ? (
         <DataTable
           data={cardList}
-          isFullWidth={!rightPanelContent}
+          isFullWidth={isListFullWidth}
           page={rest.page}
           pageSize={rest.pageSize}
           setPage={rest.setPage}
@@ -46,10 +53,13 @@ const CardList = props => {
       ) : (
         <DataCards
           data={cardList}
+          isFullWidth={isListFullWidth}
+          cardHeight={cardHeight}
+          cardWidthOverride={cardWidthOverride}
           {...rest}
         />
       )}
-      <RightPanel offsetFromTop={rightPanelOffset}>{rightPanelContent}</RightPanel>
+      {shouldShowRightPanel && <RightPanel offsetFromTop={rightPanelOffset}>{rightPanelContent}</RightPanel>}
     </>
   );
 };

--- a/src/components/DataCards.jsx
+++ b/src/components/DataCards.jsx
@@ -28,6 +28,9 @@ const DataCards = memo(props => {
     cardType,
     dynamicTags,
     total,
+    isFullWidth,
+    cardHeight = '7rem',
+    cardWidthOverride,
   } = props;
 
   const { pathname } = useLocation();
@@ -35,11 +38,13 @@ const DataCards = memo(props => {
   const { calculateTagsWidthOnCard, setGetElement } = useTags(tagList);
   const { componentRef: gridRef, componentWidth: cardListWidth } = useGetComponentWidth();
 
-  const isFullWidthPage = FULL_WIDTH_FLEX_GRID_PAGE.includes(pathname);
+  const isFullWidthPage = isFullWidth || FULL_WIDTH_FLEX_GRID_PAGE.includes(pathname);
+  const isDefaultCardHeight = cardHeight === '7rem';
 
-  const cardWidth = useCardLayout(cardListWidth, cardList.length, isFullWidthPage);
+  const layoutCardWidth = useCardLayout(cardListWidth, cardList.length, isFullWidthPage);
+  const cardWidth = cardWidthOverride || layoutCardWidth;
 
-  const styles = dataCardStyles(cardWidth, isFullWidthPage);
+  const styles = dataCardStyles(cardWidth, isFullWidthPage, cardHeight, isDefaultCardHeight);
 
   useEffect(() => {
     if (isLoading) return;
@@ -96,7 +101,7 @@ const DataCards = memo(props => {
 DataCards.displayName = 'DataCards';
 
 /** @type {MuiSx} */
-const dataCardStyles = (cardWidth, isFullWidthPage) => ({
+const dataCardStyles = (cardWidth, isFullWidthPage, cardHeight, isDefaultCardHeight) => ({
   cardListContainer: {
     flexGrow: 1,
     width: isFullWidthPage ? CARD_LIST_WIDTH_FULL : CARD_LIST_WIDTH,
@@ -106,7 +111,7 @@ const dataCardStyles = (cardWidth, isFullWidthPage) => ({
   },
   loadingSkeleton: {
     width: '100%',
-    height: '100%',
+    height: cardHeight,
     borderRadius: '0.75rem',
   },
   card: ({ palette }) => ({
@@ -114,10 +119,10 @@ const dataCardStyles = (cardWidth, isFullWidthPage) => ({
     margin: '0 1rem 1rem 0',
     minWidth: MIN_CARD_WIDTH,
     width: cardWidth,
-    height: '7rem',
-    maxHeight: '7rem',
+    height: cardHeight,
+    maxHeight: cardHeight,
     display: 'flex',
-    alignItems: 'center',
+    alignItems: isDefaultCardHeight ? 'center' : 'stretch',
     flexGrow: '0',
   }),
 });

--- a/src/hooks/useBackPath.js
+++ b/src/hooks/useBackPath.js
@@ -74,12 +74,14 @@ const getPrevPath = (routeStack, currentPath, search, viewMode, authorId, author
       return `${RouteDefinitions.CreateMCP}/?${SearchParams.ViewMode}=${viewMode}`;
     } else if (currentPath.startsWith(RouteDefinitions.MCPs) && !search.includes(SearchParams.ToolkitType)) {
       return `${RouteDefinitions.MCPs}/${getTabFromUrl(currentPath, ToolkitsTabs[0])}?${SearchParams.ViewMode}=${viewMode}`;
-    } else if (currentPath.startsWith(RouteDefinitions.Apps) && hasSubPath(currentPath)) {
+    } else if (isPathOrSubPath(currentPath, RouteDefinitions.CreateApp) && hasSubPath(currentPath)) {
       // Handle /apps/create/:appType - go back to /apps/create
       return `${RouteDefinitions.CreateApp}/?${SearchParams.ViewMode}=${viewMode}`;
-    } else if (currentPath.startsWith(RouteDefinitions.Apps) && !hasSubPath(currentPath)) {
+    } else if (isPathOrSubPath(currentPath, RouteDefinitions.CreateApp)) {
       // Handle /apps/create (selector page) - go back to apps list
       return `${RouteDefinitions.Apps}/${AppsTabs[0]}?${SearchParams.ViewMode}=${viewMode}`;
+    } else if (currentPath.startsWith(RouteDefinitions.Apps) && hasSubPath(currentPath)) {
+      return `${RouteDefinitions.Apps}/${getTabFromUrl(currentPath, AppsTabs[1])}?${SearchParams.ViewMode}=${viewMode}`;
     } else if (currentPath.startsWith(RouteDefinitions.UserPublic)) {
       if (currentPath.match(/\/user-public\/pipelines\/\d+/g)) {
         return `${RouteDefinitions.UserPublic}/${UserPublicTabs[2]}?${SearchParams.ViewMode}=${viewMode}&${SearchParams.AuthorId}=${authorId}&${SearchParams.AuthorName}=${authorName}`;
@@ -121,6 +123,8 @@ const hasSubPath = url => {
   const paths = url.split('/').filter(item => item.length > 0);
   return paths.length > 2;
 };
+
+const isPathOrSubPath = (url, basePath) => url === basePath || url.startsWith(`${basePath}/`);
 
 export default function useBackPath() {
   const { pathname, search, state: locationState } = useLocation();

--- a/src/hooks/useBackPath.js
+++ b/src/hooks/useBackPath.js
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 
 import {
   ApplicationsTabs,
+  AppsTabs,
   PUBLIC_PROJECT_ID,
   SearchParams,
   ToolkitsTabs,
@@ -78,7 +79,7 @@ const getPrevPath = (routeStack, currentPath, search, viewMode, authorId, author
       return `${RouteDefinitions.CreateApp}/?${SearchParams.ViewMode}=${viewMode}`;
     } else if (currentPath.startsWith(RouteDefinitions.Apps) && !hasSubPath(currentPath)) {
       // Handle /apps/create (selector page) - go back to apps list
-      return `${RouteDefinitions.Apps}/all?${SearchParams.ViewMode}=${viewMode}`;
+      return `${RouteDefinitions.Apps}/${AppsTabs[0]}?${SearchParams.ViewMode}=${viewMode}`;
     } else if (currentPath.startsWith(RouteDefinitions.UserPublic)) {
       if (currentPath.match(/\/user-public\/pipelines\/\d+/g)) {
         return `${RouteDefinitions.UserPublic}/${UserPublicTabs[2]}?${SearchParams.ViewMode}=${viewMode}&${SearchParams.AuthorId}=${authorId}&${SearchParams.AuthorName}=${authorName}`;

--- a/src/hooks/useCardNavigate.js
+++ b/src/hooks/useCardNavigate.js
@@ -4,6 +4,7 @@ import { useLocation, useMatch, useNavigate, useParams, useSearchParams } from '
 
 import {
   ApplicationsTabs,
+  AppsTabs,
   ContentType,
   PUBLIC_PROJECT_ID,
   SearchParams,
@@ -106,7 +107,7 @@ const useCardNavigate = props => {
       [ContentType.PipelineRejected]: buildUrl(RouteDefinitions.Pipelines, tab),
       [ContentType.ToolkitAdmin]: buildUrl(RouteDefinitions.Toolkits, tab),
       [ContentType.ToolkitAll]: buildUrl(RouteDefinitions.Toolkits, tab),
-      [ContentType.AppAll]: buildUrl(RouteDefinitions.Apps, tab),
+      [ContentType.AppAll]: buildUrl(RouteDefinitions.Apps, AppsTabs[1]),
       [ContentType.MCPAll]: buildUrl(RouteDefinitions.MCPs, tab),
       [ContentType.CredentialAll]: buildUrl(RouteDefinitions.Credentials, tab),
       [ContentType.ApplicationTop]: buildUrl(RouteDefinitions.Applications, 'top'),


### PR DESCRIPTION
## Summary
- add a Request App catalog for DeepWiki and Inventory that reuses the existing card/list stack
- restore actionable app tabs with `/apps/request` and `/apps/configured`, while keeping `/apps/all` as a legacy alias
- improve shared card/list responsiveness for custom request cards and narrow configured views

## Validation
- npm run lint
- NODE_OPTIONS=--max-old-space-size=8192 npm run build
- copied built dist into the local Pylon `elitea_core` UI dist and verified `/app/apps/request`, `/app/apps/configured`, legacy `/app/apps/all`, and View Configured navigation

Related: EliteaAI/elitea_issues#4770