### PR TITLE
feat: [EL-4766] add file attachment support to pipeline chat

### DIFF
--- a/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
@@ -1,8 +1,9 @@
 import { memo, useMemo } from 'react';
 
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import { AgentInput, ApplicationTools } from '@/[fsd]/features/agent/ui/agent-details/configurations';
+import { AttachmentSwitch } from '@/[fsd]/features/agent/ui/agent-details/configurations/switch';
 import { ViewMode } from '@/common/constants.js';
 import ApplicationAdvanceSettings from '@/components/ApplicationAdvanceSettings';
 import ConversationStarters from '@/components/ConversationStarters';
@@ -35,6 +36,10 @@ const PipelineConfigurationForm = memo(props => {
         onAttachmentToolChange={onAttachmentToolChange}
         entityProjectId={entityProjectId}
       />
+      <Box sx={styles.internalToolsSection}>
+        <Typography sx={styles.internalToolsLabel}>INTERNAL TOOLS</Typography>
+        <AttachmentSwitch disabled={isDisabled} />
+      </Box>
       {!isDisabled && (
         <>
           <AgentInput.WelcomeMessageInput />
@@ -63,6 +68,17 @@ const pipelineConfigurationFormStyles = isChatView => ({
   applicationTools: {
     marginTop: !isChatView ? '1rem' : 0,
   },
+  internalToolsSection: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+  },
+  internalToolsLabel: ({ palette }) => ({
+    fontSize: '0.75rem',
+    fontWeight: 500,
+    lineHeight: '1rem',
+    marginBottom: '0.75rem',
+    color: palette.text.secondary,
+  }),
   conversationStarters: {
     marginTop: '1rem',
   },

--- a/src/pages/Pipelines/Components/ChatPanel.jsx
+++ b/src/pages/Pipelines/Components/ChatPanel.jsx
@@ -177,7 +177,7 @@ const ChatPanel = forwardRef((props, ref) => {
               chatOnly
               type="chat"
               isAgentsPage={true}
-              hideAttachments={true}
+              hideAttachments={settings.disableAttachments}
               ref={boxRef}
               inputPlaceholder="Type your message."
             />


### PR DESCRIPTION
- Adds the Attachments toggle in PipelineConfigurationForm (INTERNAL TOOLS section)
- Makes hideAttachments conditional in ChatPanel based on settings.disableAttachments

<img width="1177" height="754" alt="image" src="https://github.com/user-attachments/assets/25c7941e-9719-4f03-868b-34bdc58a2c3b" />
<img width="1118" height="407" alt="image" src="https://github.com/user-attachments/assets/6cfe5295-11e2-4378-9858-98dd3db6b3be" />


# Pipeline file attachments

## Summary

Adds file attachment support to pipeline chat. Previously, attachments were unconditionally hidden in the
pipeline chat UI, and the backend would perform full content extraction (OCR, vectorisation, etc.) regardless
of the application type.

With this change:

- A new **Attachments** toggle in the pipeline configuration form lets admins opt a specific pipeline in to
  accepting file attachments.
- When a user attaches a file and sends a message to a pipeline, the backend appends only the file path to the
  `input` state variable as:
  ```
  <user message>
  attached file path "attachments/{conversation_id}/{filename}"
  ```
  No content embedding or extraction is performed. The pipeline node can then use any file-reading tool it has
  access to in order to process the file on demand.

---

## Changes

### Frontend — EliteaUI (`feat/EL-4766/pipeline-file-attachments`)

#### `src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx`

Adds an **INTERNAL TOOLS** section to the pipeline configuration form with an `AttachmentSwitch` component.
The switch toggles `'attachments'` in `version_details.meta.internal_tools`, which is persisted with the
pipeline version and read by `ChatPanel` to derive `settings.disableAttachments`.

```diff
+import { AttachmentSwitch } from '@/[fsd]/features/agent/ui/agent-details/configurations/switch';
 ...
+      <Box sx={styles.internalToolsSection}>
+        <Typography sx={styles.internalToolsLabel}>INTERNAL TOOLS</Typography>
+        <AttachmentSwitch disabled={isDisabled} />
+      </Box>
```

#### `src/pages/Pipelines/Components/ChatPanel.jsx`

The attachment input in the pipeline chat was previously always hidden (`hideAttachments={true}`). It is now
controlled by the pipeline's configuration flag:

```diff
-              hideAttachments={true}
+              hideAttachments={settings.disableAttachments}
```

---

### Backend — pylon_main (separate repo / PR)

#### `plugins/elitea_core/utils/attachments.py`

**`ProcessorContext`** — new optional parameter:

```python
simple_attachment_format: bool = False,
```

**`DocumentToModelProcessor.process()`** — early-return branch for pipeline mode that emits only the file path
and skips all content extraction:

```python
if getattr(context, 'simple_attachment_format', False):
    relative_path = (context.filepath or '').lstrip('/')
    return {
        "type": "text",
        "content": [{"type": "text", "text": f'attached file path "{relative_path}"'}],
        "needs_content_extraction": False,
    }
```

**`process_single_attachment_file()`** — new optional parameter `simple_attachment_format` that is forwarded
to `FileToAIProcessorCollector.process_file()` → `ProcessorContext`.

#### `plugins/elitea_core/rpc/chat_all.py`

**`process_attachment_message_items()`** — new optional parameter `simple_attachment_format`. Content
extraction is skipped when the flag is set:

```python
if items_needing_content and not simple_attachment_format:
    # ... read_file_content, vectorisation, etc.
```

**`predict_sio`** — pipeline detection before calling `process_attachment_message_items`:

```python
is_pipeline = False
sent_to = msg_group.sent_to
if (
    sent_to is not None
    and str(sent_to.entity_name) == ParticipantTypes.application.value
):
    app_id = sent_to.entity_meta.get('id')
    if app_id:
        is_pipeline = session.query(ApplicationVersion).filter(
            ApplicationVersion.application_id == app_id,
            ApplicationVersion.agent_type == AgentTypes.pipeline.value,
        ).first() is not None
msg_group = process_attachment_message_items(
    ...,
    simple_attachment_format=is_pipeline,
)
```

---

## How it works end-to-end

1. User enables attachments for a pipeline via the new **Attachments** toggle in the pipeline's configuration
   form.
2. `settings.disableAttachments` becomes `false` in `ChatPanel`, revealing the file attachment button in the
   chat input.
3. User attaches a file and sends a message. The frontend includes
   `attachments_info: [{ filepath: "/attachments/{conv_id}/{filename}" }]` in the socket payload.
4. `predict_sio` detects the recipient is a pipeline application by querying
   `ApplicationVersion.agent_type == 'pipeline'` and sets `simple_attachment_format=True`.
5. `DocumentToModelProcessor.process()` returns `attached file path "attachments/{conv_id}/{filename}"` — no
   extraction, no LLM call.
6. The pipeline node receives its `input` state with the file path appended, and can invoke any file-reading
   tool as needed.

---

## Testing

- Enable the **Attachments** toggle for a pipeline in the configuration form.
- Attach a file in the pipeline chat and send a message.
- Verify the pipeline node's `input` contains `attached file path "attachments/..."`.
- Verify that non-pipeline applications (agents, assistants) are unaffected and still receive full content
  extraction.

