### PR TITLE
fix: show error message content when tool execution fails

### DIFF
--- a/src/[fsd]/features/toolkits/indexes/lib/helpers/indexChat.helpers.js
+++ b/src/[fsd]/features/toolkits/indexes/lib/helpers/indexChat.helpers.js
@@ -278,6 +278,8 @@ export const generateChatMessageBasedOnResponse = ({ message, chatHistory, onFin
         msg.isLoading = false;
         msg.isStreaming = false;
         msg.exception = message.content;
+        // Update visible content to show error message instead of "Testing tool..."
+        msg.content = convertJsonToString(message.content);
 
         onFinish(IndexStatuses.fail);
       } else {


### PR DESCRIPTION
Previously, when a tool call failed with an exception, the chat message continued showing "Testing tool..." instead of the actual error. Now the error message is displayed directly in the message content.

Before:
<img width="688" height="437" alt="image" src="https://github.com/user-attachments/assets/1b14f181-73a6-43e3-9cdb-040a8026d702" />

After:
<img width="695" height="258" alt="image" src="https://github.com/user-attachments/assets/fc65a3a5-f569-4b25-82c4-c1e699ef7ede" />
