### PR TITLE
feat: [EL-4896] add @ user mention suggestion popup in chat input

### DIFF
--- a/src/[fsd]/features/chat/lib/hooks/index.js
+++ b/src/[fsd]/features/chat/lib/hooks/index.js
@@ -12,3 +12,7 @@ export { useSpeechRecognition } from './useSpeechRecognition.hooks';
 export { useStreamingSpeechRecognition } from './useStreamingSpeechRecognition.hooks';
 export { useTextToSpeech } from './useTextToSpeech.hooks';
 export { useSpeakingModeLoop } from './useSpeakingModeLoop.hooks';
+export {
+  useNewInputKeyDownHandler,
+  useNewStartConversationInputKeyDownHandler,
+} from './useInputKeyDownHandler.hooks';

--- a/src/[fsd]/features/chat/lib/hooks/useInputKeyDownHandler.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useInputKeyDownHandler.hooks.js
@@ -1,20 +1,40 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 const NewSpecialSymbolsString = '#';
+const AtSymbol = '@';
+const PRINTABLE_ASCII_REGEX = /^[\x20-\x7E]*$/;
 
 export const useNewInputKeyDownHandler = (options = {}) => {
   const { disableHashtagDetection = false } = options;
+
+  // '#' tracking
   const [isProcessingSymbols, setIsProcessingSymbols] = useState(false);
   const [query, setQuery] = useState('');
   const queryRef = useRef(query);
+
+  // '@' tracking
+  const [isProcessingAtSymbol, setIsProcessingAtSymbol] = useState(false);
+  const [atQuery, setAtQuery] = useState('');
+  const atQueryRef = useRef(atQuery);
+  const atAnchorRef = useRef(null);
 
   useEffect(() => {
     queryRef.current = query;
   }, [query]);
 
+  useEffect(() => {
+    atQueryRef.current = atQuery;
+  }, [atQuery]);
+
   const reset = useCallback(() => {
     setIsProcessingSymbols(false);
     setQuery('');
+  }, []);
+
+  const resetAt = useCallback(() => {
+    setIsProcessingAtSymbol(false);
+    setAtQuery('');
+    atAnchorRef.current = null;
   }, []);
 
   const onKeyDown = useCallback(
@@ -24,12 +44,45 @@ export const useNewInputKeyDownHandler = (options = {}) => {
       const { target } = event;
       const { selectionStart, selectionEnd, value } = target;
 
-      if (!isProcessingSymbols && event.key.length === 1 && NewSpecialSymbolsString.includes(event.key)) {
-        // Start processing when "#" is typed
-        setIsProcessingSymbols(true);
-        setQuery(event.key);
-      } else if (isProcessingSymbols) {
-        if (event.key.length === 1 && event.key.match(/^[\x20-\x7E]*$/)) {
+      // --- '@' mention mode ---
+      if (isProcessingAtSymbol) {
+        if (event.key.length === 1 && event.key.match(PRINTABLE_ASCII_REGEX)) {
+          if (event.key === ' ') {
+            resetAt();
+          } else {
+            setAtQuery(prev => prev + event.key);
+          }
+        } else if (event.key === 'Backspace' || event.key === 'Delete') {
+          let willDeleteAt = false;
+
+          if (selectionStart !== selectionEnd) {
+            const selectedText = value.substring(selectionStart, selectionEnd);
+            willDeleteAt = selectedText.includes(atQueryRef.current);
+          } else if (event.key === 'Backspace') {
+            const charToDelete = selectionStart > 0 ? value[selectionStart - 1] : '';
+            willDeleteAt = charToDelete === AtSymbol && atQueryRef.current.length === 1;
+          } else {
+            const charToDelete = selectionStart < value.length ? value[selectionStart] : '';
+            willDeleteAt = charToDelete === AtSymbol && atQueryRef.current.length === 1;
+          }
+
+          if (atQueryRef.current.length === 0) willDeleteAt = true;
+
+          if (willDeleteAt) {
+            resetAt();
+            return;
+          }
+
+          setAtQuery(prev => (prev.length > 1 ? prev.slice(0, -1) : prev));
+        } else if (event.key === 'Escape') {
+          resetAt();
+        }
+        return;
+      }
+
+      // --- '#' mention mode ---
+      if (isProcessingSymbols) {
+        if (event.key.length === 1 && event.key.match(PRINTABLE_ASCII_REGEX)) {
           // Add printable characters to query
           setQuery(prev => prev + event.key);
         } else if (event.key === 'Backspace' || event.key === 'Delete') {
@@ -75,9 +128,20 @@ export const useNewInputKeyDownHandler = (options = {}) => {
           // Allow escape key to cancel symbol processing
           reset();
         }
+        return;
+      }
+
+      // --- Idle: check for trigger symbols ---
+      if (event.key === AtSymbol) {
+        setIsProcessingAtSymbol(true);
+        setAtQuery(AtSymbol);
+        atAnchorRef.current = selectionStart;
+      } else if (event.key.length === 1 && NewSpecialSymbolsString.includes(event.key)) {
+        setIsProcessingSymbols(true);
+        setQuery(event.key);
       }
     },
-    [isProcessingSymbols, reset, disableHashtagDetection],
+    [isProcessingSymbols, isProcessingAtSymbol, reset, resetAt, disableHashtagDetection],
   );
 
   return {
@@ -85,6 +149,10 @@ export const useNewInputKeyDownHandler = (options = {}) => {
     isProcessingSymbols,
     query,
     stopProcessingSymbols: reset,
+    isProcessingAtSymbol,
+    atQuery,
+    stopProcessingAtSymbol: resetAt,
+    atAnchorRef,
   };
 };
 
@@ -101,7 +169,7 @@ export const useNewStartConversationInputKeyDownHandler = (options = {}) => {
         setIsProcessingSymbols(true);
         setQuery(event.key);
       } else if (isProcessingSymbols) {
-        if (event.key.length === 1 && event.key.match(/^[\x20-\x7E]*$/)) {
+        if (event.key.length === 1 && event.key.match(PRINTABLE_ASCII_REGEX)) {
           setQuery(prev => prev + event.key);
         } else if (event.key === 'Backspace') {
           setQuery(prev => prev.slice(0, -1));

--- a/src/[fsd]/features/chat/ui/user-mention-list/UserMentionList.jsx
+++ b/src/[fsd]/features/chat/ui/user-mention-list/UserMentionList.jsx
@@ -1,0 +1,165 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Box, ClickAwayListener, Typography } from '@mui/material';
+
+import UserAvatar from '@/components/UserAvatar';
+
+const UserMentionItem = memo(props => {
+  const { user, onClick, isActive } = props;
+
+  const handleClick = useCallback(
+    event => {
+      event.stopPropagation();
+      event.preventDefault();
+      onClick(user);
+    },
+    [onClick, user],
+  );
+
+  const avatarName = user.participant?.meta?.user_name || user.name;
+  const avatarSrc = user.participant?.meta?.user_avatar;
+
+  return (
+    <Box
+      onClick={handleClick}
+      sx={userMentionItemStyles.item(isActive)}
+    >
+      <UserAvatar
+        name={avatarName}
+        avatar={avatarSrc}
+        size={24}
+      />
+      <Typography
+        variant="headingSmall"
+        color="text.secondary"
+        sx={userMentionItemStyles.name}
+      >
+        {user.name}
+      </Typography>
+    </Box>
+  );
+});
+
+UserMentionItem.displayName = 'UserMentionItem';
+
+const UserMentionList = memo(props => {
+  const { users = [], query, onSelectUser, onClose } = props;
+
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const filteredUsers = useMemo(() => {
+    if (!users.length) return [];
+    const searchStr = query?.slice(1)?.toLowerCase() || '';
+    if (!searchStr) return users;
+    return users.filter(u => u.name?.toLowerCase().includes(searchStr));
+  }, [users, query]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filteredUsers]);
+
+  useEffect(() => {
+    if (!filteredUsers.length) return;
+
+    const handleKeyDown = event => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex(prev => (prev + 1) % filteredUsers.length);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex(prev => (prev - 1 + filteredUsers.length) % filteredUsers.length);
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        onSelectUser(filteredUsers[activeIndex]);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [filteredUsers, activeIndex, onSelectUser]);
+
+  if (!filteredUsers.length) return null;
+
+  return (
+    <ClickAwayListener onClickAway={onClose}>
+      <Box sx={userMentionListStyles.container}>
+        <Box sx={userMentionListStyles.header}>
+          <Typography
+            variant="subtitle"
+            color="text.primary"
+          >
+            Participants
+          </Typography>
+        </Box>
+        <Box sx={userMentionListStyles.list}>
+          {filteredUsers.map((user, index) => (
+            <UserMentionItem
+              key={user.id}
+              user={user}
+              onClick={onSelectUser}
+              isActive={index === activeIndex}
+            />
+          ))}
+        </Box>
+      </Box>
+    </ClickAwayListener>
+  );
+});
+
+UserMentionList.displayName = 'UserMentionList';
+
+/** @type {MuiSx} */
+const userMentionItemStyles = {
+  item:
+    isActive =>
+    ({ palette }) => ({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: '0.5rem',
+      padding: '0.375rem 0.5rem',
+      borderRadius: '0.5rem',
+      cursor: 'pointer',
+      backgroundColor: isActive ? palette.action.hover : 'transparent',
+      '&:hover': {
+        backgroundColor: palette.action.hover,
+      },
+    }),
+  name: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+};
+
+/** @type {MuiSx} */
+const userMentionListStyles = {
+  container: ({ palette }) => ({
+    border: `0.0625rem solid ${palette.border.lines}`,
+    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '15.4375rem',
+    borderRadius: '1rem',
+    boxSizing: 'border-box',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.25rem',
+    background: palette.background.secondary,
+    overflowY: 'auto',
+  }),
+  header: {
+    height: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '0 0.5rem',
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+  },
+};
+
+export default UserMentionList;

--- a/src/[fsd]/features/chat/ui/user-mention-list/index.js
+++ b/src/[fsd]/features/chat/ui/user-mention-list/index.js
@@ -1,0 +1,1 @@
+export { default as UserMentionList } from './UserMentionList';

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1466,7 +1466,10 @@ const ChatBox = forwardRef((props, boxRef) => {
   const users = useMemo(
     () => [
       ...(activeConversation?.participants
-        ?.filter(participant => participant.entity_name === ChatParticipantType.Users)
+        ?.filter(
+          participant =>
+            participant.entity_name === ChatParticipantType.Users && participant.entity_meta?.id !== userId,
+        )
         .map(participant => ({
           id: participant.id,
           name: participant.meta.user_name,
@@ -1478,7 +1481,7 @@ const ChatBox = forwardRef((props, boxRef) => {
         participant: 'All users',
       },
     ],
-    [activeConversation?.participants],
+    [activeConversation?.participants, userId],
   );
 
   const hasOtherUsers = useMemo(

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -16,8 +16,9 @@ import { Box } from '@mui/system';
 
 import { LATEST_VERSION_NAME } from '@/[fsd]/entities/version/lib/constants';
 import { ChatHelpers, NewConversationHelpers, toSpeakableText } from '@/[fsd]/features/chat/lib/helpers';
-import { useSlashMention, useTextToSpeech } from '@/[fsd]/features/chat/lib/hooks';
+import { useNewInputKeyDownHandler, useSlashMention, useTextToSpeech } from '@/[fsd]/features/chat/lib/hooks';
 import { SlashSuggestionList, VoiceMiniPlayer } from '@/[fsd]/features/chat/ui';
+import { UserMentionList } from '@/[fsd]/features/chat/ui/user-mention-list';
 import { McpAuthHelpers } from '@/[fsd]/features/mcp/lib/helpers';
 import {
   DEFAULT_MAX_TOKENS,
@@ -58,7 +59,6 @@ import SocketContext from '@/contexts/SocketContext';
 import useChatStreaming from '@/hooks/chat/useChatStreaming';
 import useDeleteMessageAlert from '@/hooks/chat/useDeleteMessageAlert';
 import useFetchParticipantDetails from '@/hooks/chat/useFetchParticipantDetails';
-import { useNewInputKeyDownHandler } from '@/hooks/chat/useInputKeyDownHandler';
 import useLoadMoreMessages from '@/hooks/chat/useLoadMoreMessages';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useSocket from '@/hooks/useSocket';
@@ -542,7 +542,7 @@ const ChatBox = forwardRef((props, boxRef) => {
                   it.entity_meta?.id &&
                   userId !== it.entity_meta?.id,
               )
-              .map(it => it.entity_meta?.id) || []
+              .map(it => it.id) || []
           : selectedUsers.map(user => user.user.id),
         unsavedLLMSettings,
         participants: activeConversation?.participants || [],
@@ -1373,7 +1373,16 @@ const ChatBox = forwardRef((props, boxRef) => {
     [hasPendingHitlInterrupt, hitlEditMode, onHitlResume, onPredictStream, resetSlash],
   );
 
-  const { onKeyDown, isProcessingSymbols, query, stopProcessingSymbols } = useNewInputKeyDownHandler({
+  const {
+    onKeyDown,
+    isProcessingSymbols,
+    query,
+    stopProcessingSymbols,
+    isProcessingAtSymbol,
+    atQuery,
+    stopProcessingAtSymbol,
+    atAnchorRef,
+  } = useNewInputKeyDownHandler({
     disableHashtagDetection: isAgentsPage,
   });
 
@@ -1395,6 +1404,22 @@ const ChatBox = forwardRef((props, boxRef) => {
       }
     }, 0);
   };
+
+  const onSelectUserMention = useCallback(
+    user => {
+      if (chatInput.current && atAnchorRef.current !== null) {
+        chatInput.current.replaceRange(
+          atAnchorRef.current,
+          atAnchorRef.current + atQuery.length,
+          '@' + user.name + ' ',
+        );
+      }
+      stopProcessingAtSymbol();
+    },
+    // atAnchorRef is a ref — stable, no dep needed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [atQuery, stopProcessingAtSymbol],
+  );
 
   const onResendQuestionStream = useCallback(
     async (question_id, question) => {
@@ -1454,6 +1479,15 @@ const ChatBox = forwardRef((props, boxRef) => {
       },
     ],
     [activeConversation?.participants],
+  );
+
+  const hasOtherUsers = useMemo(
+    () =>
+      (activeConversation?.participants || []).some(
+        participant =>
+          participant.entity_name === ChatParticipantType.Users && participant.entity_meta?.id !== userId,
+      ),
+    [activeConversation?.participants, userId],
   );
 
   const [showRecommendationList, setShowRecommendationList] = useState(false);
@@ -1917,6 +1951,14 @@ const ChatBox = forwardRef((props, boxRef) => {
               onSelectParticipant={onSelectParticipant}
               existingParticipants={activeConversation?.participants || []}
               onClose={onShowParticipantsList}
+            />
+          )}
+          {isProcessingAtSymbol && hasOtherUsers && (
+            <UserMentionList
+              users={users}
+              query={atQuery}
+              onSelectUser={onSelectUserMention}
+              onClose={stopProcessingAtSymbol}
             />
           )}
           {enableMentions && !!query?.slice(1) && (

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Box, Typography } from '@mui/material';
 
 import { NewConversationHelpers } from '@/[fsd]/features/chat/lib/helpers';
-import { useSlashMention } from '@/[fsd]/features/chat/lib/hooks';
+import { useNewStartConversationInputKeyDownHandler, useSlashMention } from '@/[fsd]/features/chat/lib/hooks';
 import { SlashSuggestionList } from '@/[fsd]/features/chat/ui';
 import { DEFAULT_STEPS_LIMIT } from '@/[fsd]/shared/lib/constants/llmSettings.constants';
 import { useSystemSenderName } from '@/[fsd]/shared/lib/hooks/useEnvironmentSettingByKey.hooks';
@@ -33,7 +33,6 @@ import useValidateApplicationVersion, {
 import useValidateToolkit, { useToolkitValidationInfo } from '@/hooks/application/useValidateToolkit';
 import useChatStreaming from '@/hooks/chat/useChatStreaming';
 import useFetchParticipantDetails from '@/hooks/chat/useFetchParticipantDetails';
-import { useNewStartConversationInputKeyDownHandler } from '@/hooks/chat/useInputKeyDownHandler';
 import useLocalActiveParticipant from '@/hooks/chat/useLocalActiveParticipant';
 import useNewConversationAttachments from '@/hooks/chat/useNewConversationAttachments';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';


### PR DESCRIPTION
- Add @-symbol tracking to useNewInputKeyDownHandler (atQuery, atAnchorRef, stopProcessingAtSymbol); extract PRINTABLE_ASCII_REGEX constant
- Add UserMentionList component with keyboard navigation (ArrowUp/Down/Enter) and active-item highlight; hide in private chats via hasOtherUsers guard
- Wire UserMentionList into ChatBox with onSelectUserMention handler and hasOtherUsers memo; fix @everyone to send participant row IDs (.id)
- Export new hook and component from FSD barrel files

<img width="643" height="350" alt="image" src="https://github.com/user-attachments/assets/2bedaa16-9cae-46a3-993b-8f28aae1dd02" />

## PR description

Implements `@` user mention suggestions in the chat input, matching the existing `#` agent/tool suggestion UX.

**Changes:**
- Typing `@` in the chat input opens a **Participants** popup filtered by the typed name
- Selecting a user (click or `ArrowUp`/`ArrowDown`/`Enter`) inserts their name into the input and triggers mention detection
