### PR TITLE
fix(chat): [EL-4164] remove toast notification for chat errors

### DIFF
--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -568,15 +568,11 @@ const ChatBox = forwardRef((props, boxRef) => {
 
   const [conversationEdit] = useConversationEditMutation();
 
-  const handleError = useCallback(
-    errorObj => {
-      toastError(buildErrorMessage(errorObj));
-      if (isRegenerating) {
-        setIsRegenerating(false);
-      }
-    },
-    [isRegenerating, toastError],
-  );
+  const handleError = useCallback(() => {
+    if (isRegenerating) {
+      setIsRegenerating(false);
+    }
+  }, [isRegenerating]);
 
   const onDeleteChatMessage = useCallback(
     async (messageIdToDelete, callback) => {


### PR DESCRIPTION
Remove error toast popup for chat/agent execution errors.

Per EPIC #2639 redesign requirements, error messages should display inline only (red border box with "Unknown error" fallback), not as toast notifications.
