### PR TITLE
fix: [EL-4900] keep Request App catalog in card view

### DIFF
--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
@@ -177,6 +177,7 @@ const ApplicationCatalog = memo(() => {
           cardType={ContentType.AppAll}
           loadMoreFunc={handleLoadMore}
           isFullWidth
+          disableTableView
           cardHeight="14rem"
           cardWidthOverride={APPLICATION_CATALOG_CARD_WIDTH}
           emptyListPlaceHolder={
@@ -249,6 +250,7 @@ const applicationCatalogStyles = () => ({
     flexWrap: 'wrap',
     alignItems: 'center',
     gap: '0.5rem',
+    mb: '0.25rem',
   },
   ...applicationActionButtonStyles,
   cardMeta: {

--- a/src/[fsd]/pages/apps/Apps.jsx
+++ b/src/[fsd]/pages/apps/Apps.jsx
@@ -6,7 +6,7 @@ import { Typography } from '@mui/material';
 
 import { ApplicationCatalog } from '@/[fsd]/features/apps/ui/catalog';
 import ToolkitsList from '@/[fsd]/features/toolkits/ui/list/ToolkitsList';
-import { AppsTabs, ContentType } from '@/common/constants';
+import { AppsTabs, ContentType, SearchParams } from '@/common/constants';
 import StickyTabs from '@/components/StickyTabs';
 import ViewToggle from '@/components/ViewToggle';
 import useShouldCollapseRightToolbar from '@/hooks/useShouldCollapseRightToolbar';
@@ -27,6 +27,16 @@ const CONFIGURED_APPS_EMPTY_PLACEHOLDER = (
   </Typography>
 );
 
+const getSearchForAppsTab = (nextTab, search) => {
+  if (nextTab !== AppsTabs[0]) return search;
+
+  const searchParams = new URLSearchParams(search);
+  searchParams.delete(SearchParams.View);
+
+  const nextSearch = searchParams.toString();
+  return nextSearch ? `?${nextSearch}` : '';
+};
+
 const Apps = memo(() => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -35,22 +45,28 @@ const Apps = memo(() => {
 
   const normalizedTab =
     LEGACY_APPS_TABS[tab] || (APP_TAB_INDEX_BY_KEY[tab] === undefined ? AppsTabs[0] : tab);
+  const normalizedSearch = useMemo(
+    () => getSearchForAppsTab(normalizedTab, location.search),
+    [location.search, normalizedTab],
+  );
   const selectedTab = APP_TAB_INDEX_BY_KEY[normalizedTab] ?? APP_TAB_INDEX_BY_KEY[AppsTabs[0]];
   const isConfiguredTab = selectedTab === APP_TAB_INDEX_BY_KEY[AppsTabs[1]];
 
   useEffect(() => {
-    if (normalizedTab === tab) return;
+    if (normalizedTab === tab && normalizedSearch === location.search) return;
 
-    navigate(`${RouteDefinitions.Apps}/${normalizedTab}${location.search}`, {
+    navigate(`${RouteDefinitions.Apps}/${normalizedTab}${normalizedSearch}`, {
       replace: true,
       state: location.state,
     });
-  }, [location.search, location.state, navigate, normalizedTab, tab]);
+  }, [location.search, location.state, navigate, normalizedSearch, normalizedTab, tab]);
 
   const handleChangeTab = useCallback(
     nextTabIndex => {
       const nextTab = AppsTabs[nextTabIndex] || AppsTabs[0];
-      navigate(`${RouteDefinitions.Apps}/${nextTab}${location.search}`, {
+      const nextSearch = getSearchForAppsTab(nextTab, location.search);
+
+      navigate(`${RouteDefinitions.Apps}/${nextTab}${nextSearch}`, {
         state: location.state,
       });
     },

--- a/src/[fsd]/pages/apps/Apps.jsx
+++ b/src/[fsd]/pages/apps/Apps.jsx
@@ -27,27 +27,27 @@ const CONFIGURED_APPS_EMPTY_PLACEHOLDER = (
   </Typography>
 );
 
-const getSearchForAppsTab = (nextTab, search) => {
-  if (nextTab !== AppsTabs[0]) return search;
-
-  const searchParams = new URLSearchParams(search);
-  searchParams.delete(SearchParams.View);
-
-  const nextSearch = searchParams.toString();
-  return nextSearch ? `?${nextSearch}` : '';
-};
-
 const Apps = memo(() => {
   const navigate = useNavigate();
   const location = useLocation();
   const { tab = AppsTabs[0] } = useParams();
   const { shouldCollapseRightToolbar } = useShouldCollapseRightToolbar();
 
+  const getSearchForAppsTab = useCallback((nextTab, search) => {
+    if (nextTab !== AppsTabs[0]) return search;
+
+    const searchParams = new URLSearchParams(search);
+    searchParams.delete(SearchParams.View);
+
+    const nextSearch = searchParams.toString();
+    return nextSearch ? `?${nextSearch}` : '';
+  }, []);
+
   const normalizedTab =
     LEGACY_APPS_TABS[tab] || (APP_TAB_INDEX_BY_KEY[tab] === undefined ? AppsTabs[0] : tab);
   const normalizedSearch = useMemo(
     () => getSearchForAppsTab(normalizedTab, location.search),
-    [location.search, normalizedTab],
+    [getSearchForAppsTab, location.search, normalizedTab],
   );
   const selectedTab = APP_TAB_INDEX_BY_KEY[normalizedTab] ?? APP_TAB_INDEX_BY_KEY[AppsTabs[0]];
   const isConfiguredTab = selectedTab === APP_TAB_INDEX_BY_KEY[AppsTabs[1]];
@@ -70,7 +70,7 @@ const Apps = memo(() => {
         state: location.state,
       });
     },
-    [location.search, location.state, navigate],
+    [getSearchForAppsTab, location.search, location.state, navigate],
   );
 
   const tabs = useMemo(

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -20,6 +20,7 @@ const CardList = props => {
     isFullWidth = false,
     cardHeight,
     cardWidthOverride,
+    disableTableView = false,
     resetPageOnSort,
     ...rest
   } = props;
@@ -29,6 +30,7 @@ const CardList = props => {
   const isEmptyList = useMemo(() => cardList.length === 0, [cardList.length]);
   const shouldShowRightPanel = Boolean(rightPanelContent) && !shouldCollapseRightToolbar;
   const isListFullWidth = isFullWidth || !shouldShowRightPanel;
+  const shouldRenderTable = isTableView && !disableTableView;
 
   return (
     <>
@@ -40,7 +42,7 @@ const CardList = props => {
           isFullWidth={isListFullWidth}
           sx={emptyListSX}
         />
-      ) : isTableView ? (
+      ) : shouldRenderTable ? (
         <DataTable
           data={cardList}
           isFullWidth={isListFullWidth}


### PR DESCRIPTION
## Summary
- keep the Request App catalog locked to card rendering even when the URL has `?view=table` from the Configured tab
- preserve table/card switching for the Configured tab only
- raise the request-card action row slightly so buttons do not sit on the card content border

## Validation
- git diff --check
- npm run lint
- NODE_OPTIONS=--max-old-space-size=8192 npm run build
- copied the built `dist` to the local Pylon `elitea_core` UI dist and verified `/app/apps/configured?view=table` remains table while `/app/apps/request?view=table` renders cards only

Closes EliteaAI/elitea_issues#4900