### PR TITLE
fix: [EL-4885] Voice-to-Text Input Overrides User Edits When New Speech Is Detected

### DIFF
--- a/src/[fsd]/features/chat/lib/hooks/useSpeakingModeLoop.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSpeakingModeLoop.hooks.js
@@ -21,7 +21,7 @@ const selectAsrModel = items => {
  * Voice loop for speaking mode:
  *  1. Auto-starts recording when isSpeakingMode is enabled
  *  2. Inserts transcript into inputRef
- *  3. After SILENCE_TIMEOUT_MS of no new final transcript → auto-sends
+ *  3. After SILENCE_TIMEOUT_MS of no new final transcript → auto-sends and stops recording
  *  4. Waits for AI to finish streaming AND TTS to finish playing
  *  5. Restarts recording for the next turn
  */
@@ -32,8 +32,13 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
   const preCursorRef = useRef('');
   const postCursorRef = useRef('');
   const voiceAccumulatedRef = useRef('');
+  const lastSetValueRef = useRef(null);
   const silenceTimerRef = useRef(null);
   const hasSentRef = useRef(false);
+  // Holds the latest stopRecording so the silence timer can call it without
+  // creating a circular declaration dependency (handleTranscript is declared
+  // before stopRecording is available from the hooks below).
+  const stopRecordingRef = useRef(null);
 
   const { data: asrModelsData } = useListModelsQuery(
     { projectId, section: 'asr', include_shared: true },
@@ -50,11 +55,24 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
 
   const handleTranscript = useCallback(
     ({ final, interim }) => {
+      // Re-sync cursor refs if the user manually edited the input between transcript
+      // events (e.g. deleted the previous transcript while still recording).
+      if (lastSetValueRef.current !== null) {
+        const currentContent = inputRef.current?.getInputContent() ?? '';
+        if (currentContent !== lastSetValueRef.current) {
+          const cursor = inputRef.current?.getCursorPosition() ?? currentContent.length;
+          preCursorRef.current = currentContent.slice(0, cursor);
+          postCursorRef.current = currentContent.slice(cursor);
+          voiceAccumulatedRef.current = '';
+        }
+      }
+
       const voiceBase = preCursorRef.current + voiceAccumulatedRef.current;
 
       if (interim) {
         const newValue = voiceBase + interim + postCursorRef.current;
         const cursorPos = voiceBase.length + interim.length;
+        lastSetValueRef.current = newValue;
         inputRef.current?.setValue(newValue, cursorPos);
       }
 
@@ -62,6 +80,7 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
         voiceAccumulatedRef.current += (voiceAccumulatedRef.current ? ' ' : '') + final;
         const newValue = preCursorRef.current + voiceAccumulatedRef.current + postCursorRef.current;
         const cursorPos = preCursorRef.current.length + voiceAccumulatedRef.current.length;
+        lastSetValueRef.current = newValue;
         inputRef.current?.setValue(newValue, cursorPos);
 
         clearSilenceTimer();
@@ -71,6 +90,8 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
             hasSentRef.current = true;
             inputRef.current?.sendQuestion?.();
             inputRef.current?.reset?.();
+            // Pause recording until the AI response and TTS are done
+            stopRecordingRef.current?.();
           }
         }, SILENCE_TIMEOUT_MS);
       }
@@ -95,10 +116,14 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
     ? serverHook
     : clientHook;
 
+  // Keep the ref in sync so the silence timer always calls the latest version
+  stopRecordingRef.current = stopRecording;
+
   const beginRecording = useCallback(() => {
     preCursorRef.current = '';
     postCursorRef.current = '';
     voiceAccumulatedRef.current = '';
+    lastSetValueRef.current = '';
     startRecording();
   }, [startRecording]);
 

--- a/src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js
@@ -214,6 +214,9 @@ export const useStreamingSpeechRecognition = ({
 
   const stopRecording = useCallback(() => {
     if (!isRecording) return;
+    // Block events from this session before tearing down audio so late backend
+    // messages (e.g. a final Realtime transcript still in-flight) are discarded.
+    acceptEventsRef.current = false;
     _releaseAudio();
     socket?.emit(sioEvents.asr_stop, {});
     setIsRecording(false);
@@ -223,6 +226,7 @@ export const useStreamingSpeechRecognition = ({
   useEffect(() => {
     return () => {
       if (!streamRef.current) return;
+      acceptEventsRef.current = false;
       _releaseAudio();
       socket?.emit(sioEvents.asr_stop, {});
     };

--- a/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
+++ b/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
@@ -40,14 +40,32 @@ const VoiceButton = memo(
     const postCursorContentRef = useRef('');
     // Accumulates all finalized voice text within the current recording session
     const voiceFinalAccumulatedRef = useRef('');
+    // The last value we programmatically set via setValue — used to detect
+    // manual edits the user made between transcript events.
+    const lastSetValueRef = useRef(null);
 
     const handleTranscript = useCallback(
       ({ final, interim }) => {
+        // If the user manually edited the input between transcript events (e.g. deleted
+        // the previous transcript while still recording), re-sync our cursor refs so the
+        // next transcript continues from the current input state rather than the stale
+        // accumulated refs.
+        if (lastSetValueRef.current !== null) {
+          const currentContent = inputRef.current?.getInputContent() ?? '';
+          if (currentContent !== lastSetValueRef.current) {
+            const cursor = inputRef.current?.getCursorPosition() ?? currentContent.length;
+            preCursorContentRef.current = currentContent.slice(0, cursor);
+            postCursorContentRef.current = currentContent.slice(cursor);
+            voiceFinalAccumulatedRef.current = '';
+          }
+        }
+
         const voiceBase = preCursorContentRef.current + voiceFinalAccumulatedRef.current;
         if (interim) {
           // Live preview: cursor sits after the interim words (before postCursor)
           const newValue = voiceBase + interim + postCursorContentRef.current;
           const cursorPos = voiceBase.length + interim.length;
+          lastSetValueRef.current = newValue;
           inputRef.current?.setValue(newValue, cursorPos);
         }
         if (final) {
@@ -56,6 +74,7 @@ const VoiceButton = memo(
           const newValue =
             preCursorContentRef.current + voiceFinalAccumulatedRef.current + postCursorContentRef.current;
           const cursorPos = preCursorContentRef.current.length + voiceFinalAccumulatedRef.current.length;
+          lastSetValueRef.current = newValue;
           inputRef.current?.setValue(newValue, cursorPos);
         }
       },
@@ -132,6 +151,9 @@ const VoiceButton = memo(
       preCursorContentRef.current = content.slice(0, cursor);
       postCursorContentRef.current = content.slice(cursor);
       voiceFinalAccumulatedRef.current = '';
+      // Seed the edit-detection tracker with the content as it is now, so the
+      // first transcript event can tell if the user edits before it arrives.
+      lastSetValueRef.current = content;
       startRecording();
     }, [inputRef, startRecording]);
 


### PR DESCRIPTION
# Fix #4885: Voice input & voice chat transcript corruption + speaking mode recording lifecycle

## Summary

- Migrate `VoiceMiniPlayer` from legacy `pages/` into the FSD feature layer
- Fix deleted transcript reappearing in the input during an active voice input session
- Fix deleted transcript reappearing in the input during an active voice chat session
- Fix stale socket events from a finished session writing into the next recording session
- Pause recording when the silence timer fires and auto-sends a message; resume only after the AI response and TTS playback finish

---

## Changes

### 1. Move `VoiceMiniPlayer` to FSD (`src/[fsd]/features/chat/ui/voice-mini-player/`)

`VoiceMiniPlayer` was living in `src/pages/NewChat/` alongside route-level page code. Moved it to the feature layer following FSD conventions.

**Files added:**
- `src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx`
- `src/[fsd]/features/chat/ui/voice-mini-player/index.js`

**Files modified:**
- `src/[fsd]/features/chat/ui/index.js` — added `VoiceMiniPlayer` to the barrel export
- `src/pages/NewChat/ChatBox.jsx` — updated import path to `@/[fsd]/features/chat/ui`

**Files deleted:**
- `src/pages/NewChat/VoiceMiniPlayer.jsx`

---

### 2. Fix: deleted transcript reappears during an active recording session

Affects both **voice input** (`VoiceButton.jsx`) and **voice chat** (`useSpeakingModeLoop.hooks.js`).

**Root cause**

`voiceFinalAccumulatedRef` (and its equivalent `voiceAccumulatedRef` in the loop hook) accumulates every finalized transcript chunk since recording started. With a VAD-based model (Whisper), transcript chunks arrive automatically on detected silence without the user stopping the session. If the user deletes the accumulated text from the input and speaks again, the next `final` event still builds on the stale accumulated ref, causing the deleted text to reappear at the start of the new utterance.

**Fix**

Added `lastSetValueRef` to both hooks to track the last value written to the input programmatically. At the top of `handleTranscript`, the current input content is compared against `lastSetValueRef.current`. If they differ, the user manually edited the input — the cursor refs and the accumulator are re-synced from the current input state before applying the incoming transcript.

```
User speaks "Hello World"
→ voiceAccumulatedRef = "Hello World", lastSetValue = "Hello World"

User deletes → input = ""

Next final("New Message") arrives:
  getInputContent() = "" ≠ lastSetValue "Hello World"
  → re-sync: preCursor = "", voiceAccumulated = "", postCursor = ""
  → apply: voiceAccumulated = "New Message", input = "New Message"  ✓
```

`lastSetValueRef` is seeded with the current input content at recording start (`handleStartRecording` / `beginRecording`) so the very first transcript event can also detect a pre-start edit.

---

### 3. Fix: stale socket events from a finished session write into the next session (`useStreamingSpeechRecognition.hooks.js`)

**Root cause**

`acceptEventsRef.current` was set to `false` only at the *start* of `startRecording()` and never cleared in `stopRecording()`. Any `asr_transcript_done` event the backend emitted after stop (a final message in-flight when `asr_stop` was processed) arrived with `acceptEventsRef = true` and was applied to the new session's input.

**Fix**

Set `acceptEventsRef.current = false` immediately in `stopRecording()` and the unmount cleanup.

```js
const stopRecording = useCallback(() => {
  if (!isRecording) return;
  acceptEventsRef.current = false;  // ← added
  _releaseAudio();
  socket?.emit(sioEvents.asr_stop, {});
  setIsRecording(false);
}, [isRecording, socket, _releaseAudio]);
```

---

### 4. Pause recording while AI responds and TTS plays (`useSpeakingModeLoop.hooks.js`)

**Problem**

When the silence timer fired and auto-sent a message, recording was never stopped. The microphone kept capturing audio throughout the AI streaming response and TTS playback, causing wasted ASR API calls and potential unintended transcript injections.

**Fix**

Call `stopRecording()` inside the silence timer callback immediately after sending. The existing "restart after streaming + TTS done" effect handles resuming.

```js
silenceTimerRef.current = setTimeout(() => {
  const content = inputRef.current?.getInputContent?.() ?? '';
  if (content.trim()) {
    hasSentRef.current = true;
    inputRef.current?.sendQuestion?.();
    inputRef.current?.reset?.();
    stopRecordingRef.current?.();  // ← pause until next turn
  }
}, SILENCE_TIMEOUT_MS);
```

`stopRecording` is exposed via `stopRecordingRef` (updated each render) rather than added directly to `handleTranscript`'s `useCallback` deps, since `stopRecording` is declared after `handleTranscript` in the hook body and adding it to the deps array would cause a temporal dead zone error.
