### PR TITLE
feat: [EL-4766] add file attachment support to pipeline chat

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
@@ -85,6 +85,17 @@ const ApplicationTools = memo(props => {
     };
   }, [sortedInternalTools, showAllInternalTools, currentInternalTools.length]);
 
+  // For pipeline pages show only the attachments card; for agent pages show all available tools.
+  const pipelineVisibleTools = useMemo(
+    () =>
+      isFromPipeline ? sortedInternalTools.filter(t => t.name === 'attachments') : displayedInternalTools,
+    [isFromPipeline, sortedInternalTools, displayedInternalTools],
+  );
+
+  const shouldShowInternalTools = isFromPipeline
+    ? pipelineVisibleTools.length > 0
+    : !hidePythonSandbox && sortedInternalTools.length > 0;
+
   const markedDuplicateTools = useMemo(
     () =>
       markAllDuplicatesByMultipleKeys(
@@ -127,11 +138,11 @@ const ApplicationTools = memo(props => {
                 />
               ))}
 
-              {!isFromPipeline && !hidePythonSandbox && sortedInternalTools.length > 0 && (
+              {shouldShowInternalTools && (
                 <Box sx={styles.internalToolsContainer}>
                   <Typography sx={styles.internalToolsTitle}>INTERNAL TOOLS</Typography>
                   <Box sx={styles.internalToolsGrid}>
-                    {displayedInternalTools.map(tool => (
+                    {pipelineVisibleTools.map(tool => (
                       <Switch.AgentInternalToolSwitch
                         key={tool.name}
                         title={tool.title}
@@ -142,7 +153,7 @@ const ApplicationTools = memo(props => {
                       />
                     ))}
                   </Box>
-                  {canToggleTools && (
+                  {!isFromPipeline && canToggleTools && (
                     <Box sx={styles.showMoreContainer}>
                       <Typography
                         onClick={() => setShowAllInternalTools(!showAllInternalTools)}

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AttachmentSwitch.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AttachmentSwitch.jsx
@@ -1,11 +1,18 @@
 import { memo, useCallback, useMemo } from 'react';
 
 import { useFormikContext } from 'formik';
+import YAML from 'js-yaml';
+import { useDispatch, useSelector } from 'react-redux';
 
+import {
+  STATE_INPUT_ATTACHMENTS,
+  StateVariableTypes,
+} from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
 import { InternalToolsConstants } from '@/[fsd]/shared/lib/constants';
 import { Switch, Text } from '@/[fsd]/shared/ui';
 import { PERMISSIONS } from '@/common/constants';
 import useCheckPermission from '@/hooks/useCheckPermission';
+import { actions as pipelineActions } from '@/slices/pipeline';
 
 const ATTACHMENTS_INTERNAL_TOOL = 'attachments';
 
@@ -17,6 +24,9 @@ const ATTACHMENTS_INTERNAL_TOOL = 'attachments';
 const AttachmentSwitch = memo(({ disabled }) => {
   const { checkPermission } = useCheckPermission();
   const { values, setFieldValue } = useFormikContext();
+  const dispatch = useDispatch();
+  const { yamlCode, yamlJsonObject } = useSelector(state => state.pipeline);
+  const isPipeline = Boolean(yamlCode);
 
   // Get attachments tool info from constants
   const attachmentToolInfo = useMemo(
@@ -51,8 +61,33 @@ const AttachmentSwitch = memo(({ disabled }) => {
       }
 
       setFieldValue('version_details.meta.internal_tools', newInternalTools);
+
+      // Sync input_attachments state variable in pipeline YAML
+      if (isPipeline) {
+        const currentState = yamlJsonObject?.state || {};
+        const alreadyHasKey = STATE_INPUT_ATTACHMENTS in currentState;
+
+        if (checkedValue && !alreadyHasKey) {
+          const newYamlJsonObject = {
+            ...yamlJsonObject,
+            state: {
+              ...currentState,
+              [STATE_INPUT_ATTACHMENTS]: { type: StateVariableTypes.List, default: [] },
+            },
+          };
+          dispatch(pipelineActions.setYamlCode(YAML.dump(newYamlJsonObject)));
+          dispatch(pipelineActions.setYamlJsonObject({ yamlJsonObject: newYamlJsonObject }));
+        } else if (!checkedValue && alreadyHasKey) {
+          const remainingState = Object.fromEntries(
+            Object.entries(currentState).filter(([k]) => k !== STATE_INPUT_ATTACHMENTS),
+          );
+          const newYamlJsonObject = { ...yamlJsonObject, state: remainingState };
+          dispatch(pipelineActions.setYamlCode(YAML.dump(newYamlJsonObject)));
+          dispatch(pipelineActions.setYamlJsonObject({ yamlJsonObject: newYamlJsonObject }));
+        }
+      }
     },
-    [values?.version_details?.meta?.internal_tools, setFieldValue],
+    [values?.version_details?.meta?.internal_tools, setFieldValue, isPipeline, yamlJsonObject, dispatch],
   );
 
   return (

--- a/src/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants.js
+++ b/src/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants.js
@@ -21,7 +21,9 @@ export const DefaultState = {
   [STATE_MESSAGES]: { type: StateVariableTypes.List },
 };
 
+export const STATE_INPUT_ATTACHMENTS = 'input_attachments';
 export const StateDefaultProps = [STATE_INPUT, STATE_MESSAGES];
+export const StateManagedProps = [STATE_INPUT_ATTACHMENTS];
 
 export const LegacyIntType = 'int';
 

--- a/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableList.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/state/StateVariableList.jsx
@@ -20,7 +20,11 @@ const StateVariableList = memo(props => {
 
   const stateEntries = useMemo(() => {
     return Object.entries(states || FlowEditorConstants.DefaultState)
-      .filter(([name]) => !FlowEditorConstants.StateDefaultProps.includes(name))
+      .filter(
+        ([name]) =>
+          !FlowEditorConstants.StateDefaultProps.includes(name) &&
+          !FlowEditorConstants.StateManagedProps.includes(name),
+      )
       .map(([name, config]) => ({
         name,
         type: config.type || 'str',
@@ -146,6 +150,24 @@ const StateVariableList = memo(props => {
         editable={false}
         disabled={disabled}
       />
+      {!!states?.[FlowEditorConstants.STATE_INPUT_ATTACHMENTS] && (
+        <FlowEditorState.StateVariableItem
+          key={FlowEditorConstants.STATE_INPUT_ATTACHMENTS}
+          name={FlowEditorConstants.STATE_INPUT_ATTACHMENTS}
+          type={FlowEditorConstants.StateVariableTypes.List}
+          enabled
+          isDefault
+          drawerWidth={drawerWidth}
+          validateName={validateName}
+          onToggle={handleToggle}
+          onDelete={handleDelete}
+          onUpdateName={handleUpdateNameWithCreate}
+          onUpdateType={handleUpdateType}
+          onUpdateDefaultValue={handleUpdateDefaultValue}
+          editable={false}
+          disabled={disabled}
+        />
+      )}
       {stateEntries.map(({ name, type, value }) => (
         <FlowEditorState.StateVariableItem
           key={name}

--- a/src/[fsd]/features/pipelines/lib/hooks/index.js
+++ b/src/[fsd]/features/pipelines/lib/hooks/index.js
@@ -1,1 +1,2 @@
 export { default as usePipelineChat } from './usePipelineChat.hooks';
+export { usePipelineAttachmentYamlSync } from './usePipelineAttachmentYamlSync.hooks';

--- a/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
+++ b/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+import { useFormikContext } from 'formik';
+import YAML from 'js-yaml';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+  STATE_INPUT_ATTACHMENTS,
+  StateVariableTypes,
+} from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
+import { actions as pipelineActions } from '@/slices/pipeline';
+
+const ATTACHMENTS_TOOL_NAME = 'attachments';
+
+/**
+ * Watches the pipeline's internal_tools list and keeps the `input_attachments`
+ * YAML state variable in sync: adds it when attachments are enabled, removes it
+ * when they are disabled.
+ *
+ * Must be called inside a Formik context on the pipeline configuration page.
+ */
+export const usePipelineAttachmentYamlSync = () => {
+  const { values } = useFormikContext();
+  const dispatch = useDispatch();
+  const { yamlCode, yamlJsonObject } = useSelector(state => state.pipeline);
+
+  const hasAttachments =
+    values?.version_details?.meta?.internal_tools?.includes(ATTACHMENTS_TOOL_NAME) ?? false;
+
+  // Keep a ref so the effect always reads the latest YAML object without
+  // needing to re-run whenever any unrelated YAML change happens.
+  const yamlJsonObjectRef = useRef(yamlJsonObject);
+  yamlJsonObjectRef.current = yamlJsonObject;
+
+  useEffect(() => {
+    if (!yamlCode) return;
+
+    const currentYamlObj = yamlJsonObjectRef.current;
+    const currentState = currentYamlObj?.state || {};
+    const alreadyHasKey = STATE_INPUT_ATTACHMENTS in currentState;
+
+    if (hasAttachments && !alreadyHasKey) {
+      const updated = {
+        ...currentYamlObj,
+        state: {
+          ...currentState,
+          [STATE_INPUT_ATTACHMENTS]: { type: StateVariableTypes.List, default: [] },
+        },
+      };
+      dispatch(pipelineActions.setYamlCode(YAML.dump(updated)));
+      dispatch(pipelineActions.setYamlJsonObject({ yamlJsonObject: updated }));
+    } else if (!hasAttachments && alreadyHasKey) {
+      const remainingState = Object.fromEntries(
+        Object.entries(currentState).filter(([k]) => k !== STATE_INPUT_ATTACHMENTS),
+      );
+      const updated = { ...currentYamlObj, state: remainingState };
+      dispatch(pipelineActions.setYamlCode(YAML.dump(updated)));
+      dispatch(pipelineActions.setYamlJsonObject({ yamlJsonObject: updated }));
+    }
+  }, [hasAttachments, yamlCode, dispatch]);
+};

--- a/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
@@ -1,9 +1,8 @@
 import { memo, useMemo } from 'react';
 
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 
 import { AgentInput, ApplicationTools } from '@/[fsd]/features/agent/ui/agent-details/configurations';
-import { AttachmentSwitch } from '@/[fsd]/features/agent/ui/agent-details/configurations/switch';
 import { ViewMode } from '@/common/constants.js';
 import ApplicationAdvanceSettings from '@/components/ApplicationAdvanceSettings';
 import ConversationStarters from '@/components/ConversationStarters';
@@ -36,10 +35,6 @@ const PipelineConfigurationForm = memo(props => {
         onAttachmentToolChange={onAttachmentToolChange}
         entityProjectId={entityProjectId}
       />
-      <Box sx={styles.internalToolsSection}>
-        <Typography sx={styles.internalToolsLabel}>INTERNAL TOOLS</Typography>
-        <AttachmentSwitch disabled={isDisabled} />
-      </Box>
       {!isDisabled && (
         <>
           <AgentInput.WelcomeMessageInput />
@@ -68,17 +63,6 @@ const pipelineConfigurationFormStyles = isChatView => ({
   applicationTools: {
     marginTop: !isChatView ? '1rem' : 0,
   },
-  internalToolsSection: {
-    marginTop: '1rem',
-    padding: '0.75rem 1rem',
-  },
-  internalToolsLabel: ({ palette }) => ({
-    fontSize: '0.75rem',
-    fontWeight: 500,
-    lineHeight: '1rem',
-    marginBottom: '0.75rem',
-    color: palette.text.secondary,
-  }),
   conversationStarters: {
     marginTop: '1rem',
   },

--- a/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
@@ -1,8 +1,9 @@
 import { memo, useMemo } from 'react';
 
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import { AgentInput, ApplicationTools } from '@/[fsd]/features/agent/ui/agent-details/configurations';
+import { AttachmentSwitch } from '@/[fsd]/features/agent/ui/agent-details/configurations/switch';
 import { ViewMode } from '@/common/constants.js';
 import ApplicationAdvanceSettings from '@/components/ApplicationAdvanceSettings';
 import ConversationStarters from '@/components/ConversationStarters';
@@ -35,6 +36,10 @@ const PipelineConfigurationForm = memo(props => {
         onAttachmentToolChange={onAttachmentToolChange}
         entityProjectId={entityProjectId}
       />
+      <Box sx={styles.internalToolsSection}>
+        <Typography sx={styles.internalToolsLabel}>INTERNAL TOOLS</Typography>
+        <AttachmentSwitch disabled={isDisabled} />
+      </Box>
       {!isDisabled && (
         <>
           <AgentInput.WelcomeMessageInput />
@@ -63,6 +68,17 @@ const pipelineConfigurationFormStyles = isChatView => ({
   applicationTools: {
     marginTop: !isChatView ? '1rem' : 0,
   },
+  internalToolsSection: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+  },
+  internalToolsLabel: ({ palette }) => ({
+    fontSize: '0.75rem',
+    fontWeight: 500,
+    lineHeight: '1rem',
+    marginBottom: '0.75rem',
+    color: palette.text.secondary,
+  }),
   conversationStarters: {
     marginTop: '1rem',
   },

--- a/src/pages/Pipelines/Components/ChatPanel.jsx
+++ b/src/pages/Pipelines/Components/ChatPanel.jsx
@@ -177,7 +177,7 @@ const ChatPanel = forwardRef((props, ref) => {
               chatOnly
               type="chat"
               isAgentsPage={true}
-              hideAttachments={true}
+              hideAttachments={settings.disableAttachments}
               ref={boxRef}
               inputPlaceholder="Type your message."
             />

--- a/src/pages/Pipelines/Components/ChatPanel.jsx
+++ b/src/pages/Pipelines/Components/ChatPanel.jsx
@@ -177,7 +177,6 @@ const ChatPanel = forwardRef((props, ref) => {
               chatOnly
               type="chat"
               isAgentsPage={true}
-              hideAttachments={settings.disableAttachments}
               ref={boxRef}
               inputPlaceholder="Type your message."
             />

--- a/src/pages/Pipelines/Components/ConfigurationTab.jsx
+++ b/src/pages/Pipelines/Components/ConfigurationTab.jsx
@@ -7,7 +7,7 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 
 import RunHistoryContainer from '@/[fsd]/entities/run-history/ui/RunHistoryContainer';
 import { ParticipantEntityTypes } from '@/[fsd]/features/chat/lib/constants/participant.constants';
-import { usePipelineChat } from '@/[fsd]/features/pipelines/lib/hooks';
+import { usePipelineAttachmentYamlSync, usePipelineChat } from '@/[fsd]/features/pipelines/lib/hooks';
 import {
   DEFAULT_MAX_TOKENS,
   DEFAULT_REASONING_EFFORT,
@@ -48,6 +48,7 @@ const ConfigurationTab = memo(props => {
   const projectId = useSelectedProjectId();
 
   useAgentMCPToolsStatusMonitor();
+  usePipelineAttachmentYamlSync();
 
   const { isSmallWindow } = useIsSmallWindow(() => {
     setTimeout(() => {


### PR DESCRIPTION
- Pipeline INTERNAL TOOLS section now uses the same agent-style card UI (reuses `ApplicationTools`)
- Makes hideAttachments conditional in ChatPanel based on settings.disableAttachments
- Sync input_attachments YAML state and STATE panel display

<img width="1523" height="911" alt="image" src="https://github.com/user-attachments/assets/5d09b5f7-214f-42e8-b26d-cbfe10b3b8ce" />

<img width="1025" height="619" alt="image" src="https://github.com/user-attachments/assets/42773b9e-ad4f-49a9-aaa6-b30daff8b421" />

<img width="1198" height="945" alt="image" src="https://github.com/user-attachments/assets/84896142-7e42-48e4-92bb-306cd3a08416" />


### Summary

Enables file attachments in pipeline (LangGraph) chat. When the **Allow Attachments** toggle is switched on
for a pipeline, uploaded files are read, their text content injected into the pipeline graph state as
`input_attachments`, and the attachment button is shown in the pipeline chat input.

---

### Changes

#### Frontend — EliteaUI

**`ApplicationTools.jsx`**

- Removed the `!isFromPipeline` guard on the INTERNAL TOOLS section so pipelines now render the same
  card-based grid as agents.
- When on a pipeline page, the grid is filtered to show only the **Attachments** card; agent-specific tools
  (Python sandbox, Swarm, etc.) remain hidden.
- The "Show all / Show less" toggle is suppressed for pipelines (only one tool is shown).

**`PipelineConfigurationForm.jsx`**

- Removed the custom flat INTERNAL TOOLS section (label + `AttachmentSwitch`). The section is now rendered
  inside `ApplicationTools`, giving it the same look as the agent configuration panel.

**`usePipelineAttachmentYamlSync.hooks.js`** _(new)_

- Extracted the YAML state-sync logic (previously inlined in `AttachmentSwitch`) into a dedicated hook in the
  pipeline feature layer.
- Watches `internal_tools` via `useEffect` and adds/removes `input_attachments: { type: list, default: [] }`
  from the pipeline YAML state accordingly.

**`ConfigurationTab.jsx`**

- Calls `usePipelineAttachmentYamlSync()` to keep the YAML in sync when the Attachments toggle changes.

**`ChatPanel.jsx`**

- Changed `hideAttachments={true}` → `hideAttachments={settings.disableAttachments}` so the attachment button
  is visible in pipeline chat when attachments are enabled.

**`flowEditor.constants.js`**

- Added `STATE_INPUT_ATTACHMENTS = 'input_attachments'`
- Added `StateManagedProps = [STATE_INPUT_ATTACHMENTS]` — runtime-managed state variables not editable by
  users.

**`StateVariableList.jsx`**

- `input_attachments` is filtered from the editable variable list (so it never appears as an editable `[]` row
  that confuses users).
- `input_attachments` is rendered as a dedicated read-only fixed item (like `input` / `messages`) — visible
  only when present in the YAML state.

---

#### Backend — `pylon_main` (`elitea_core`)

**`utils/attachments.py`**

- Added `pipeline_process()` to `BaseFileToAIProcessor` and its subclasses. Returns a structured dict
  `{type, text, attachment_filepath}` where `attachment_filepath` is a marker holding the bucket path — this
  is stripped before the message reaches the LLM API.

**`rpc/chat_all.py`**

- In `process_attachment_message_items()`: passes `pipeline_mode=True` for pipeline participants, triggering
  `pipeline_process()` instead of the standard `process()`.
- In `generate_toolkit_payload()`: injects the attachment toolkit for pipeline agents when `attachments` is
  present in `internal_tools`.

---

#### Backend — `pylon_indexer` (`indexer_worker`)

**`methods/indexer_agent.py`**

- Before building the LangGraph `invoke_input`, iterates over `user_input` chunks and extracts any
  `attachment_filepath` markers (set by `pipeline_process()`), stripping them so clean `{type, text}` dicts
  reach the model API.
- Injects the collected filepaths into `invoke_input['input_attachments']`, populating the pipeline graph
  state declared in the YAML — available to any node via `{input_attachments}` f-string interpolation.

---

### How it works (end-to-end)

1. User enables **Allow Attachments** toggle on a pipeline → `input_attachments: { type: list, default: [] }`
   is added to the YAML state.
2. User uploads a file in pipeline chat → backend stores it in the attachment bucket and calls
   `pipeline_process()`, producing a chunk with an `attachment_filepath` marker.
3. At invoke time, `indexer_agent.py` strips the markers from the message content and passes the file paths as
   `input_attachments` into the LangGraph state.
4. Pipeline nodes can reference attached file paths via `{input_attachments}` (e.g. in an LLM task f-string).
