### PR TITLE
feat: [EL-4501] change architect of tts

### DIFF
--- a/src/[fsd]/features/chat/lib/helpers/asr.helpers.js
+++ b/src/[fsd]/features/chat/lib/helpers/asr.helpers.js
@@ -1,0 +1,6 @@
+/**
+ * Returns true for batch HTTP transcription models (whisper-1, gpt-4o-transcribe, etc.).
+ * Mirrors the backend _is_whisper_model() check in elitea_core/sio/asr.py.
+ */
+export const isWhisperModel = name =>
+  Boolean(name && (name.toLowerCase().includes('whisper') || name.toLowerCase().includes('transcribe')));

--- a/src/[fsd]/features/chat/lib/helpers/index.js
+++ b/src/[fsd]/features/chat/lib/helpers/index.js
@@ -1,3 +1,4 @@
 export * as ChatHelpers from './chat.helpers.js';
 export * as NewConversationHelpers from './newConversation.helpers.js';
 export { toSpeakableText, translateSpokenPos } from './tts.helpers.js';
+export { isWhisperModel } from './asr.helpers.js';

--- a/src/[fsd]/features/chat/lib/helpers/tts.helpers.js
+++ b/src/[fsd]/features/chat/lib/helpers/tts.helpers.js
@@ -105,6 +105,192 @@ const inlineText = tokens => {
     .join('');
 };
 
+/**
+ * Like inlineText but also builds fine-grained segments so each text run maps
+ * precisely to its position in the original markdown.
+ *
+ * origBase    — absolute start position of these tokens in the original markdown
+ * strippedBase — absolute start position of these tokens in the stripped text
+ *
+ * Returns { text: string, segments: Segment[] }
+ * where Segment = { origStart, origLen, strippedStart, strippedLen }
+ *
+ * Segments for leaf text tokens have a 1:1 char mapping (modulo emoji
+ * stripping which is rare mid-word), so translateSpokenPos works correctly.
+ */
+const inlineTextSegments = (tokens, origBase, strippedBase) => {
+  if (!tokens?.length) return { text: '', segments: [] };
+
+  let origOffset = 0;
+  let strippedOffset = 0;
+  const segments = [];
+  const parts = [];
+
+  for (const token of tokens) {
+    const tokenOrigStart = origBase + origOffset;
+
+    switch (token.type) {
+      case 'text': {
+        if (token.tokens?.length) {
+          // text token wrapping sub-tokens — recurse at same origBase; no extra delimiter
+          const inner = inlineTextSegments(token.tokens, tokenOrigStart, strippedBase + strippedOffset);
+          segments.push(...inner.segments);
+          parts.push(inner.text);
+          strippedOffset += inner.text.length;
+        } else {
+          const piece = stripEmoji(token.text ?? token.raw ?? '');
+          if (piece) {
+            segments.push({
+              origStart: tokenOrigStart,
+              origLen: token.raw.length,
+              strippedStart: strippedBase + strippedOffset,
+              strippedLen: piece.length,
+            });
+            parts.push(piece);
+            strippedOffset += piece.length;
+          }
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'em':
+      case 'strong':
+      case 'strong_em': {
+        // Skip the opening delimiter (* / ** / ***) so inner content maps 1:1
+        const delimLen = token.type === 'strong_em' ? 3 : token.type === 'strong' ? 2 : 1;
+        const innerTokens = token.tokens ?? [];
+        const inner = inlineTextSegments(
+          innerTokens,
+          tokenOrigStart + delimLen,
+          strippedBase + strippedOffset,
+        );
+        segments.push(...inner.segments);
+        parts.push(inner.text);
+        strippedOffset += inner.text.length;
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'link': {
+        const href = token.href ?? '';
+        const linkTokens = token.tokens ?? [];
+        const textFromTokens = inlineText(linkTokens);
+        if (isUrl(href)) {
+          const piece =
+            !textFromTokens || textFromTokens === href || isUrl(textFromTokens) ? 'the link' : textFromTokens;
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        } else if (isFilePath(href)) {
+          const piece = !textFromTokens || textFromTokens === href ? 'the file path' : textFromTokens;
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        } else {
+          // Descriptive link — fine-grained segments for the display text (starts after '[')
+          const inner = inlineTextSegments(linkTokens, tokenOrigStart + 1, strippedBase + strippedOffset);
+          segments.push(...inner.segments);
+          parts.push(inner.text);
+          strippedOffset += inner.text.length;
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'image': {
+        const alt = stripEmoji(token.text ?? '').trim();
+        const piece = alt ? `an image showing ${alt}` : '';
+        if (piece) {
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'codespan': {
+        const piece = (token.text?.length ?? 0) <= 40 ? (token.text ?? '') : 'a code example';
+        if (piece) {
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'escape': {
+        const piece = token.text ?? '';
+        if (piece) {
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+
+      case 'br': {
+        segments.push({
+          origStart: tokenOrigStart,
+          origLen: token.raw.length,
+          strippedStart: strippedBase + strippedOffset,
+          strippedLen: 1,
+        });
+        parts.push('\n');
+        strippedOffset += 1;
+        origOffset += token.raw.length;
+        break;
+      }
+
+      default: {
+        const piece = stripEmoji(token.text ?? token.raw ?? '');
+        if (piece) {
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedBase + strippedOffset,
+            strippedLen: piece.length,
+          });
+          parts.push(piece);
+          strippedOffset += piece.length;
+        }
+        origOffset += token.raw.length;
+        break;
+      }
+    }
+  }
+
+  return { text: parts.join(''), segments };
+};
+
 // ─── Block token → speakable text ────────────────────────────────────────────
 
 /**
@@ -197,16 +383,33 @@ export const toSpeakableText = markdown => {
       // `html` blocks return '' from blockText; skip early to avoid empty segments.
       if (token.type === 'space' || token.type === 'html') continue;
 
-      const piece = blockText([token]);
-      if (piece) {
-        segments.push({
-          origStart: tokenOrigStart,
-          origLen: token.raw.length,
-          strippedStart: strippedPos,
-          strippedLen: piece.length,
-        });
-        strippedPos += piece.length;
-        parts.push(piece);
+      if (token.type === 'paragraph' || token.type === 'heading') {
+        // Fine-grained inline segments: one segment per leaf text run so
+        // translateSpokenPos gives word-level accuracy for highlight.
+        const { text: inlineResult, segments: inlineSegs } = inlineTextSegments(
+          token.tokens ?? [],
+          tokenOrigStart,
+          strippedPos,
+        );
+        if (inlineResult) {
+          segments.push(...inlineSegs);
+          const piece = inlineResult + '\n';
+          strippedPos += piece.length;
+          parts.push(piece);
+        }
+      } else {
+        // Coarse segment for code blocks, tables, lists, blockquotes, etc.
+        const piece = blockText([token]);
+        if (piece) {
+          segments.push({
+            origStart: tokenOrigStart,
+            origLen: token.raw.length,
+            strippedStart: strippedPos,
+            strippedLen: piece.length,
+          });
+          strippedPos += piece.length;
+          parts.push(piece);
+        }
       }
     }
 

--- a/src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isWhisperModel } from '@/[fsd]/features/chat/lib/helpers';
 import { sioEvents } from '@/common/constants';
 
 // Buffer sizes at 24 kHz — trade-off between latency and API call frequency
@@ -7,9 +8,6 @@ import { sioEvents } from '@/common/constants';
 // Realtime models stream continuously and benefit from lower latency.
 const BUFFER_SIZE_WHISPER = 7200; // 300 ms — reduce Whisper API call frequency
 const BUFFER_SIZE_REALTIME = 4800; // 200 ms — lower latency for streaming models
-
-// Mirrors the backend _is_whisper_model() check
-const isWhisperModel = name => Boolean(name && name.toLowerCase().includes('whisper'));
 
 // Target sample rate expected by both Whisper and the Realtime API
 const TARGET_SAMPLE_RATE = 24000;
@@ -119,16 +117,13 @@ export const useStreamingSpeechRecognition = ({
     };
   }, [socket]);
 
-  const float32ToPcm16Base64 = useCallback(float32Array => {
+  const float32ToPcm16Buffer = useCallback(float32Array => {
     const pcm = new Int16Array(float32Array.length);
     for (let i = 0; i < float32Array.length; i++) {
       const s = Math.max(-1, Math.min(1, float32Array[i]));
       pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
     }
-    const bytes = new Uint8Array(pcm.buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]);
-    return btoa(binary);
+    return pcm.buffer;
   }, []);
 
   const startRecording = useCallback(async () => {
@@ -168,8 +163,8 @@ export const useStreamingSpeechRecognition = ({
       });
 
       workletNode.port.onmessage = e => {
-        const base64 = float32ToPcm16Base64(e.data);
-        socket.emit(sioEvents.asr_audio_chunk, { audio_base64: base64 });
+        const pcm16Buffer = float32ToPcm16Buffer(e.data);
+        socket.emit(sioEvents.asr_audio_chunk, { audio: pcm16Buffer });
       };
 
       const gainNode = audioContext.createGain();
@@ -196,7 +191,7 @@ export const useStreamingSpeechRecognition = ({
       else if (err.name === 'NotFoundError') onErrorRef.current?.('audio-capture');
       else onErrorRef.current?.('network');
     }
-  }, [socket, projectId, asrModel, float32ToPcm16Base64]);
+  }, [socket, projectId, asrModel, float32ToPcm16Buffer]);
 
   const _releaseAudio = useCallback(() => {
     // Null refs first so concurrent calls (stopRecording + unmount) don't double-close

--- a/src/[fsd]/features/chat/lib/hooks/useTextToSpeech.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useTextToSpeech.hooks.js
@@ -74,6 +74,21 @@ const findCharAtTime = (times, t) => {
 // Reducer that bails out (returns the same reference) when the new range
 // is identical to the current one. This prevents unnecessary re-renders
 // when the RAF loop calls setSpokenRange on every frame with the same word.
+
+/** Decode raw binary PCM-16-LE to a Float32Array of normalised [-1, 1] samples. */
+const decodePcm16 = audio => {
+  const bytes =
+    audio instanceof ArrayBuffer
+      ? new Uint8Array(audio)
+      : new Uint8Array(audio.buffer, audio.byteOffset, audio.byteLength);
+  const samples = new Float32Array(bytes.byteLength / 2);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let i = 0; i < samples.length; i++) {
+    samples[i] = view.getInt16(i * 2, true) / 32768.0;
+  }
+  return samples;
+};
+
 const spokenRangeReducer = (prev, next) => {
   if (next === null) return prev === null ? prev : null;
   if (prev && prev.start === next.start && prev.end === next.end) return prev;
@@ -115,6 +130,30 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
   // Punctuation-aware char timeline for the current session.
   // Built in speak() from the TTS text + calibratedRate.
   const charTimelineRef = useRef(null);
+  // Sentence waypoints: exact { charPos, audioTime } anchors received from the
+  // backend tts_done events that carry char_end.  audioTime is seconds elapsed
+  // from playback start (nextStartTimeRef - playStartTimeRef at the moment the
+  // sentence's audio finishes buffering).  Used for linear interpolation in the
+  // RAF loop to give near-exact word highlight synchronisation.
+  const sentenceWaypointsRef = useRef([]); // [{ charPos, audioTime }]
+  // 1-chunk pipeline buffer. A fade-out is applied to the tail of the pending chunk
+  // right before it is scheduled, and a fade-in to the head of the first chunk of
+  // each new sentence. This eliminates amplitude discontinuities at sentence
+  // boundaries (the main source of audible pops).
+  const pendingChunkRef = useRef(null); // { samples: Float32Array, sample_rate }
+  // True at the start of every sentence — reset after the first chunk of that sentence is enqueued.
+  const newSentenceRef = useRef(true);
+  // Buffered-playback refs — incoming PCM is queued here; a scheduler loop
+  // pulls from it and pre-schedules audio into the AudioContext to prevent
+  // buffer underruns caused by network jitter.
+  const pcmQueueRef = useRef([]); // [{ samples: Float32Array, sampleRate: number }]
+  const schedulerTimerRef = useRef(null); // setInterval ID for the scheduler loop
+  const finalTtsDoneRef = useRef(false); // true once the final tts_done (no char_end) fires
+  // Monotonically-increasing count of samples enqueued this session — used to
+  // compute sentence-waypoint audioTime independently of how far the scheduler
+  // has advanced, so waypoints are correct even when buffering introduces lag.
+  const totalEnqueuedSamplesRef = useRef(0);
+  const sampleRateRef = useRef(24000); // sample rate of the current TTS stream
 
   const isPlaying = status === 'playing';
   const isPaused = status === 'paused';
@@ -167,60 +206,90 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
     totalDurationRef.current = 0;
     allChunksReceivedRef.current = false;
     charTimelineRef.current = null;
+    sentenceWaypointsRef.current = [];
+    pendingChunkRef.current = null;
+    newSentenceRef.current = true;
+    clearInterval(schedulerTimerRef.current);
+    schedulerTimerRef.current = null;
+    pcmQueueRef.current = [];
+    finalTtsDoneRef.current = false;
+    totalEnqueuedSamplesRef.current = 0;
   }, []);
 
-  const playPcm16Chunk = useCallback(
-    (audio_base64, sample_rate = 24000) => {
-      const ctx = ensureAudioContext(sample_rate);
-      if (!ctx) return;
+  // Push decoded samples into the playback queue. All fades must be applied
+  // in-place by the caller before this function is called. The scheduler loop
+  // (scheduleFromQueue) is responsible for actually sending buffers to the
+  // AudioContext — that decoupling is what prevents buffer underruns.
+  //
+  // Tiny fragments (< 1 render quantum = 128 samples) are merged into the
+  // previous queue entry instead of being scheduled as separate AudioBufferSourceNodes.
+  // The HTTP chunked-transfer encoding occasionally produces 1–4 byte trailing
+  // fragments at sentence boundaries, which cause amplitude discontinuities
+  // when played back as individual 1–2 sample buffers (below the Web Audio
+  // render quantum), manifesting as audible pops.
+  const enqueueSamples = useCallback((samples, sampleRate = 24000) => {
+    sampleRateRef.current = sampleRate;
+    const QUANTUM = 128; // Web Audio API render quantum — sub-quantum buffers cause pops
+    if (samples.length < QUANTUM && pcmQueueRef.current.length > 0) {
+      // Merge tiny fragment into the tail of the previous segment
+      const last = pcmQueueRef.current[pcmQueueRef.current.length - 1];
+      const merged = new Float32Array(last.samples.length + samples.length);
+      merged.set(last.samples, 0);
+      merged.set(samples, last.samples.length);
+      pcmQueueRef.current[pcmQueueRef.current.length - 1] = { samples: merged, sampleRate };
+    } else {
+      pcmQueueRef.current.push({ samples, sampleRate });
+    }
+    totalEnqueuedSamplesRef.current += samples.length;
+  }, []);
+
+  // Scheduler tick — invoked by setInterval every 25 ms.
+  // Pulls segments from pcmQueueRef and pre-schedules them into the AudioContext
+  // up to LOOKAHEAD seconds ahead of ctx.currentTime.
+  //
+  // A 200 ms pre-roll is enforced before the first buffer is scheduled so that
+  // transient network delays cannot immediately cause an underrun. Once the pre-roll
+  // is met (or the final tts_done has fired), playback begins and the scheduler
+  // keeps the lookahead window filled on every tick.
+  const scheduleFromQueue = useCallback(() => {
+    const ctx = audioContextRef.current;
+    if (!ctx || ctx.state === 'closed') return;
+
+    if (ctx.state === 'suspended' && !userPausedRef.current) {
+      ctx.resume().catch(() => {});
+      return;
+    }
+
+    const sr = sampleRateRef.current;
+    const PREROLL_SAMPLES = Math.floor(sr * 0.2); // 200 ms worth of samples
+    const LOOKAHEAD = 0.25; // schedule up to 250 ms ahead of current time
+
+    // Hold off until enough data is buffered, unless the stream is already done.
+    if (playStartTimeRef.current === null) {
+      const queued = pcmQueueRef.current.reduce((sum, seg) => sum + seg.samples.length, 0);
+      if (queued < PREROLL_SAMPLES && !finalTtsDoneRef.current) {
+        return;
+      }
+    }
+
+    const now = ctx.currentTime;
+    const scheduleUntil = now + LOOKAHEAD;
+
+    while (nextStartTimeRef.current < scheduleUntil) {
+      const segment = pcmQueueRef.current.shift();
+      if (!segment) break;
 
       try {
-        const binaryStr = atob(audio_base64);
-        const bytes = new Uint8Array(binaryStr.length);
-        for (let i = 0; i < binaryStr.length; i++) {
-          bytes[i] = binaryStr.charCodeAt(i);
-        }
-
-        const samples = new Float32Array(bytes.byteLength / 2);
-        const view = new DataView(bytes.buffer);
-        for (let i = 0; i < samples.length; i++) {
-          samples[i] = view.getInt16(i * 2, true) / 32768.0;
-        }
-
-        const buffer = ctx.createBuffer(1, samples.length, sample_rate);
+        const { samples, sampleRate } = segment;
+        const buffer = ctx.createBuffer(1, samples.length, sampleRate);
         buffer.copyToChannel(samples, 0);
 
         const source = ctx.createBufferSource();
         source.buffer = buffer;
+        source.connect(masterGainRef.current ?? ctx.destination);
 
-        // If the browser auto-suspended the context (autoplay policy) and the user
-        // hasn't explicitly paused, resume now so chunks aren't scheduled on a
-        // frozen timeline (which would cause them to pile up and play in a burst).
-        if (ctx.state === 'suspended' && !userPausedRef.current) {
-          ctx.resume().catch(() => {});
-        }
+        const startTime = Math.max(nextStartTimeRef.current, now);
 
-        // Route through a GainNode so we can apply a short linear ramp on the
-        // first chunk (silence → full) to eliminate the click caused by the
-        // AudioContext output jumping from 0 to a non-zero first sample.
-        const gain = ctx.createGain();
-        const isFirstChunk = playStartTimeRef.current === null;
-        const FADE_DURATION = 0.005; // 5 ms — inaudible but removes the discontinuity
-        if (isFirstChunk) {
-          gain.gain.setValueAtTime(0, 0);
-        }
-        source.connect(gain);
-        gain.connect(masterGainRef.current ?? ctx.destination);
-
-        const now = ctx.currentTime;
-        const startTime = nextStartTimeRef.current <= now ? now : nextStartTimeRef.current;
-
-        // Apply fade-in ramp on the first chunk only
-        if (isFirstChunk) {
-          gain.gain.linearRampToValueAtTime(1, startTime + FADE_DURATION);
-        }
-
-        // Track when audio playback actually begins (first chunk only)
         if (playStartTimeRef.current === null) {
           playStartTimeRef.current = startTime;
         }
@@ -229,17 +298,35 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
         nextStartTimeRef.current = startTime + buffer.duration;
 
         scheduledSourcesRef.current.push(source);
-        // Prune finished sources to avoid unbounded growth
         source.onended = () => {
           scheduledSourcesRef.current = scheduledSourcesRef.current.filter(s => s !== source);
         };
       } catch (err) {
         // eslint-disable-next-line no-console
-        console.error('[TTS] Failed to decode/play PCM chunk:', err);
+        console.error('[TTS] Failed to schedule PCM chunk:', err);
       }
-    },
-    [ensureAudioContext],
-  );
+    }
+
+    // Stream completion: final tts_done fired and the queue has been fully drained.
+    if (finalTtsDoneRef.current && pcmQueueRef.current.length === 0 && !allChunksReceivedRef.current) {
+      const bufferedDuration =
+        playStartTimeRef.current !== null ? nextStartTimeRef.current - playStartTimeRef.current : 0;
+      totalDurationRef.current = bufferedDuration > 0 ? bufferedDuration : 0;
+      if (bufferedDuration > 0 && fullTextRef.current.length > 0) {
+        calibratedRateRef.current = fullTextRef.current.length / bufferedDuration;
+      }
+      // Fade out master gain at end-of-stream to silence any DC-offset click
+      // that would occur if the last PCM buffer ends at a non-zero sample.
+      const masterGain = masterGainRef.current;
+      if (masterGain && nextStartTimeRef.current > 0) {
+        const FADE_OUT = 0.02; // 20 ms
+        const endTime = nextStartTimeRef.current;
+        masterGain.gain.setValueAtTime(1, Math.max(now, endTime - FADE_OUT));
+        masterGain.gain.linearRampToValueAtTime(0, endTime);
+      }
+      allChunksReceivedRef.current = true;
+    }
+  }, []);
 
   // ─────────────────────────────────────────────────────────────────────────
   // Browser SpeechSynthesis helpers
@@ -300,6 +387,7 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
         userPausedRef.current = false;
         socket.emit(sioEvents.tts_stop, {});
         stopModelAudio();
+        sentenceWaypointsRef.current = [];
         fullTextRef.current = text;
         // Build punctuation-aware timeline for this session's text.
         // Uses the calibrated rate from the previous session (or the default
@@ -307,9 +395,15 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
         // scales elapsed time against the real totalDuration so any rate
         // inaccuracy is corrected for the post-streaming phase.
         charTimelineRef.current = buildCharTimeline(text, calibratedRateRef.current);
+        pcmQueueRef.current = [];
+        finalTtsDoneRef.current = false;
+        totalEnqueuedSamplesRef.current = 0;
         // Create the AudioContext eagerly so pause() can suspend it
         // before the first chunk arrives
         ensureAudioContext(24000);
+        // Start the scheduler loop — it holds off playing until the pre-roll is met.
+        clearInterval(schedulerTimerRef.current);
+        schedulerTimerRef.current = setInterval(scheduleFromQueue, 25);
         socket.emit(sioEvents.tts_start, {
           project_id: ttsModel.project_id,
           model_name: ttsModel.name,
@@ -326,7 +420,7 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
         startUtterance(text, 0);
       }
     },
-    [hasModelTTS, ttsModel, socket, stopModelAudio, startUtterance, ensureAudioContext],
+    [hasModelTTS, ttsModel, socket, stopModelAudio, startUtterance, ensureAudioContext, scheduleFromQueue],
   );
 
   const pause = useCallback(() => {
@@ -380,30 +474,85 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
   useEffect(() => {
     if (!hasModelTTS) return;
 
-    const handleChunk = ({ audio_base64, sample_rate }) => {
-      playPcm16Chunk(audio_base64, sample_rate);
+    // Apply a linear fade-in or fade-out over FADE_SAMPLES samples in-place.
+    // 5 ms at 24 kHz = 120 samples — inaudible but sufficient to eliminate
+    // amplitude discontinuities at sentence boundaries.
+    const applyFade = (samples, fadeSamples, type) => {
+      const count = Math.min(fadeSamples, samples.length);
+      if (type === 'in') {
+        for (let i = 0; i < count; i++) {
+          samples[i] *= i / count;
+        }
+      } else {
+        const start = samples.length - count;
+        for (let i = 0; i < count; i++) {
+          samples[start + i] *= (count - 1 - i) / count;
+        }
+      }
     };
 
-    const handleDone = () => {
-      // Record total audio duration and signal that all chunks are buffered.
-      // The RAF loop will call setStatus('done') once the audio actually finishes.
-      const bufferedDuration = nextStartTimeRef.current - playStartTimeRef.current;
-      totalDurationRef.current = bufferedDuration > 0 ? bufferedDuration : 0;
-      allChunksReceivedRef.current = true;
-      // Calibrate chars/second for the next session's linear phase
-      if (bufferedDuration > 0 && fullTextRef.current.length > 0) {
-        calibratedRateRef.current = fullTextRef.current.length / bufferedDuration;
+    const handleChunk = ({ audio, sample_rate }) => {
+      const sr = sample_rate || 24000;
+      const FADE_SAMPLES = Math.floor(sr * 0.005); // 5 ms
+
+      const samples = decodePcm16(audio);
+
+      // Apply fade-in to the head of the first chunk of each sentence so the
+      // amplitude ramps up from 0 rather than jumping in abruptly after the
+      // silence left by the previous sentence's fade-out.
+      if (newSentenceRef.current) {
+        applyFade(samples, FADE_SAMPLES, 'in');
+        newSentenceRef.current = false;
       }
-      // Schedule a short linear fade-out on the master gain so the last PCM buffer
-      // doesn't end abruptly at a non-zero sample (which causes a DC-offset click).
-      const masterGain = masterGainRef.current;
-      const ctx = audioContextRef.current;
-      if (masterGain && ctx && nextStartTimeRef.current > 0) {
-        const FADE_OUT = 0.02; // 20 ms — inaudible but removes the click
-        const endTime = nextStartTimeRef.current;
-        masterGain.gain.setValueAtTime(1, Math.max(ctx.currentTime, endTime - FADE_OUT));
-        masterGain.gain.linearRampToValueAtTime(0, endTime);
+
+      // Flush the previous pending chunk as-is — consecutive chunks within a
+      // sentence are contiguous PCM bytes, so no fade is needed at this boundary.
+      if (pendingChunkRef.current) {
+        enqueueSamples(pendingChunkRef.current.samples, pendingChunkRef.current.sample_rate);
+        pendingChunkRef.current = null;
       }
+
+      // Hold the new chunk; it will be flushed with a fade-out when the
+      // sentence-boundary tts_done arrives, or as-is if more chunks follow.
+      pendingChunkRef.current = { samples, sample_rate: sr };
+    };
+
+    const handleDone = ({ char_end } = {}) => {
+      const sr = pendingChunkRef.current?.sample_rate || 24000;
+      const FADE_SAMPLES = Math.floor(sr * 0.005); // 5 ms
+
+      if (char_end !== undefined) {
+        // Sentence boundary — apply fade-out to the last pending chunk so the
+        // waveform tapers to zero before the next sentence's fade-in begins.
+        if (pendingChunkRef.current) {
+          const { samples, sample_rate } = pendingChunkRef.current;
+          applyFade(samples, FADE_SAMPLES, 'out');
+          enqueueSamples(samples, sample_rate);
+          pendingChunkRef.current = null;
+        }
+        newSentenceRef.current = true;
+
+        // Compute waypoint audioTime from total samples enqueued rather than from
+        // nextStartTimeRef, because the scheduler may not have processed the queue
+        // yet — using enqueued count gives the correct absolute playback position
+        // regardless of scheduling lag.
+        const audioTime = totalEnqueuedSamplesRef.current / sampleRateRef.current;
+        sentenceWaypointsRef.current.push({ charPos: char_end, audioTime });
+        return;
+      }
+
+      // Final tts_done — flush the last pending chunk without an extra fade-out:
+      // the master-gain ramp in scheduleFromQueue handles the end-of-stream click.
+      if (pendingChunkRef.current) {
+        const { samples, sample_rate } = pendingChunkRef.current;
+        enqueueSamples(samples, sample_rate);
+        pendingChunkRef.current = null;
+      }
+
+      // Signal that all chunks have been received. The scheduler loop
+      // (scheduleFromQueue) will set allChunksReceivedRef once the queue drains,
+      // at which point it also records totalDuration and schedules the fade-out.
+      finalTtsDoneRef.current = true;
     };
 
     const handleError = ({ error }) => {
@@ -423,7 +572,7 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
       socket.off(sioEvents.tts_done, handleDone);
       socket.off(sioEvents.tts_error, handleError);
     };
-  }, [hasModelTTS, socket, playPcm16Chunk, stopModelAudio]);
+  }, [hasModelTTS, socket, enqueueSamples, stopModelAudio]);
 
   // ─────────────────────────────────────────────────────────────────────────
   // RAF loop — word highlighting + completion detection for model TTS
@@ -468,23 +617,53 @@ const useTextToSpeech = ({ ttsModel, socket } = {}) => {
       const allReceived = allChunksReceivedRef.current;
 
       if (elapsed >= 0 && text) {
-        // Use the punctuation-aware char timeline built at speak() time.
-        // After tts_done fires we know the real total duration, so we scale
-        // elapsed to correct for any rate inaccuracy in the timeline model.
-        // Before tts_done the timeline runs at the calibrated rate as-is.
-        const timeline = charTimelineRef.current;
+        const waypoints = sentenceWaypointsRef.current;
         let charPos;
-        if (timeline) {
-          let scaledElapsed;
-          if (allReceived && totalDuration > 0 && timeline.totalEstimated > 0) {
-            scaledElapsed = elapsed * (timeline.totalEstimated / totalDuration);
-          } else {
-            scaledElapsed = elapsed;
+
+        if (waypoints.length > 0) {
+          // Interpolate between exact sentence-boundary anchors sent by the backend.
+          // Build anchor list starting at (0, 0); append final (text.length, totalDuration)
+          // once all audio is buffered so the last sentence also interpolates correctly.
+          const anchors = [{ charPos: 0, audioTime: 0 }, ...waypoints];
+          if (allReceived && totalDuration > 0) {
+            anchors.push({ charPos: text.length, audioTime: totalDuration });
           }
-          charPos = findCharAtTime(timeline.times, scaledElapsed);
+
+          let found = false;
+          for (let i = 1; i < anchors.length; i++) {
+            if (elapsed <= anchors[i].audioTime) {
+              const prev = anchors[i - 1];
+              const next = anchors[i];
+              const segDuration = next.audioTime - prev.audioTime;
+              const t = segDuration > 0 ? Math.min(1, (elapsed - prev.audioTime) / segDuration) : 0;
+              charPos = prev.charPos + Math.floor(t * (next.charPos - prev.charPos));
+              found = true;
+              break;
+            }
+          }
+
+          if (!found) {
+            // Past all known anchors — extrapolate with calibrated rate.
+            const last = anchors[anchors.length - 1];
+            charPos = Math.min(
+              text.length - 1,
+              last.charPos + Math.floor((elapsed - last.audioTime) * calibratedRateRef.current),
+            );
+          }
         } else {
-          // Fallback if timeline was not built (shouldn't happen in normal flow).
-          charPos = Math.min(Math.floor(elapsed * calibratedRateRef.current), text.length - 1);
+          // No waypoints yet — use the punctuation-aware char timeline.
+          const timeline = charTimelineRef.current;
+          if (timeline) {
+            let scaledElapsed;
+            if (allReceived && totalDuration > 0 && timeline.totalEstimated > 0) {
+              scaledElapsed = elapsed * (timeline.totalEstimated / totalDuration);
+            } else {
+              scaledElapsed = elapsed;
+            }
+            charPos = findCharAtTime(timeline.times, scaledElapsed);
+          } else {
+            charPos = Math.min(Math.floor(elapsed * calibratedRateRef.current), text.length - 1);
+          }
         }
 
         // Advance past any whitespace so charPos lands on a word character

--- a/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
+++ b/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
@@ -3,6 +3,7 @@ import { forwardRef, memo, useCallback, useContext, useEffect, useImperativeHand
 import { Box } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
+import { isWhisperModel } from '@/[fsd]/features/chat/lib/helpers';
 import { useSpeechRecognition, useStreamingSpeechRecognition } from '@/[fsd]/features/chat/lib/hooks';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { useListModelsQuery } from '@/api/configurations';
@@ -95,26 +96,21 @@ const VoiceButton = memo(
       [toastError],
     );
 
-    const isWhisperModel = useCallback(name => Boolean(name && name.toLowerCase().includes('whisper')), []);
-
     /**
      * Select the best available ASR model following priority order:
      * default streaming → first streaming → default whisper → first whisper
      */
-    const selectAsrModel = useCallback(
-      items => {
-        const streamingModels = items.filter(m => !isWhisperModel(m.name));
-        const whisperModels = items.filter(m => isWhisperModel(m.name));
+    const selectAsrModel = useCallback(items => {
+      const streamingModels = items.filter(m => !isWhisperModel(m.name));
+      const whisperModels = items.filter(m => isWhisperModel(m.name));
 
-        return (
-          streamingModels.find(m => m.default) ??
-          streamingModels[0] ??
-          whisperModels.find(m => m.default) ??
-          whisperModels[0]
-        );
-      },
-      [isWhisperModel],
-    );
+      return (
+        streamingModels.find(m => m.default) ??
+        streamingModels[0] ??
+        whisperModels.find(m => m.default) ??
+        whisperModels[0]
+      );
+    }, []);
 
     const { data: asrModelsData } = useListModelsQuery(
       { projectId, section: 'asr', include_shared: true },

--- a/src/components/Chat/ApplicationAnswer.jsx
+++ b/src/components/Chat/ApplicationAnswer.jsx
@@ -179,12 +179,17 @@ const ApplicationAnswer = React.forwardRef((props, ref) => {
   const realAnswer = useMemo(() => convertJsonToString(rawAnswer || '', true), [rawAnswer]);
   const hasSpeakableText = useMemo(() => !!toSpeakableText(realAnswer).text, [realAnswer]);
 
-  // Progressive highlight: always from start of message to current spoken position.
-  // spokenRange positions are in stripped-text coordinates; translate back to original markdown.
+  // Translate the current TTS word range (in stripped-text coordinates) back to
+  // original markdown coordinates for word-level highlight.
+  // Fine-grained inline segments in speakingSegments ensure 1:1 char mapping
+  // within each segment so translateSpokenPos gives word-accurate positions.
   const activeSpokenRange = useMemo(() => {
     if (messageId !== speakingMessageId || !spokenRange) return null;
-    const translatedEnd = translateSpokenPos(spokenRange.end, speakingSegments);
-    return { start: 0, end: translatedEnd };
+    if (!speakingSegments?.length) return spokenRange;
+    const start = translateSpokenPos(spokenRange.start, speakingSegments);
+    const end = translateSpokenPos(spokenRange.end, speakingSegments);
+    if (end <= start) return null;
+    return { start, end };
   }, [messageId, speakingMessageId, spokenRange, speakingSegments]);
 
   // Cumulative start offsets of each message_item in the joined realAnswer string


### PR DESCRIPTION
# fix: Route ASR through LiteLLM proxy and pylon_indexer tasks

Closes #4899

## Summary

ASR (Automatic Speech Recognition) was making direct HTTP/WebSocket calls to the provider API from `pylon_main`, bypassing the LiteLLM proxy and the standard worker task architecture. Additionally, `gpt-4o-transcribe` was misclassified as a realtime streaming model, causing it to connect to the wrong endpoint.

This fix reroutes all ASR traffic through the same path used by TTS and LLM calls: `pylon_main` → `task_node` → `pylon_indexer` → LiteLLM proxy → provider API.

---

## Backend Changes

### `elitea_core` — `sio/asr.py`

**Root cause fix — `_is_whisper_model()` misclassification:**

```python
# Before
def _is_whisper_model(model_name: str) -> bool:
    return bool(model_name and "whisper" in model_name.lower())

# After
def _is_whisper_model(model_name: str) -> bool:
    """True for batch HTTP transcription models (whisper-1, gpt-4o-transcribe, etc.)."""
    lower = model_name.lower() if model_name else ""
    return bool(lower and ("whisper" in lower or "transcribe" in lower))
```

`gpt-4o-transcribe` was routed to the realtime WebSocket path, which failed immediately. Adding the `"transcribe"` check sends it to the correct batch/HTTP path.

**Architecture change — removed direct API calls, added task dispatch:**

Previously `pylon_main` owned the entire transcription stack: credential resolution, WebSocket management, direct HTTP Whisper calls via `requests`, and a `websocket-client` dependency for realtime models.

Now `pylon_main` only does VAD buffering and task dispatch:

- **Batch/Whisper models** (`whisper-1`, `gpt-4o-transcribe`, etc.): PCM audio is buffered with VAD in `pylon_main`. On silence or hard-limit timer, flushes via `task_node.start_task("indexer_asr_whisper", pool="indexer")`.
- **Realtime models**: A long-lived `indexer_asr_realtime` task is started. Raw PCM audio frames are forwarded to the indexer via `event_node.emit("voice_asr_audio_input_{sid}")`.

Removed from `pylon_main`:
- `_resolve_asr_credentials()` — RPC-based credential lookup
- `_call_whisper()` / `_transcribe_and_emit()` — direct HTTP to provider
- `_build_ws_params()` / `_on_ws_open()` / `_on_realtime_message()` / `_on_realtime_error()` — WebSocket client management
- `websocket-client` import and `threading.Thread` for WebSocket

Audio input changed from base64-encoded dict (`{"audio_base64": "..."}`) to raw binary Socket.IO frames (or `{"audio": bytes}`), which is more efficient and consistent with the realtime path.

---

### `runtime_engine_litellm` — `methods/binaries.py` + `methods/init.py`

**Problem:** LiteLLM's audio transcription path imports `soundfile`, which requires the system library `libsndfile1`. This library was absent in the Docker container, causing `APIConnectionError: cannot load library 'libsndfile.so'` on every transcription request.

**Fix — `methods/binaries.py`:** Added `apt_packages()` method that installs system packages:

```python
@web.method()
def apt_packages(self, packages):
    """Install system packages required by LiteLLM (e.g. libsndfile1 for audio support)."""
    if not packages:
        return
    import subprocess
    env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
    try:
        subprocess.run(["apt-get", "update", "-qq"], env=env, check=True, capture_output=True)
        subprocess.run(
            ["apt-get", "install", "-y", "--no-install-recommends"] + list(packages),
            env=env, check=True, capture_output=True,
        )
    except Exception as exc:
        log.warning("apt_packages: failed to install %s: %s", packages, exc)
```

`apt-get update` is required before `install` because Docker containers have stale/empty package lists.

**Fix — `methods/init.py`:** Calls `apt_packages` inside `@web.init()` (runs on every container startup), not in `preload()` (runs only on first plugin installation):

```python
else:
    self.apt_packages(config.get("apt_packages", ["libsndfile1"]))  # added
    self.venv_create(config)
    self.venv_packages(config)
    ...
```

`libsndfile1` is now reinstalled on every `pylon_indexer` restart, so it survives container rebuilds. The list of packages to install is configurable via `apt_packages` in the plugin config (defaults to `["libsndfile1"]`).

---

## Frontend Changes

### `EliteaUI`

**Root cause fix — `isWhisperModel()` out of sync with backend:**

Both `VoiceButton.jsx` and `useStreamingSpeechRecognition.hooks.js` had inline `isWhisperModel` checks that only tested for `"whisper"`, missing `"transcribe"`. This caused `gpt-4o-transcribe` to be:
- Selected as a *streaming* (realtime) model in `VoiceButton.selectAsrModel()` instead of batch, giving it lower priority than intended
- Sent with the realtime audio chunk size (200 ms / 4800 bytes) instead of the Whisper batch size (300 ms / 7200 bytes)

**New shared helper — `src/[fsd]/features/chat/lib/helpers/asr.helpers.js`:**

```js
/**
 * Returns true for batch HTTP transcription models (whisper-1, gpt-4o-transcribe, etc.).
 * Mirrors the backend _is_whisper_model() check in elitea_core/sio/asr.py.
 */
export const isWhisperModel = name =>
  Boolean(name && (name.toLowerCase().includes('whisper') || name.toLowerCase().includes('transcribe')));
```

Single source of truth for both files. Exported from `helpers/index.js`.

**`src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js`:**
- Removed inline `isWhisperModel` constant
- Now imports `isWhisperModel` from `@/[fsd]/features/chat/lib/helpers`

**`src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx`:**
- Removed `useCallback`-wrapped inline `isWhisperModel` (and its `[isWhisperModel]` dependency in `selectAsrModel`)
- Now imports `isWhisperModel` from `@/[fsd]/features/chat/lib/helpers`
- `selectAsrModel`'s `useCallback` dependency array simplified to `[]` (imported functions are stable references)

---

## Backend Changes (continued)

### `indexer_worker` — new ASR task methods + `module.py`

Two new task methods implement the indexer-side of the ASR routing:

**`methods/indexer_asr_whisper.py`** (new file):

Runs in a `task_node_light` thread (short-lived, IO-bound). Called once per buffered speech segment by the VAD logic in `pylon_main`.

- Converts raw PCM16 bytes to WAV via `wave` (no external library)
- `POST`s to `http://127.0.0.1:8081/v1/audio/transcriptions` (LiteLLM proxy)
- Emits `voice_asr_transcript_done` back to `pylon_main` via `event_node`
- HTTP 429 (rate-limited) is silently dropped so recording stays alive; other errors emit `voice_asr_error`

**`methods/indexer_asr_realtime.py`** (new file):

Runs in a `task_node_light` thread (long-lived, IO-bound). Manages a WebSocket connection to the provider realtime ASR endpoint via the LiteLLM proxy.

- Subscribes to `voice_asr_audio_input_{sid}` — forwards raw PCM16 frames from `pylon_main` to the provider WebSocket as `input_audio_buffer.append` messages
- Subscribes to `voice_asr_stop_{sid}` — closes the WebSocket cleanly
- Buffers audio in a queue until the WebSocket is connected, then flushes
- Emits `voice_asr_transcript_delta` and `voice_asr_transcript_done` back to `pylon_main`

**`module.py`**:

Registers the two new task methods on `task_node_light`:

```python
worker_core.task_node_light.register_task(self.indexer_asr_whisper, "indexer_asr_whisper")
worker_core.task_node_light.register_task(self.indexer_asr_realtime, "indexer_asr_realtime")
```

---

### `indexer_worker` — `methods/indexer_tts.py`

**Problem:** TTS text is split into sentences so the frontend can receive exact `char_end` waypoints for word-highlight interpolation. Each sentence is a separate HTTP call to the LiteLLM proxy, meaning the TTS model re-initialises its prosody state for every call. This causes audible tone shifts at sentence boundaries — each sentence sounds like it was spoken by a different person.

**Fix — `_get_tone_params()`:** Added a provider-detection helper that injects extra payload fields on each sentence call to give the model prosody context:

```python
_DEFAULT_GPT4O_TTS_INSTRUCTIONS = (
    "Affect: calm and warm. "
    "Pacing: steady and measured, never rushing. "
    "Tone: conversational and clear. "
    "Do not change your speaking style, pitch, or rhythm between sentences."
)

def _get_tone_params(model_name: str, sentences: list, idx: int, voice_instructions: str = "") -> dict:
    lower = model_name.lower()

    if "eleven" in lower:
        # ElevenLabs: previous_text / next_text maintain prosody across calls
        params = {}
        if idx > 0:
            params["previous_text"] = " ".join(s for s, _ in sentences[:idx])
        if idx < len(sentences) - 1:
            params["next_text"] = " ".join(s for s, _ in sentences[idx + 1:])
        return params

    if "gpt-4o" in lower and "tts" in lower:
        # OpenAI gpt-4o-*-tts: detailed instructions pin speaking style per call.
        # Uses caller-provided voice_instructions when set, otherwise the built-in default.
        instructions = voice_instructions.strip() or _DEFAULT_GPT4O_TTS_INSTRUCTIONS
        return {"instructions": instructions}

    return {}  # other models: no change in behaviour
```

Provider is detected from the original `model_name` (before LiteLLM project-prefix). `_stream_sentence` merges these extra fields into the request payload via `**(extra_params or {})`. Sentence splitting and `char_end` waypoints are fully preserved — word highlighting is unaffected.

**`voice_instructions` parameter:** The `indexer_tts` task and `elitea_core/sio/tts.py` both accept an optional `voice_instructions` string. When the frontend passes it in the `tts_start` Socket.IO event, it overrides the built-in gpt-4o persona description. This allows callers to customise the speaking style without changing backend defaults.

---

## Files Changed

| File | Change |
|------|--------|
| `elitea_core/sio/asr.py` | Rewrote ASR SIO handlers to dispatch indexer tasks; fixed `_is_whisper_model` |
| `runtime_engine_litellm/methods/binaries.py` | Added `apt_packages()` method |
| `runtime_engine_litellm/methods/init.py` | Call `apt_packages` on every init |
| `indexer_worker/methods/indexer_asr_whisper.py` | New task: PCM16→WAV conversion, POST to LiteLLM `/v1/audio/transcriptions` |
| `indexer_worker/methods/indexer_asr_realtime.py` | New task: long-lived WebSocket relay to LiteLLM realtime ASR endpoint |
| `indexer_worker/module.py` | Register `indexer_asr_whisper` and `indexer_asr_realtime` tasks on `task_node_light` |
| `indexer_worker/methods/indexer_tts.py` | Added `_get_tone_params()` for provider-specific tone consistency; added `voice_instructions` param |
| `elitea_core/sio/tts.py` | Read `voice_instructions` from `tts_start` payload and forward to indexer task |
| `EliteaUI/src/[fsd]/features/chat/lib/helpers/asr.helpers.js` | New shared `isWhisperModel` helper |
| `EliteaUI/src/[fsd]/features/chat/lib/helpers/index.js` | Export `isWhisperModel` |
| `EliteaUI/src/[fsd]/features/chat/lib/hooks/useStreamingSpeechRecognition.hooks.js` | Import helper, remove duplicate |
| `EliteaUI/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx` | Import helper, remove duplicate |

---

## Test Plan

- [ ] Start a chat with `gpt-4o-transcribe` set as the ASR model
- [ ] Click the mic button and speak — confirm transcription appears in the input field
- [ ] Verify `pylon_indexer` logs show `POST /v1/audio/transcriptions HTTP/1.1" 200 OK`
- [ ] Verify no `cannot load library 'libsndfile.so'` errors after `pylon_indexer` restart
- [ ] Confirm realtime ASR models (non-transcribe/whisper) still route to the realtime task path
- [ ] Confirm the mic button activates and deactivates correctly with no console errors
- [ ] With an ElevenLabs TTS model: speak a multi-sentence message, confirm consistent tone across sentences
- [ ] With `gpt-4o-mini-tts`: confirm consistent speaking style across sentence boundaries
- [ ] With `tts-1` / `tts-1-hd`: confirm behaviour is unchanged (no extra params sent)
- [ ] Confirm word highlighting still tracks correctly during TTS playback
