### PR TITLE
fix: [EL-0000] Fixed tertiary variant for adjusting a layout of the icon

### DIFF
--- a/src/[fsd]/shared/ui/button/BaseBtn.jsx
+++ b/src/[fsd]/shared/ui/button/BaseBtn.jsx
@@ -408,7 +408,16 @@ export const eliteaButtonVariants = [
         minWidth: '1.75rem !important',
         borderRadius: '1rem',
         gap: '0.625rem',
-        ...(isIconOnly ? { width: '1.75rem', padding: 0 } : { padding: '0.375rem 1rem' }),
+        ...(isIconOnly
+          ? {
+              width: '1.75rem',
+              padding: 0,
+              gap: 0,
+              '& .MuiButton-startIcon': {
+                margin: '0 !important',
+              },
+            }
+          : { padding: '0.375rem 1rem' }),
 
         '--btn-icon-fill': theme.palette.icon.fill.default,
         '& .MuiButton-startIcon path': { fill: 'var(--btn-icon-fill)' },


### PR DESCRIPTION
Samvel`s request

## Summary

| Where | What | Why |
|-------|------|-----|
| BaseBtn.jsx:415 | Added `gap: 0` for icon-only tertiary | **Main fix:** Default gap (0.625rem) created extra space in flex layout |
| BaseBtn.jsx:416-418 | Added `'& .MuiButton-startIcon': { margin: '0 !important' }` | **Main fix:** Override MUI default margins (-4px left, 8px right) |

**Root cause:** MUI Button applies default margins to `.MuiButton-startIcon` (`margin-left: -4px`, `margin-right: 8px`). Custom styles with `margin: 0` had insufficient specificity to override. Solution: use `!important` and remove flex `gap` for icon-only buttons.

<img width="318" height="101" alt="Screenshot 2026-05-15 113825" src="https://github.com/user-attachments/assets/b60b11ac-0ef7-411a-9c74-ae61121a5c7d" />
