### PR TITLE
fix: [EL-4921] preserve chat input during participant selection

### DIFF
--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1398,11 +1398,12 @@ const ChatBox = forwardRef((props, boxRef) => {
 
   const onSelectParticipant = selectedParticipant => {
     const isSearchParticipant = isProcessingSymbols;
+    const currentQuery = query;
     stopProcessingSymbols();
     setTimeout(() => {
       onSelectThisParticipant(selectedParticipant);
       if (isSearchParticipant) {
-        chatInput.current?.reset();
+        chatInput.current?.removeSymbol(currentQuery);
       }
     }, 0);
   };

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -102,8 +102,23 @@ const NewChatInput = forwardRef((props, ref) => {
     isTTSPlaying,
   });
 
-  // Forward the same imperative handle the outer caller expects from UserInput
-  useImperativeHandle(ref, () => userInputRef.current, []);
+  // Expose a stable imperative API while delegating each call to the latest UserInput handle.
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => userInputRef.current?.focus?.(),
+      reset: () => userInputRef.current?.reset?.(),
+      getInputContent: () => userInputRef.current?.getInputContent?.(),
+      getCursorPosition: () => userInputRef.current?.getCursorPosition?.(),
+      setValue: (...args) => userInputRef.current?.setValue?.(...args),
+      replaceRange: (...args) => userInputRef.current?.replaceRange?.(...args),
+      removeSymbol: (...args) => userInputRef.current?.removeSymbol?.(...args),
+      sendQuestion: (...args) => userInputRef.current?.sendQuestion?.(...args),
+      insertTextAtCursor: (...args) => userInputRef.current?.insertTextAtCursor?.(...args),
+      mentionUser: (...args) => userInputRef.current?.mentionUser?.(...args),
+    }),
+    [],
+  );
 
   const handleVoiceRecordingChange = useCallback(
     recording => {

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -433,7 +433,6 @@ const NewConversationView = forwardRef(
 
       if (isProcessingSymbols) {
         stopProcessingSymbols();
-        chatInput.current?.reset();
       }
 
       const details =


### PR DESCRIPTION
## Summary

This PR fixes the `@mention` bug where selecting a participant could clear existing message content instead of
preserving the draft and inserting the mention into the current input.

## Issue

When a user already had text in the input and then selected a participant:

- selecting a user mention could replace the visible draft instead of preserving the existing message content
- imperative input actions could operate on stale input state and behave as if the draft were empty

## Changes

- updated participant selection flows in `ChatBox` and `NewConversationView` to preserve existing draft
  content instead of clearing the whole input
- replaced direct imperative ref forwarding in `NewChatInput` with a stable proxy API so actions like
  `mentionUser` and `replaceRange` always delegate to the latest `UserInput` handle

## Result

- existing text stays in the input after selecting a user mention
- the selected mention is applied to the current draft instead of replacing it
- mention-related input actions use the current draft state instead of stale state

## Testing

Not run locally.

Recommended manual checks:

1. Type a message with existing text, then select a user from `@mention` suggestions in the chat input.
2. Type a message with existing text, then select `@Everyone` or another user participant from the UI.
3. Verify the existing draft text remains and the selected mention is inserted into the current message.
