### PR TITLE
fix: [EL-4910] Fixed when clicking pin/unpin and dot menu triggered bucket expansion

### DIFF
--- a/src/pages/Artifacts/Components/BucketItem.jsx
+++ b/src/pages/Artifacts/Components/BucketItem.jsx
@@ -120,10 +120,7 @@ export const BucketItem = forwardRef((props, ref) => {
 
   const onShowMenuList = useCallback(() => {
     setShowMenu(true);
-    if (!isActive) {
-      onSelect(bucket);
-    }
-  }, [bucket, isActive, onSelect]);
+  }, []);
 
   const menuItems = useMemo(() => {
     const hasActionRights = action =>
@@ -241,19 +238,25 @@ export const BucketItem = forwardRef((props, ref) => {
       </Box>
 
       {isPinned && (
-        <Button.BaseBtn
-          component={PinIconFilled}
-          sx={styles.menuIcon}
-          onClick={e => handlePinBucket(e)}
-        />
+        <Box onClick={e => e.stopPropagation()}>
+          <Button.BaseBtn
+            variant="tertiary"
+            startIcon={<PinIconFilled />}
+            sx={styles.pinIcon}
+            onClick={handlePinBucket}
+          />
+        </Box>
       )}
 
       {!isPinned && isHovering && (
-        <Button.BaseBtn
-          component={PinIcon}
-          sx={styles.menuIcon}
-          onClick={e => handlePinBucket(e)}
-        />
+        <Box onClick={e => e.stopPropagation()}>
+          <Button.BaseBtn
+            variant="tertiary"
+            startIcon={<PinIcon />}
+            sx={styles.pinIcon}
+            onClick={handlePinBucket}
+          />
+        </Box>
       )}
 
       <Box
@@ -373,6 +376,16 @@ const bucketItemStyles = ({ isActive, isHovering, isNextItemHighlighted, showMen
       },
     },
     menuIcon: { fontSize: '1rem', color: theme.palette.icon.fill.default },
+    pinIcon: {
+      minWidth: '1.75rem',
+      width: '1.75rem',
+      height: '1.75rem',
+      padding: 0,
+      gap: 0,
+      '& .MuiButton-startIcon': {
+        margin: 0,
+      },
+    },
   };
 };
 

--- a/src/pages/Artifacts/Components/BucketsListContent.jsx
+++ b/src/pages/Artifacts/Components/BucketsListContent.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
@@ -27,6 +27,24 @@ const BucketsListContent = memo(props => {
     onPin,
   } = props;
 
+  const [expandedBuckets, setExpandedBuckets] = useState({});
+
+  const handleBucketToggle = useCallback(bucketName => {
+    setExpandedBuckets(prev => ({
+      ...prev,
+      [bucketName]: !prev[bucketName],
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (selectedBucketName && !expandedBuckets[selectedBucketName]) {
+      setExpandedBuckets(prev => ({
+        ...prev,
+        [selectedBucketName]: true,
+      }));
+    }
+  }, [selectedBucketName]);
+
   const styles = bucketsListContentStyles();
 
   const renderBucketsList = filtredBuckets => {
@@ -36,6 +54,7 @@ const BucketsListContent = memo(props => {
         selectedBucketName={selectedBucketName}
         selectedFile={selectedFile}
         currentPrefix={currentPrefix}
+        expandedBuckets={expandedBuckets}
         onEdit={onEdit}
         onDelete={onDelete}
         onSelect={onSelect}
@@ -43,6 +62,7 @@ const BucketsListContent = memo(props => {
         onSelectFile={onSelectFile}
         onSelectFolder={onSelectFolder}
         onPin={onPin}
+        onToggle={handleBucketToggle}
       />
     );
   };

--- a/src/pages/Artifacts/Components/SimpleBucketList.jsx
+++ b/src/pages/Artifacts/Components/SimpleBucketList.jsx
@@ -13,6 +13,7 @@ const SimpleBucketList = memo(props => {
     selectedBucketName,
     selectedFile,
     currentPrefix,
+    expandedBuckets,
     onEdit,
     onDelete,
     onSelect,
@@ -20,10 +21,10 @@ const SimpleBucketList = memo(props => {
     onSelectFile,
     onSelectFolder,
     onPin,
+    onToggle,
   } = props;
 
   const [hoveredBucketName, setHoveredBucketName] = useState(null);
-  const [expandedBuckets, setExpandedBuckets] = useState({});
   const selectedBucketRef = useRef(null);
   const hasInitialScrolledRef = useRef(false);
 
@@ -32,24 +33,6 @@ const SimpleBucketList = memo(props => {
   const handleItemHover = useCallback((bucketName, isHovered) => {
     setHoveredBucketName(isHovered ? bucketName : null);
   }, []);
-
-  const handleBucketToggle = useCallback(bucketName => {
-    setExpandedBuckets(prev => ({
-      ...prev,
-      [bucketName]: !prev[bucketName],
-    }));
-  }, []);
-
-  // Auto-expand selected bucket to show files (only when selection changes)
-  useEffect(() => {
-    if (selectedBucketName && !expandedBuckets[selectedBucketName]) {
-      setExpandedBuckets(prev => ({
-        ...prev,
-        [selectedBucketName]: true,
-      }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedBucketName]); // Only re-run when selectedBucketName changes, not expandedBuckets
 
   // Scroll to top only on initial load from URL
   useEffect(() => {
@@ -98,7 +81,7 @@ const SimpleBucketList = memo(props => {
                   isNextItemHighlighted={isNextBucketHighlighted}
                   onItemHover={handleItemHover}
                   isExpanded={isExpanded}
-                  onToggle={handleBucketToggle}
+                  onToggle={onToggle}
                   onPin={onPin}
                 />
                 {isExpanded && (


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4910

## Summary: Bucket Pin Click Behavior Fix

### Problem
Clicking the pin button on a bucket was triggering unintended bucket expansion, even when the bucket wasn't selected.

### Root Causes
1. Event bubbling from pin button to parent container
2. `onShowMenuList` was calling `onSelect(bucket)` which triggered selection
3. `expandedBuckets` state was local to `SimpleBucketList` — when a bucket moved between pinned/unpinned lists (separate component instances), state was lost and useEffect auto-expanded

### Changes Made

| File | Change | Reason |
|------|--------|--------|
| `BucketItem.jsx` | Wrapped pin `Button.BaseBtn` in `<Box onClick={e => e.stopPropagation()}>` | Prevent click event from bubbling to parent's `handleSelectBucket` |
| `BucketItem.jsx` | Removed `onSelect(bucket)` call from `onShowMenuList` | Prevent DotMenu click from auto-selecting/expanding bucket |
| `BucketItem.jsx` | Changed `component={PinIcon}` to `variant="tertiary" startIcon={<PinIcon />}` | Fix MUI ref warning — SVG components don't support refs |
| `BucketItem.jsx` | Added `pinIcon` style with `gap: 0`, `margin: 0` | Center icon properly in button |
| `BucketsListContent.jsx` | Lifted `expandedBuckets` state and `handleBucketToggle` from `SimpleBucketList` | Share expansion state across pinned/unpinned lists to preserve it when bucket moves |
| `SimpleBucketList.jsx` | Removed local `expandedBuckets` state and auto-expand `useEffect`; now receives `expandedBuckets` and `onToggle` as props | Use shared state from parent |

<img width="411" height="943" alt="image" src="https://github.com/user-attachments/assets/d6218303-54d5-4e0c-8817-3d2728839202" />
