### PR TITLE
feat: [EL-4901] Extracted info icon to new reusable component and refactored

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
@@ -2,9 +2,10 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 
-import { Box, FormControlLabel, Tooltip, Typography } from '@mui/material';
+import { Box, FormControlLabel, Typography } from '@mui/material';
 
 import { Switch, Text } from '@/[fsd]/shared/ui';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import AttachSvgIcon from '@/assets/attach-icon.svg?react';
 import CalendarIcon from '@/assets/calendar.svg?react';
 import ImageSvgIcon from '@/assets/image.svg?react';
@@ -13,7 +14,6 @@ import PythonIcon from '@/assets/python.svg?react';
 import SwarmIconSVG from '@/assets/swarm-icon.svg?react';
 import ToolsIcon from '@/assets/tools-icon.svg?react';
 import EntityIcon from '@/components/EntityIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 
 const AgentInternalToolSwitch = memo(props => {
   const { title, name, disabled, infoTooltip, icon } = props;
@@ -77,24 +77,11 @@ const AgentInternalToolSwitch = memo(props => {
         />
         <Typography sx={styles.title}>{title}</Typography>
         {infoTooltip && (
-          <Tooltip
-            title={<Text.TextWithLink {...infoTooltip} />}
-            placement="top"
-            slotProps={{
-              popper: {
-                sx: {
-                  zIndex: 9999,
-                },
-              },
-            }}
-          >
-            <Box sx={styles.iconContainer}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
+          <InfoTooltip
+            infoTooltip={infoTooltip}
+            TitleComponent={Text.TextWithLink}
+            sx={styles.iconContainer}
+          />
         )}
       </Box>
       <FormControlLabel

--- a/src/[fsd]/features/mcp/ui/modal/OAuthFormFields.jsx
+++ b/src/[fsd]/features/mcp/ui/modal/OAuthFormFields.jsx
@@ -1,9 +1,9 @@
 import { memo } from 'react';
 
-import { Box, FormControlLabel, Tooltip, Typography } from '@mui/material';
+import { FormControlLabel, Typography } from '@mui/material';
 
 import { Checkbox, Input } from '@/[fsd]/shared/ui';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 const OAuthFormFields = memo(props => {
   const {
@@ -58,17 +58,10 @@ const OAuthFormFields = memo(props => {
           >
             Scope (optional)
             {availableScopes.length > 0 && (
-              <Tooltip
-                title={`MCP server supports: ${availableScopes.join(', ')}.`}
-                placement="top"
-              >
-                <Box sx={styles.infoIconWrapper}>
-                  <InfoIcon
-                    width={16}
-                    height={16}
-                  />
-                </Box>
-              </Tooltip>
+              <InfoTooltip
+                infoTooltip={`MCP server supports: ${availableScopes.join(', ')}.`}
+                sx={styles.infoIconWrapper}
+              />
             )}
           </Typography>
         }

--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/LabelWithTooltip.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/LabelWithTooltip.jsx
@@ -2,10 +2,7 @@ import { memo } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import StyledTooltip from '@/ComponentsLib/Tooltip';
-import InfoIcon from '@/components/Icons/InfoIcon';
-
-const ICON_SIZE = 16;
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 const LabelWithTooltip = memo(props => {
   const { tooltip, title = 'Value', fill } = props;
@@ -17,20 +14,10 @@ const LabelWithTooltip = memo(props => {
     >
       {title && <Typography variant="labelMedium">{title}</Typography>}
       {tooltip && (
-        <StyledTooltip
-          placement="top"
-          title={tooltip}
-        >
-          <Box
-            component="span"
-            sx={styles.iconWrapper(fill)}
-          >
-            <InfoIcon
-              width={ICON_SIZE}
-              height={ICON_SIZE}
-            />
-          </Box>
-        </StyledTooltip>
+        <InfoTooltip
+          infoTooltip={{ title: tooltip, icon: { fill } }}
+          sx={styles.iconWrapper}
+        />
       )}
     </Box>
   );
@@ -46,11 +33,12 @@ const styles = {
     gap: '.25rem',
     zIndex: 999,
   },
-  iconWrapper: fill => ({
+  iconWrapper: {
     display: 'inline-flex',
     alignItems: 'center',
-    color: ({ palette }) => fill || palette.icon.main,
-  }),
+    position: 'static',
+    bottom: 0,
+  },
 };
 
 export default LabelWithTooltip;

--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/PipelineScheduleModal.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/PipelineScheduleModal.jsx
@@ -5,11 +5,10 @@ import 'react-js-cron/dist/styles.css';
 
 import { Box, Button, GlobalStyles, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { validateCronExpression } from '@/[fsd]/features/toolkits/indexes/lib/helpers/indexSchedule.helpers.js';
 import { Modal } from '@/[fsd]/shared/ui';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import FormInput from '@/components/FormInput';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import RadioButtonGroup from '@/components/RadioButtonGroup';
 
 // Default cron: every Saturday at midnight
@@ -96,24 +95,11 @@ const PipelineScheduleModal = props => {
                 >
                   minute - hour - day (month) - month - day (week)
                 </Typography>
-                <Tooltip
-                  title="Cron expression help"
-                  placement="top"
-                  slotProps={{ popper: { modifiers: [{ name: 'offset', options: { offset: [0, -8] } }] } }}
-                >
-                  <Box
-                    sx={styles.infoIconWrapper}
-                    component="a"
-                    href="https://crontab.guru/#*_*_*_*"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <InfoIcon
-                      width={16}
-                      height={16}
-                    />
-                  </Box>
-                </Tooltip>
+                <InfoTooltip
+                  infoTooltip="Cron expression help"
+                  href="https://crontab.guru/#*_*_*_*"
+                  sx={styles.infoIconWrapper}
+                />
               </Box>
             </Box>
           </Box>

--- a/src/[fsd]/features/settings/ui/ai-configuration/Configuration/ConfigurationsPanel.jsx
+++ b/src/[fsd]/features/settings/ui/ai-configuration/Configuration/ConfigurationsPanel.jsx
@@ -2,11 +2,10 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import AddModelButton from '@/[fsd]/features/settings/ui/ai-configuration/Configuration/AddModelButton';
 import ConfigurationSection from '@/[fsd]/features/settings/ui/ai-configuration/Configuration/ConfigurationSection';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { ALLOW_PROJECT_OWN_LLMS, PUBLIC_PROJECT_ID } from '@/common/constants';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
 const ConfigurationsPanel = memo(props => {
@@ -49,17 +48,7 @@ const ConfigurationsPanel = memo(props => {
           >
             {label}
           </Typography>
-          <Tooltip
-            title={tooltipText}
-            placement="top"
-          >
-            <Box
-              sx={styles.inlineInfoIconWrapper}
-              aria-label={`${String(label).toLowerCase()}-model-info`}
-            >
-              <InfoIcon />
-            </Box>
-          </Tooltip>
+          <InfoTooltip infoTooltip={tooltipText} sx={styles.inlineInfoIconWrapper} />
         </Box>
       );
     },

--- a/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexNameWrapper.jsx
+++ b/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexNameWrapper.jsx
@@ -3,15 +3,14 @@ import { memo, useMemo } from 'react';
 import { Box, CircularProgress, Typography, useTheme } from '@mui/material';
 
 import { IndexStatuses } from '@/[fsd]/features/toolkits/indexes/lib/constants/indexDetails.constants';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import StopIcon from '@/assets/stop-icon.svg?react';
 import AttentionIcon from '@/components/Icons/AttentionIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 
 const IndexNameWrapper = memo(props => {
   const { index } = props;
-  const styles = indexNameWrapperStyles();
-
   const theme = useTheme();
+  const styles = indexNameWrapperStyles(theme);
 
   const state = index?.metadata?.state;
   const isFailed = state === IndexStatuses.fail;
@@ -38,10 +37,9 @@ const IndexNameWrapper = memo(props => {
         <Box sx={ui => styles.errorWrapper(ui, isFailed)}>
           <>
             {isFailed ? (
-              <InfoIcon
-                width={16}
-                height={16}
-                fill={theme.palette.background.button.danger}
+              <InfoTooltip
+                infoTooltip={{ icon: styles.errorInfoIcon }}
+                disableTooltip
               />
             ) : isPartlyOk ? (
               <AttentionIcon
@@ -84,7 +82,7 @@ const IndexNameWrapper = memo(props => {
 IndexNameWrapper.displayName = 'IndexNameWrapper';
 
 /** @type {MuiSx} */
-const indexNameWrapperStyles = () => ({
+const indexNameWrapperStyles = theme => ({
   nameWrapper: {
     display: 'flex',
     justifyContent: 'flex-start',
@@ -113,6 +111,9 @@ const indexNameWrapperStyles = () => ({
         : {}),
     },
   }),
+  errorInfoIcon: {
+    fill: theme.palette.background.button.danger,
+  },
   progressWrapper: ({ palette }) => ({
     display: 'flex',
     justifyContent: 'center',

--- a/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexScheduleModal.jsx
+++ b/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexScheduleModal.jsx
@@ -6,13 +6,12 @@ import { useSelector } from 'react-redux';
 
 import { Box, Button, GlobalStyles, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { IndexCronDefault } from '@/[fsd]/features/toolkits/indexes/lib/constants/indexDetails.constants';
 import { validateCronExpression } from '@/[fsd]/features/toolkits/indexes/lib/helpers/indexSchedule.helpers.js';
 import { Modal } from '@/[fsd]/shared/ui';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import CredentialsSelect from '@/components/CredentialsSelect';
 import FormInput from '@/components/FormInput';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import RadioButtonGroup from '@/components/RadioButtonGroup';
 import { useSelectedProject } from '@/hooks/useSelectedProject';
 
@@ -118,24 +117,11 @@ const IndexScheduleModal = props => {
                 >
                   minute – hour – day (month) – month – day (week)
                 </Typography>
-                <Tooltip
-                  title="Cron expression help"
-                  placement="top"
-                  slotProps={{ popper: { modifiers: [{ name: 'offset', options: { offset: [0, -8] } }] } }}
-                >
-                  <Box
-                    sx={styles.infoIconWrapper}
-                    component="a"
-                    href="https://crontab.guru/#*_*_*_*"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <InfoIcon
-                      width={16}
-                      height={16}
-                    />
-                  </Box>
-                </Tooltip>
+                <InfoTooltip
+                  infoTooltip="Cron expression help"
+                  href="https://crontab.guru/#*_*_*_*"
+                  sx={styles.infoIconWrapper}
+                />
               </Box>
 
               {credentialsData && (

--- a/src/[fsd]/features/toolkits/indexes/ui/IndexesList/IndexListItem.jsx
+++ b/src/[fsd]/features/toolkits/indexes/ui/IndexesList/IndexListItem.jsx
@@ -6,11 +6,11 @@ import { Box, CircularProgress, Skeleton, Typography } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
 import { IndexStatuses } from '@/[fsd]/features/toolkits/indexes/lib/constants/indexDetails.constants';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import ClockIcon from '@/assets/clock.svg?react';
 import FileIcon from '@/assets/file.svg?react';
 import StopIcon from '@/assets/stop-icon.svg?react';
 import AttentionIcon from '@/components/Icons/AttentionIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 
 const IndexListItem = memo(props => {
   const { index, onIndexClick, currentIndex, useMock } = props;
@@ -126,13 +126,11 @@ const IndexListItem = memo(props => {
         />
       )}
       {index.metadata.state === IndexStatuses.fail && (
-        <Box sx={styles.icon}>
-          <InfoIcon
-            width={16}
-            height={16}
-            fill="#D71616"
-          />
-        </Box>
+        <InfoTooltip
+          infoTooltip={{ icon: styles.error }}
+          disableTooltip
+          sx={styles.icon}
+        />
       )}
 
       {index.metadata.state === IndexStatuses.cancelled && (
@@ -226,6 +224,9 @@ const indexListItem = () => ({
     right: '1rem',
     marginTop: '-.4375rem',
   }),
+  error: {
+    fill: '#D71616',
+  },
   warning: {
     path: ({ palette }) => ({
       fill: palette.background.warning,

--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/EmptyMcpTools.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/EmptyMcpTools.jsx
@@ -2,20 +2,17 @@ import { memo } from 'react';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 const EmptyMcpTools = memo(() => {
-  const styles = getStyles();
   const theme = useTheme();
+  const styles = getStyles(theme);
   return (
     <Box sx={styles.container}>
-      <Box sx={styles.infoIconWrapper}>
-        <InfoIcon
-          width={14}
-          height={14}
-          fill={theme.palette.icon.fill.tips}
-        />
-      </Box>
+      <InfoTooltip
+        infoTooltip={{ icon: styles.info }}
+        disableTooltip
+      />
       <Typography
         variant="bodySmall"
         sx={styles.text}
@@ -26,13 +23,7 @@ const EmptyMcpTools = memo(() => {
   );
 });
 
-const getStyles = () => ({
-  infoIconWrapper: {
-    display: 'flex',
-    alignItems: 'center',
-    width: '0.875rem',
-    height: '0.875rem',
-  },
+const getStyles = theme => ({
   container: ({ palette }) => ({
     marginTop: '0.75rem',
     display: 'flex',
@@ -46,6 +37,11 @@ const getStyles = () => ({
     borderRadius: '0.5rem',
     background: palette.background.tips,
   }),
+  info: {
+    width: 14,
+    height: 14,
+    fill: theme.palette.icon.fill.tips,
+  },
   text: ({ palette }) => ({
     color: palette.text.tips,
   }),

--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -4,7 +4,6 @@ import YAML from 'js-yaml';
 
 import { Box, FormControlLabel, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { OpenApiHelpers, ToolBaseHelpers } from '@/[fsd]/features/toolkits/lib/helpers';
 import { ToolkitForm } from '@/[fsd]/features/toolkits/ui';
 import { ArrayFieldInput } from '@/[fsd]/features/toolkits/ui/form/ToolBase';
@@ -13,13 +12,12 @@ import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
 import { Checkbox, Field, Input } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
-import { TooltipMarkdownContent } from '@/[fsd]/shared/ui/tooltip';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { MAX_NAME_LENGTH } from '@/common/constants';
 import AgentSelect from '@/components/AgentSelect';
 import CredentialsSelect from '@/components/CredentialsSelect';
 import EmbeddingModelSelect from '@/components/EmbeddingModelSelect';
 import FormInput from '@/components/FormInput.jsx';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import ImageGenerationModelSelect from '@/components/ImageGenerationModelSelect';
 import LlmModelSelect from '@/components/LlmModelSelect';
 import SecretManagementInput from '@/components/SecretManagementInput.jsx';
@@ -164,7 +162,6 @@ const ToolBaseProperty = memo(props => {
     [settings?.selected_tools, editField, buildEditFieldPath],
   );
 
-  // Helper to render label with optional info icon tooltip
   const renderLabelWithHint = useCallback(
     (isRequired = false) => {
       if (!description) return label;
@@ -173,18 +170,10 @@ const ToolBaseProperty = memo(props => {
         <>
           {label}
           {isRequired && ' *'}
-
-          <Tooltip
-            title={<TooltipMarkdownContent>{description}</TooltipMarkdownContent>}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={19}
-                height={19}
-              />
-            </Box>
-          </Tooltip>
+          <InfoTooltip
+            infoTooltip={description}
+            sx={styles.infoIconWrapper}
+          />
         </>
       );
     },

--- a/src/[fsd]/shared/ui/field/AnyOfPatternField.jsx
+++ b/src/[fsd]/shared/ui/field/AnyOfPatternField.jsx
@@ -2,9 +2,8 @@ import { memo, useCallback } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { Field } from '@/[fsd]/shared/ui';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { jsonLinter } from '@/hooks/useCodeMirrorLanguageExtensions';
 import { json } from '@codemirror/lang-json';
 
@@ -55,19 +54,7 @@ const AnyOfPatternField = memo(props => {
     >
       <Box sx={styles.header}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {description && (
-          <Tooltip
-            title={description}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
-        )}
+        {description && <InfoTooltip infoTooltip={description} sx={styles.infoIconWrapper} />}
       </Box>
       <Box sx={{ marginTop: '0.75rem' }}>
         <Field.ResizableCodeMirrorEditor

--- a/src/[fsd]/shared/ui/field/CommonArrayField.jsx
+++ b/src/[fsd]/shared/ui/field/CommonArrayField.jsx
@@ -3,9 +3,8 @@ import { memo, useCallback } from 'react';
 import { Typography } from '@mui/material';
 import { Box } from '@mui/system';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { Field, Select } from '@/[fsd]/shared/ui';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { jsonLinter } from '@/hooks/useCodeMirrorLanguageExtensions';
 import { json } from '@codemirror/lang-json';
 
@@ -69,19 +68,7 @@ const CommonArrayField = memo(props => {
       >
         <Box sx={styles.header}>
           <Typography variant="bodyMedium">{label}</Typography>
-          {description && (
-            <Tooltip
-              title={description}
-              placement="top"
-            >
-              <Box sx={styles.infoIconWrapper}>
-                <InfoIcon
-                  width={16}
-                  height={16}
-                />
-              </Box>
-            </Tooltip>
-          )}
+          {description && <InfoTooltip infoTooltip={description} sx={styles.infoIconWrapper} />}
         </Box>
         <Select.SingleSelect
           required={isRequired}

--- a/src/[fsd]/shared/ui/field/CommonBooleanField.jsx
+++ b/src/[fsd]/shared/ui/field/CommonBooleanField.jsx
@@ -2,10 +2,9 @@ import { memo, useCallback } from 'react';
 
 import { Box, FormControlLabel, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { Checkbox } from '@/[fsd]/shared/ui';
 import { includeFieldWrapperOverlapStyles } from '@/[fsd]/shared/ui/field/styles';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 const CommonBooleanField = memo(props => {
   const { fieldKey, fieldValue, fieldProperties, onChangeInputVariables, toolInputVariables } = props;
@@ -40,19 +39,7 @@ const CommonBooleanField = memo(props => {
         label={
           <Box sx={styles.header}>
             <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-            {description && (
-              <Tooltip
-                title={description}
-                placement="top"
-              >
-                <Box sx={styles.infoIconWrapper}>
-                  <InfoIcon
-                    width={16}
-                    height={16}
-                  />
-                </Box>
-              </Tooltip>
-            )}
+            {description && <InfoTooltip infoTooltip={description} sx={styles.infoIconWrapper} />}
           </Box>
         }
         sx={styles.formControlLabel}

--- a/src/[fsd]/shared/ui/field/CommonNumberField.jsx
+++ b/src/[fsd]/shared/ui/field/CommonNumberField.jsx
@@ -2,10 +2,9 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { includeFieldWrapperOverlapStyles } from '@/[fsd]/shared/ui/field/styles';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import FormInput from '@/components/FormInput.jsx';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import Slider from '@/components/Slider.jsx';
 
 const CommonNumberField = memo(props => {
@@ -152,19 +151,7 @@ const CommonNumberField = memo(props => {
     >
       <Box sx={styles.header}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {description && (
-          <Tooltip
-            title={description}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
-        )}
+        {description && <InfoTooltip infoTooltip={description} />}
       </Box>
       <FormInput
         required={fieldProperties.isRequired}
@@ -209,15 +196,6 @@ const commonNumberFieldStyles = () => ({
     ...includeFieldWrapperOverlapStyles(disabled),
   }),
   header: { display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '0.5rem' },
-  infoIconWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    height: '100%',
-    width: '1rem',
-    cursor: 'pointer',
-    pointerEvents: 'auto',
-  },
 });
 
 export default CommonNumberField;

--- a/src/[fsd]/shared/ui/field/CommonObjectField.jsx
+++ b/src/[fsd]/shared/ui/field/CommonObjectField.jsx
@@ -2,9 +2,8 @@ import { memo, useCallback } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { Field } from '@/[fsd]/shared/ui';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { jsonLinter } from '@/hooks/useCodeMirrorLanguageExtensions';
 import { json } from '@codemirror/lang-json';
 
@@ -49,19 +48,7 @@ const CommonObjectField = memo(props => {
     >
       <Box sx={styles.header}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {description && (
-          <Tooltip
-            title={description}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
-        )}
+        {description && <InfoTooltip infoTooltip={description} sx={styles.infoIconWrapper} />}
       </Box>
       <Box sx={{ marginTop: '0.75rem' }}>
         <Field.ResizableCodeMirrorEditor

--- a/src/[fsd]/shared/ui/field/CommonStringField.jsx
+++ b/src/[fsd]/shared/ui/field/CommonStringField.jsx
@@ -2,12 +2,10 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { Box, IconButton, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
-import { Field } from '@/[fsd]/shared/ui';
+import { Field, Input } from '@/[fsd]/shared/ui';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
-import FormInput from '@/components/FormInput';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import CopyIcon from '@/components/Icons/CopyIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import useToast from '@/hooks/useToast';
 
 const CommonStringField = memo(props => {
@@ -92,6 +90,17 @@ const CommonStringField = memo(props => {
     ];
   }, [enumValues, isRequired, property]);
 
+  const renderInfoTooltip = useCallback(
+    descriptionValue =>
+      descriptionValue ? (
+        <InfoTooltip
+          infoTooltip={descriptionValue}
+          sx={styles.infoIconWrapper}
+        />
+      ) : null,
+    [styles.infoIconWrapper],
+  );
+
   if (enumOptions) {
     return (
       <Box
@@ -101,19 +110,7 @@ const CommonStringField = memo(props => {
       >
         <Box sx={styles.header}>
           <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-          {description && (
-            <Tooltip
-              title={description}
-              placement="top"
-            >
-              <Box sx={styles.infoIconWrapper}>
-                <InfoIcon
-                  width={16}
-                  height={16}
-                />
-              </Box>
-            </Tooltip>
-          )}
+          {renderInfoTooltip(description)}
         </Box>
         <SingleSelect
           sx={{ width: 'calc(100% - 0.35rem)', margin: '0 auto' }}
@@ -137,19 +134,7 @@ const CommonStringField = memo(props => {
       >
         <Box sx={styles.header}>
           <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-          {description && (
-            <Tooltip
-              title={description}
-              placement="top"
-            >
-              <Box sx={styles.infoIconWrapper}>
-                <InfoIcon
-                  width={16}
-                  height={16}
-                />
-              </Box>
-            </Tooltip>
-          )}
+          {renderInfoTooltip(description)}
         </Box>
         <Field.CodeMirrorEditor
           value={fieldValue || ''}
@@ -188,22 +173,9 @@ const CommonStringField = memo(props => {
       )}
       <Box sx={{ ...styles.header, ...styles.noMargin }}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {description && (
-          <Tooltip
-            title={description}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
-        )}
+        {renderInfoTooltip(description)}
       </Box>
-      <FormInput
-        inputEnhancer={isMultiline}
+      <Input.StyledInputEnhancer
         required={isRequired}
         multiline={isMultiline}
         minRows={lines ? parseInt(lines) : isMultiline ? 3 : 1}

--- a/src/[fsd]/shared/ui/field/SecretInputField.jsx
+++ b/src/[fsd]/shared/ui/field/SecretInputField.jsx
@@ -2,9 +2,8 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { includeFieldWrapperOverlapStyles } from '@/[fsd]/shared/ui/field/styles';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import SecretManagementInput from '@/components/SecretManagementInput.jsx';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
@@ -39,19 +38,7 @@ const SecretInputFieldField = memo(props => {
     >
       <Box sx={styles.header}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {tooltipHint && (
-          <Tooltip
-            title={tooltipHint}
-            placement="top"
-          >
-            <Box sx={styles.infoIconWrapper}>
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
-        )}
+        {tooltipHint && <InfoTooltip infoTooltip={tooltipHint} sx={styles.infoIconWrapper} />}
       </Box>
       <SecretManagementInput
         sx={{ marginTop: '0rem' }}

--- a/src/[fsd]/shared/ui/input/InputBase.jsx
+++ b/src/[fsd]/shared/ui/input/InputBase.jsx
@@ -273,8 +273,8 @@ const styledInputBaseStyles = (
   inputLabelSlot: {
     textOverflow: 'clip',
     ...(needsLabelUnclip && {
-      overflow: 'visible',
-      maxWidth: 'none',
+      overflow: 'visible !important',
+      maxWidth: 'none !important',
     }),
   },
   containerBox: {

--- a/src/[fsd]/shared/ui/input/textFieldVariants.js
+++ b/src/[fsd]/shared/ui/input/textFieldVariants.js
@@ -87,7 +87,7 @@ export const eliteaTextFieldStyle = () => ({
     fontSize: '1rem',
     fontWeight: 500,
   },
-  '& .MuiInputLabel-shrink .MuiBox-root:has(> svg)': {
+  '& .MuiInputLabel-shrink .MuiBox-root:has(> svg):not([data-info-tooltip])': {
     width: 16,
     height: 16,
     minWidth: 16,
@@ -96,10 +96,18 @@ export const eliteaTextFieldStyle = () => ({
     transform: 'scale(1.3334)',
     transformOrigin: 'center',
   },
+  '& .MuiInputLabel-shrink [data-info-tooltip]': {
+    transform: 'scale(1.3334)',
+    transformOrigin: 'center',
+  },
   '& .MuiInputLabel-root': {
     maxWidth: '100%',
     '&:not(.MuiInputLabel-shrink)': {
       maxWidth: 'calc(100% - 1.5rem)',
+    },
+    '&:has([data-info-tooltip])': {
+      overflow: 'visible',
+      maxWidth: 'none',
     },
   },
   '& .MuiInputBase-root': {

--- a/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
+++ b/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
@@ -1,14 +1,9 @@
 import { memo } from 'react';
 
-import { Box, Tooltip, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
-import { TooltipMarkdownContent } from '@/[fsd]/shared/ui/tooltip';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
-/**
- * Reusable field label with optional info icon and tooltip
- * Used for form fields, settings, and other input labels
- */
 const InfoLabelWithTooltip = memo(props => {
   const {
     label,
@@ -22,6 +17,8 @@ const InfoLabelWithTooltip = memo(props => {
     iconSize = 16,
     required = false,
   } = props;
+
+  const styles = infoLabelWithTooltipStyles(iconSize);
 
   const labelSx = [
     inheritColor ? { color: 'inherit' } : styles.label,
@@ -50,16 +47,7 @@ const InfoLabelWithTooltip = memo(props => {
   return (
     <Box sx={[styles.container, sx]}>
       {labelNode}
-      {tooltip && (
-        <Tooltip title={<TooltipMarkdownContent>{tooltip}</TooltipMarkdownContent>}>
-          <Box sx={styles.iconWrapper}>
-            <InfoIcon
-              width={iconSize}
-              height={iconSize}
-            />
-          </Box>
-        </Tooltip>
-      )}
+      {tooltip && <InfoTooltip infoTooltip={{ title: tooltip, icon: styles.info }} />}
     </Box>
   );
 });
@@ -67,7 +55,7 @@ const InfoLabelWithTooltip = memo(props => {
 InfoLabelWithTooltip.displayName = 'InfoLabelWithTooltip';
 
 /** @type {MuiSx} */
-const styles = {
+const infoLabelWithTooltipStyles = iconSize => ({
   container: {
     display: 'flex',
     alignItems: 'center',
@@ -76,15 +64,10 @@ const styles = {
   label: ({ palette }) => ({
     color: palette.text.primary,
   }),
-  iconWrapper: {
-    display: 'flex',
-    alignItems: 'center',
-    cursor: 'pointer',
-
-    '&:hover': {
-      opacity: 0.8,
-    },
+  info: {
+    width: iconSize,
+    height: iconSize,
   },
-};
+});
 
 export default InfoLabelWithTooltip;

--- a/src/[fsd]/shared/ui/select/SingleSelect.jsx
+++ b/src/[fsd]/shared/ui/select/SingleSelect.jsx
@@ -10,17 +10,15 @@ import {
   ListSubheader,
   MenuItem,
   Select,
-  Tooltip,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
 import { FLAT_MENU_ACTION_VALUE } from '@/[fsd]/shared/lib/constants/singleSelectConstants';
 import { Banner } from '@/[fsd]/shared/ui';
-import { TooltipMarkdownContent } from '@/[fsd]/shared/ui/tooltip';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import RemoveIcon from '@/assets/remove-icon.svg?react';
 import ArrowDownIcon from '@/components/Icons/ArrowDownIcon';
-import InfoIcon from '@/components/Icons/InfoIcon';
 
 import SingleSelectDropdown from './SingleSelectDropdown';
 import { getSingleSelectShowBorderSx, getSingleSelectWithoutBorderSx } from './singleSelectVariants';
@@ -135,8 +133,19 @@ const SingleSelect = memo(props => {
         customSelectedColor,
         customSelectedFontSize,
         showBorder,
+        effectiveMultiple,
+        required,
+        hasInfoTooltip: Boolean(infoIconDescription),
       }),
-    [theme, customSelectedColor, customSelectedFontSize, showBorder],
+    [
+      theme,
+      customSelectedColor,
+      customSelectedFontSize,
+      showBorder,
+      effectiveMultiple,
+      required,
+      infoIconDescription,
+    ],
   );
 
   const handleChange = useCallback(
@@ -614,44 +623,16 @@ const SingleSelect = memo(props => {
         {labelNode ??
           (label && !separateLabel && (
             <InputLabel
-              sx={[
-                {
-                  left: '0.75rem',
-                  fontSize: '1rem',
-                  fontWeight: 500,
-                  ...(effectiveMultiple && {
-                    '&:not(.MuiInputLabel-shrink)': { top: '0.5rem' },
-                  }),
-                  ...(required && {
-                    '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
-                  }),
-                },
-                labelSX,
-              ]}
+              sx={[styles.inputLabel, labelSX]}
               shrink={shrinkLabel ? true : undefined}
             >
               {label}
               {required && ' *'}
               {infoIconDescription && (
-                <Box
-                  component="span"
-                  sx={{
-                    marginLeft: '0.15rem',
-                    ':hover': { opacity: 0.8 },
-                  }}
-                >
-                  <Tooltip
-                    title={<TooltipMarkdownContent>{infoIconDescription}</TooltipMarkdownContent>}
-                    placement="top"
-                  >
-                    <Box component="span">
-                      <InfoIcon
-                        width={19}
-                        height={19}
-                      />
-                    </Box>
-                  </Tooltip>
-                </Box>
+                <InfoTooltip
+                  infoTooltip={{ title: infoIconDescription }}
+                  sx={styles.infoTooltip}
+                />
               )}
             </InputLabel>
           ))}
@@ -704,7 +685,17 @@ const SingleSelect = memo(props => {
 
 SingleSelect.displayName = 'SingleSelect';
 
-const singleSelectStyles = (theme, { customSelectedColor, customSelectedFontSize, showBorder } = {}) => ({
+const singleSelectStyles = (
+  theme,
+  {
+    customSelectedColor,
+    customSelectedFontSize,
+    showBorder,
+    effectiveMultiple,
+    required,
+    hasInfoTooltip,
+  } = {},
+) => ({
   labelContainer: {
     display: 'flex',
     alignItems: 'center',
@@ -766,6 +757,29 @@ const singleSelectStyles = (theme, { customSelectedColor, customSelectedFontSize
       border: 'none !important',
       outline: 'none !important',
     },
+  },
+  inputLabel: {
+    display: 'flex',
+    left: '0.75rem',
+    fontSize: '1rem',
+    fontWeight: 500,
+    ...(effectiveMultiple && {
+      '&:not(.MuiInputLabel-shrink)': { top: '0.5rem' },
+    }),
+    ...(required && {
+      '& .MuiInputLabel-asterisk, & .MuiFormLabel-asterisk': { display: 'none' },
+    }),
+    ...(hasInfoTooltip && {
+      overflow: 'visible',
+      maxWidth: 'none',
+    }),
+    '& [data-info-tooltip]': {
+      transform: 'scale(1.3334)',
+      transformOrigin: 'center',
+    },
+  },
+  infoTooltip: {
+    marginLeft: '0.5rem',
   },
   formControl: showBorder ? getSingleSelectShowBorderSx(theme) : getSingleSelectWithoutBorderSx(theme),
   multipleSelect: {

--- a/src/[fsd]/shared/ui/switch/BaseSwitch.jsx
+++ b/src/[fsd]/shared/ui/switch/BaseSwitch.jsx
@@ -1,41 +1,11 @@
-import React, { forwardRef, memo, useCallback, useMemo } from 'react';
+import React, { forwardRef, memo, useCallback } from 'react';
 
-import { Box, FormControlLabel, Switch as MuiSwitch, Tooltip, Typography } from '@mui/material';
+import { Box, FormControlLabel, Switch as MuiSwitch, Typography } from '@mui/material';
 
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 export const SWITCH_VARIANTS = {
   elitea: 'elitea',
-};
-
-const INFO_TOOLTIP_DEFAULTS = {
-  placement: 'top',
-  zIndex: 9999,
-  icon: { width: 16, height: 16 },
-};
-
-const parseInfoTooltip = (infoTooltip, slotProps) => {
-  if (!infoTooltip) return null;
-
-  const isObject = typeof infoTooltip === 'object' && !React.isValidElement(infoTooltip);
-
-  return {
-    title: isObject ? infoTooltip.title : infoTooltip,
-    placement: isObject
-      ? (infoTooltip.placement ?? INFO_TOOLTIP_DEFAULTS.placement)
-      : INFO_TOOLTIP_DEFAULTS.placement,
-    zIndex: isObject
-      ? (infoTooltip.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex)
-      : (slotProps?.tooltip?.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex),
-    icon: {
-      width: isObject
-        ? (infoTooltip.icon?.width ?? INFO_TOOLTIP_DEFAULTS.icon.width)
-        : INFO_TOOLTIP_DEFAULTS.icon.width,
-      height: isObject
-        ? (infoTooltip.icon?.height ?? INFO_TOOLTIP_DEFAULTS.icon.height)
-        : INFO_TOOLTIP_DEFAULTS.icon.height,
-    },
-  };
 };
 
 const BaseSwitch = memo(
@@ -79,27 +49,8 @@ const BaseSwitch = memo(
       />
     );
 
-    const tooltipConfig = useMemo(() => parseInfoTooltip(infoTooltip, slotProps), [infoTooltip, slotProps]);
-
-    const tooltipIcon = tooltipConfig ? (
-      <Tooltip
-        title={tooltipConfig.title}
-        placement={tooltipConfig.placement}
-        slotProps={{
-          popper: {
-            sx: {
-              zIndex: tooltipConfig.zIndex,
-            },
-          },
-        }}
-      >
-        <Box sx={styles.iconContainer}>
-          <InfoIcon
-            width={tooltipConfig.icon.width}
-            height={tooltipConfig.icon.height}
-          />
-        </Box>
-      </Tooltip>
+    const tooltipIcon = infoTooltip ? (
+      <InfoTooltip infoTooltip={infoTooltip} slotProps={slotProps} />
     ) : null;
 
     if (label) {
@@ -157,13 +108,6 @@ const genStyles = ({ width }) => ({
     gap: '0.25rem',
   },
   label: { display: 'flex', alignItems: 'center', gap: '0.25rem' },
-  iconContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.25rem',
-    height: '100%',
-    '& :hover': { opacity: 0.8 },
-  },
   formControlLabel: {
     gap: '0.7rem',
   },

--- a/src/[fsd]/shared/ui/tooltip/InfoTooltip.jsx
+++ b/src/[fsd]/shared/ui/tooltip/InfoTooltip.jsx
@@ -1,0 +1,119 @@
+import React, { memo, useCallback, useMemo } from 'react';
+
+import { Box, Tooltip } from '@mui/material';
+
+import TooltipMarkdownContent from '@/[fsd]/shared/ui/tooltip/TooltipMarkdownContent';
+import InfoIcon from '@/components/Icons/InfoIcon';
+
+const INFO_TOOLTIP_DEFAULTS = {
+  placement: 'top',
+  zIndex: 9999,
+  icon: { width: 16, height: 16 },
+};
+
+const InfoTooltip = memo(props => {
+  const {
+    infoTooltip,
+    slotProps,
+    sx,
+    href,
+    linkTarget = '_blank',
+    rel = 'noopener noreferrer',
+    disableTooltip = false,
+    TitleComponent,
+    titleComponentProps,
+  } = props;
+
+  const styles = infoTooltipStyles();
+
+  const parseInfoTooltip = useCallback((tooltip, sProps) => {
+    if (!tooltip) return null;
+
+    const isObject = typeof tooltip === 'object' && !React.isValidElement(tooltip);
+
+    return {
+      title: isObject ? tooltip.title : tooltip,
+      placement: isObject
+        ? (tooltip.placement ?? INFO_TOOLTIP_DEFAULTS.placement)
+        : INFO_TOOLTIP_DEFAULTS.placement,
+      zIndex: isObject
+        ? (tooltip.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex)
+        : (sProps?.tooltip?.zIndex ?? INFO_TOOLTIP_DEFAULTS.zIndex),
+      icon: {
+        width: isObject
+          ? (tooltip.icon?.width ?? INFO_TOOLTIP_DEFAULTS.icon.width)
+          : INFO_TOOLTIP_DEFAULTS.icon.width,
+        height: isObject
+          ? (tooltip.icon?.height ?? INFO_TOOLTIP_DEFAULTS.icon.height)
+          : INFO_TOOLTIP_DEFAULTS.icon.height,
+        fill: isObject ? tooltip.icon?.fill : undefined,
+      },
+    };
+  }, []);
+
+  const tooltipConfig = useMemo(
+    () => parseInfoTooltip(infoTooltip, slotProps),
+    [parseInfoTooltip, infoTooltip, slotProps],
+  );
+
+  if (!tooltipConfig) return null;
+
+  const boxProps = href ? { component: 'a', href, target: linkTarget, rel } : {};
+
+  const iconElement = (
+    <Box
+      data-info-tooltip
+      sx={[styles.iconContainer, sx]}
+      {...boxProps}
+    >
+      <InfoIcon
+        width={tooltipConfig.icon.width}
+        height={tooltipConfig.icon.height}
+        fill={tooltipConfig.icon.fill}
+      />
+    </Box>
+  );
+
+  if (disableTooltip) return iconElement;
+
+  const resolvedTitleProps = titleComponentProps ?? (typeof infoTooltip === 'object' ? infoTooltip : {});
+  const titleContent = TitleComponent ? (
+    <TitleComponent {...resolvedTitleProps} />
+  ) : (
+    <TooltipMarkdownContent>{tooltipConfig.title}</TooltipMarkdownContent>
+  );
+
+  return (
+    <Tooltip
+      title={titleContent}
+      placement={tooltipConfig.placement}
+      slotProps={{
+        popper: {
+          sx: {
+            zIndex: tooltipConfig.zIndex,
+          },
+        },
+      }}
+    >
+      {iconElement}
+    </Tooltip>
+  );
+});
+
+InfoTooltip.displayName = 'InfoTooltip';
+
+const infoTooltipStyles = () => ({
+  iconContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.25rem',
+    height: '100%',
+    position: 'relative',
+    cursor: 'pointer',
+    bottom: '0.25rem',
+    overflow: 'visible',
+    '& :hover': { opacity: 0.8 },
+  },
+});
+
+export default InfoTooltip;

--- a/src/[fsd]/shared/ui/tooltip/index.js
+++ b/src/[fsd]/shared/ui/tooltip/index.js
@@ -1,3 +1,4 @@
 export { default as TypographyWithConditionalTooltip } from './TypographyWithConditionalTooltip';
 export { default as ConditionalTooltip } from './ConditionalTooltip';
 export { default as TooltipMarkdownContent } from './TooltipMarkdownContent';
+export { default as InfoTooltip } from './InfoTooltip';

--- a/src/components/MermaidDiagramOutput/DiagramOutput.jsx
+++ b/src/components/MermaidDiagramOutput/DiagramOutput.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import domtoimage from 'dom-to-image';
 import mermaid from 'mermaid';
@@ -8,6 +8,7 @@ import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import { Box, CircularProgress, IconButton, Typography } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import FullscreenIcon from '@/assets/full-screen-icon.svg?react';
 import MinusIcon from '@/assets/minus-icon.svg?react';
 import { HEIGHTS, ICON_SIZES, WIDTHS } from '@/common/designTokens';
@@ -15,7 +16,6 @@ import { useTheme } from '@emotion/react';
 
 import DotMenu from '../DotMenu';
 import DownloadIcon from '../Icons/DownloadIcon';
-import InfoIcon from '../Icons/InfoIcon';
 import PlusIcon from '../Icons/PlusIcon';
 import './DiagramOutput.css';
 
@@ -137,15 +137,17 @@ const createUserFriendlyErrorMessage = error => {
   return fallbackMessage;
 };
 
-const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, quickFixTooltip = '' }) => {
+const MermaidDiagramOutput = memo(props => {
+  const { code, onQuickFix, isQuickFixLoading = false, quickFixTooltip = '' } = props;
+  const theme = useTheme();
   // console.log('MermaidDiagramOutput=====>', code)
   const panZoomTigerRef = useRef(null);
-  const theme = useTheme();
   const [hasBeenChanged, setHasBeenChanged] = useState(false);
   const { diagramId, graphId } = useMemo(() => getDiagramId(), []);
   const [isValidCode, setIsValidCode] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [rawErrorMessage, setRawErrorMessage] = useState('');
+  const styles = mermaidDiagramOutputStyles(theme, isValidCode, errorMessage, WIDTHS, HEIGHTS);
 
   const createExportDiagram = useCallback(async () => {
     const canvas = document.createElement('div');
@@ -421,71 +423,21 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
   }, [theme.palette.text.primary]);
 
   return (
-    <Box
-      width={'100%'}
-      display={'flex'}
-      flexDirection={'column'}
-      padding="0px 0px 0px 0px"
-      gap="12px"
-      height={'100%'}
-      boxSizing={'border-box'}
-      position={'relative'}
-    >
-      <Box
-        display={'flex'}
-        flexDirection={'row'}
-        height={'auto'}
-        justifyContent={'flex-end'}
-        alignItems={'center'}
-        position={'absolute'}
-        top="12px"
-        right={'12px'}
-        gap={'8px'}
-      >
+    <Box sx={styles.container}>
+      <Box sx={styles.toolbar}>
         {errorMessage && onQuickFix && (
           <Tooltip
             title={quickFixTooltip}
             placement="bottom"
           >
-            <span>
+            <Box component="span">
               <IconButton
                 onClick={handleQuickFix}
                 disabled={isQuickFixLoading}
                 disableRipple
-                sx={({ palette }) => ({
-                  boxSizing: 'border-box',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  justifyContent: 'center',
-                  height: '1.75rem',
-                  paddingLeft: '0.75rem',
-                  paddingRight: '0.75rem',
-                  color: palette.split.text.default,
-                  background: palette.split.default,
-                  borderRadius: '1.5rem',
-                  whiteSpace: 'nowrap',
-                  '&:hover': {
-                    background: palette.split.hover,
-                  },
-                  '&:active': {
-                    color: palette.split.text.pressed,
-                    backgroundColor: palette.split.pressed,
-                  },
-                  '&:disabled': {
-                    color: palette.split.text.disabled,
-                    backgroundColor: palette.split.disabled,
-                  },
-                })}
+                sx={styles.quickFixButton}
               >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color: ({ palette }) => palette.text.createButton,
-                  }}
-                >
+                <Box sx={styles.quickFixIconWrapper}>
                   {isQuickFixLoading ? (
                     <CircularProgress
                       size={16}
@@ -496,17 +448,13 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
                   )}
                 </Box>
                 <Typography
-                  sx={({ typography }) => ({
-                    color: 'inherit',
-                    fontFamily: typography.fontFamily,
-                    fontFeatureSettings: typography.fontFeatureSettings,
-                  })}
+                  sx={styles.quickFixText}
                   variant="labelSmall"
                 >
                   {isQuickFixLoading ? 'Fixing...' : 'Quick Fix'}
                 </Typography>
               </IconButton>
-            </span>
+            </Box>
           </Tooltip>
         )}
         <DotMenu
@@ -521,97 +469,45 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
           }}
           disabled={!isValidCode}
           iconColor="secondary"
-          menuIcon={
-            <DownloadIcon
-              sx={{ fontSize: '16px', marginTop: '-1px' }}
-              fill={isValidCode ? theme.palette.icon.fill.default : theme.palette.icon.fill.disabled}
-            />
-          }
+          menuIcon={<DownloadIcon sx={styles.downloadIcon} />}
         >
           {menuItems}
         </DotMenu>
       </Box>
-      <Box
-        display={'flex'}
-        flexDirection={'column'}
-        height={'auto'}
-        justifyContent={'flex-end'}
-        alignItems={'flex-end'}
-        position={'absolute'}
-        bottom="12px"
-        left={'12px'}
-        borderRadius={'2px'}
-        border={`1px solid ${theme.palette.border.lines}`}
-      >
+      <Box sx={styles.zoomControls}>
         <IconButton
           variant="elitea"
           color="tertiary"
-          sx={{
-            marginLeft: '0px',
-            borderRadius: '0px',
-            borderBottom: `1px solid ${theme.palette.border.lines}`,
-          }}
+          sx={styles.zoomButton}
           onClick={onZoomIn}
         >
-          <PlusIcon
-            sx={{ fontSize: '16px' }}
-            fill={theme.palette.icon.fill.default}
-          />
+          <PlusIcon sx={styles.zoomIcon} />
         </IconButton>
         <IconButton
           variant="elitea"
           color="tertiary"
-          sx={{
-            marginLeft: '0px',
-            borderRadius: '0px',
-            borderBottom: `1px solid ${theme.palette.border.lines}`,
-          }}
+          sx={styles.zoomButton}
           onClick={onZoomOut}
         >
-          <MinusIcon
-            sx={{ fontSize: '16px' }}
-            fill={theme.palette.icon.fill.default}
-          />
+          <MinusIcon sx={styles.zoomIcon} />
         </IconButton>
         <IconButton
           disabled={!hasBeenChanged}
           variant="elitea"
           color="tertiary"
-          sx={{ marginLeft: '0px', borderRadius: '0px' }}
+          sx={styles.zoomButtonLast}
           onClick={onReset}
         >
-          <FullscreenIcon
-            sx={{ fontSize: '16px' }}
-            fill={theme.palette.icon.fill.secondary}
-          />
+          <FullscreenIcon sx={styles.fullscreenIcon} />
         </IconButton>
       </Box>
-      <Box
-        height={'100%'}
-        width={'100%'}
-        maxWidth={'100%'}
-        border={`1px solid ${theme.palette.border.lines} `}
-        borderRadius={'8px'}
-        display={'flex'}
-        flexDirection="column"
-        justifyContent={'flex-start'}
-        alignItems={'center'}
-        boxSizing={'border-box'}
-        overflow={'scroll'}
-        backgroundColor={theme.palette.background.tabPanel}
-      >
+      <Box sx={styles.diagramContainer}>
         {errorMessage && (
-          <Box
-            width={'100%'}
-            marginTop={'8px'}
-            marginBottom={'8px'}
-            padding="8px"
-            flexWrap={'wrap'}
-          >
+          <Box sx={styles.errorMessageBox}>
             <Typography
               variant="labelMedium"
               color="error"
-              sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.2 }}
+              sx={styles.errorText}
             >
               {(() => {
                 const message = errorMessage?.toString() || '';
@@ -620,14 +516,11 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
                 return parts.map((part, index) => {
                   if (part === '**TIP_ICON**') {
                     return (
-                      <InfoIcon
+                      <InfoTooltip
                         key={index}
-                        sx={{
-                          fontSize: '16px',
-                          verticalAlign: 'text-bottom',
-                          marginRight: '4px',
-                          color: theme.palette.info.main,
-                        }}
+                        infoTooltip={{ icon: styles.infoIcon }}
+                        disableTooltip
+                        sx={styles.infoTooltip}
                       />
                     );
                   } else if (part.startsWith('**') && part.endsWith('**')) {
@@ -637,14 +530,7 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
                         key={index}
                         component="span"
                         variant="labelMedium"
-                        sx={{
-                          fontWeight: 'bold',
-                          backgroundColor:
-                            theme.palette.background.errorCodeHighlight || theme.palette.action.hover,
-                          padding: '2px 4px',
-                          borderRadius: '4px',
-                          fontFamily: 'monospace',
-                        }}
+                        sx={styles.boldErrorText}
                       >
                         {boldText}
                       </Typography>
@@ -656,31 +542,171 @@ const MermaidDiagramOutput = ({ code, onQuickFix, isQuickFixLoading = false, qui
             </Typography>
           </Box>
         )}
-        <div
+        <Box
+          component="div"
           id={diagramId}
           className={`mermaid ${errorMessage ? 'mermaid-error' : ''}`}
-          style={{
-            width: '100% !important',
-            height: '100% !important',
-            marginTop: '0px',
-            padding: '4px',
-            ...(errorMessage
-              ? {
-                  maxWidth: WIDTHS.errorContainer,
-                  maxHeight: HEIGHTS.errorContainer,
-                  display: 'flex',
-                  justifyContent: 'flex-start',
-                  alignItems: 'flex-start',
-                  textAlign: 'left',
-                  margin: '0',
-                  marginTop: '8px',
-                }
-              : {}),
-          }}
-        />
+          sx={styles.mermaid}
+        ></Box>
       </Box>
     </Box>
   );
-};
+});
+
+MermaidDiagramOutput.displayName = 'MermaidDiagramOutput';
+
+const mermaidDiagramOutputStyles = (theme, isValidCode, errorMessage, widthsValue, heightsValue) => ({
+  container: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    padding: 0,
+    gap: '0.75rem',
+    height: '100%',
+    boxSizing: 'border-box',
+    position: 'relative',
+  },
+  toolbar: {
+    display: 'flex',
+    flexDirection: 'row',
+    height: 'auto',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    position: 'absolute',
+    top: '0.75rem',
+    right: '0.75rem',
+    gap: '0.5rem',
+  },
+  quickFixButton: ({ palette }) => ({
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    justifyContent: 'center',
+    height: '1.75rem',
+    paddingLeft: '0.75rem',
+    paddingRight: '0.75rem',
+    color: palette.split.text.default,
+    background: palette.split.default,
+    borderRadius: '1.5rem',
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      background: palette.split.hover,
+    },
+    '&:active': {
+      color: palette.split.text.pressed,
+      backgroundColor: palette.split.pressed,
+    },
+    '&:disabled': {
+      color: palette.split.text.disabled,
+      backgroundColor: palette.split.disabled,
+    },
+  }),
+  quickFixIconWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: ({ palette }) => palette.text.createButton,
+  },
+  quickFixText: ({ typography }) => ({
+    color: 'inherit',
+    fontFamily: typography.fontFamily,
+    fontFeatureSettings: typography.fontFeatureSettings,
+  }),
+  downloadIcon: {
+    fontSize: '1rem',
+    marginTop: '-0.0625rem',
+    fill: isValidCode ? theme.palette.icon.fill.default : theme.palette.icon.fill.disabled,
+  },
+  zoomControls: ({ palette }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    height: 'auto',
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
+    position: 'absolute',
+    bottom: '0.75rem',
+    left: '0.75rem',
+    borderRadius: '0.125rem',
+    border: `0.0625rem solid ${palette.border.lines}`,
+  }),
+  zoomButton: ({ palette }) => ({
+    marginLeft: 0,
+    borderRadius: 0,
+    borderBottom: `0.0625rem solid ${palette.border.lines}`,
+  }),
+  zoomButtonLast: {
+    marginLeft: 0,
+    borderRadius: 0,
+  },
+  zoomIcon: {
+    fontSize: '1rem',
+    fill: theme.palette.icon.fill.default,
+  },
+  fullscreenIcon: {
+    fontSize: '1rem',
+    fill: theme.palette.icon.fill.secondary,
+  },
+  diagramContainer: ({ palette }) => ({
+    height: '100%',
+    width: '100%',
+    maxWidth: '100%',
+    border: `0.0625rem solid ${palette.border.lines}`,
+    borderRadius: '0.5rem',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    boxSizing: 'border-box',
+    overflow: 'scroll',
+    backgroundColor: palette.background.default,
+  }),
+  errorMessageBox: {
+    width: '100%',
+    marginTop: '0.5rem',
+    marginBottom: '0.5rem',
+    padding: '0.5rem',
+    flexWrap: 'wrap',
+  },
+  errorText: {
+    whiteSpace: 'pre-wrap',
+    lineHeight: 1.2,
+  },
+  infoIcon: {
+    fill: theme.palette.info.main,
+  },
+  infoTooltip: {
+    display: 'inline-flex',
+    verticalAlign: 'text-bottom',
+    marginRight: '0.25rem',
+    position: 'static',
+    bottom: 0,
+  },
+  boldErrorText: ({ palette }) => ({
+    fontWeight: 'bold',
+    backgroundColor: palette.background.errorCodeHighlight || palette.action.hover,
+    padding: '0.125rem 0.25rem',
+    borderRadius: '0.25rem',
+    fontFamily: 'monospace',
+  }),
+  mermaid: {
+    width: '100% !important',
+    height: '100% !important',
+    marginTop: 0,
+    padding: '0.25rem',
+    ...(errorMessage
+      ? {
+          maxWidth: widthsValue.errorContainer,
+          maxHeight: heightsValue.errorContainer,
+          display: 'flex',
+          justifyContent: 'flex-start',
+          alignItems: 'flex-start',
+          textAlign: 'left',
+          margin: 0,
+          marginTop: '0.5rem',
+        }
+      : {}),
+  },
+});
 
 export default MermaidDiagramOutput;

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -1,111 +1,111 @@
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 
 import { Box, FormControlLabel, RadioGroup, Typography, useTheme } from '@mui/material';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
 import { Checkbox } from '@/[fsd]/shared/ui';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
-import InfoIcon from './Icons/InfoIcon';
-
-export default function RadioButtonGroup({
-  value,
-  defaultValue,
-  onChange,
-  items,
-  wrapRow = false,
-  columnGap,
-  disabled,
-}) {
-  const theme = useTheme();
-  const onChangeHandler = useCallback(
-    event => {
-      onChange(event.target.value);
-    },
-    [onChange],
-  );
-  return (
-    <RadioGroup
-      aria-labelledby="radio-buttons-group-label"
-      defaultValue={defaultValue}
-      name="radio-buttons-group"
-      value={value}
-      onChange={onChangeHandler}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          rowGap: '0px',
-          columnGap: columnGap || '24px',
-          flexWrap: wrapRow ? 'wrap' : 'nowrap',
-        }}
+const RadioButtonGroup = memo(
+  ({ value, defaultValue, onChange, items, wrapRow = false, columnGap, disabled }) => {
+    const theme = useTheme();
+    const styles = radioButtonGroupStyles(theme, wrapRow, columnGap);
+    const onChangeHandler = useCallback(
+      event => {
+        onChange(event.target.value);
+      },
+      [onChange],
+    );
+    return (
+      <RadioGroup
+        aria-labelledby="radio-buttons-group-label"
+        defaultValue={defaultValue}
+        name="radio-buttons-group"
+        value={value}
+        onChange={onChangeHandler}
       >
-        {items.map(item => (
-          <Box
-            key={item.value}
-            display="flex"
-            flexDirection="column"
-          >
-            <FormControlLabel
-              sx={{
-                alignItems: 'flex-start',
-                mb: '8px',
-              }}
-              value={item.value}
-              control={
-                <Checkbox.BaseCheckbox
-                  mode="radio"
-                  disabled={item.disabled || disabled}
-                />
-              }
-              label={
-                <Box sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '10px' }}>
-                  <Typography
-                    component="div"
-                    variant="bodyMedium"
-                    color={theme.palette.text.secondary}
-                    sx={{ mt: '7px' }}
-                  >
-                    {item.label}
-                  </Typography>
-                  {item.description && (
+        <Box sx={styles.container}>
+          {items.map(item => (
+            <Box
+              key={item.value}
+              sx={styles.itemContainer}
+            >
+              <FormControlLabel
+                sx={styles.formControlLabel}
+                value={item.value}
+                control={
+                  <Checkbox.BaseCheckbox
+                    mode="radio"
+                    disabled={item.disabled || disabled}
+                  />
+                }
+                label={
+                  <Box sx={styles.labelContainer}>
                     <Typography
                       component="div"
-                      variant="bodySmall"
+                      variant="bodyMedium"
+                      sx={styles.typographyLabel}
                     >
-                      {item.description}
+                      {item.label}
                     </Typography>
-                  )}
-                  {item.info && (
-                    <Tooltip
-                      title={item.info}
-                      placement="top"
-                    >
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          justifyContent: 'center',
-                          height: '100%',
-                          width: '12px',
-                          pt: '9px',
-                        }}
+                    {item.description && (
+                      <Typography
+                        component="div"
+                        variant="bodySmall"
                       >
-                        <InfoIcon
-                          width={12}
-                          height={12}
-                          fill={theme.palette.icon.main}
-                        />
-                      </Box>
-                    </Tooltip>
-                  )}
-                </Box>
-              }
-            />
-          </Box>
-        ))}
-      </Box>
-    </RadioGroup>
-  );
-}
+                        {item.description}
+                      </Typography>
+                    )}
+                    {item.info && (
+                      <InfoTooltip
+                        infoTooltip={{
+                          title: item.info,
+                          icon: styles.infoIcon,
+                        }}
+                      />
+                    )}
+                  </Box>
+                }
+              />
+            </Box>
+          ))}
+        </Box>
+      </RadioGroup>
+    );
+  },
+);
+
+const radioButtonGroupStyles = (theme, wrapRow, columnGap) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    rowGap: '0',
+    columnGap: columnGap || '1.5rem',
+    flexWrap: wrapRow ? 'wrap' : 'nowrap',
+  },
+  itemContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  formControlLabel: {
+    alignItems: 'flex-start',
+    mb: '0.5rem',
+  },
+  labelContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: '0.625rem',
+  },
+  typographyLabel: ({ palette }) => ({
+    color: palette.text.secondary,
+    mt: '0.4375rem',
+  }),
+  infoIcon: {
+    fill: theme.palette.icon.main,
+  },
+});
+
+RadioButtonGroup.displayName = 'RadioButtonGroup';
+
+export default RadioButtonGroup;

--- a/src/components/SecretManagementInput.jsx
+++ b/src/components/SecretManagementInput.jsx
@@ -1,13 +1,12 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Visibility, VisibilityOff } from '@mui/icons-material';
-import { Box, InputAdornment, TextField, Tooltip } from '@mui/material';
+import { Box, InputAdornment, TextField } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
-import { TooltipMarkdownContent } from '@/[fsd]/shared/ui/tooltip';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { useSecretsListQuery } from '@/api/secrets.js';
-import InfoIcon from '@/components/Icons/InfoIcon';
 import Toggle from '@/components/Toggle.jsx';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
@@ -193,17 +192,10 @@ export const SecretField = memo(props => {
                 {label}
                 {required ? ' *' : ''}
               </Box>
-              <Tooltip title={<TooltipMarkdownContent>{tooltipDescription}</TooltipMarkdownContent>}>
-                <Box
-                  component="span"
-                  sx={styles.tooltipIconInLabel}
-                >
-                  <InfoIcon
-                    width={16}
-                    height={16}
-                  />
-                </Box>
-              </Tooltip>
+              <InfoTooltip
+                infoTooltip={tooltipDescription}
+                sx={styles.infoIconWrapper}
+              />
             </Box>
           )}
           <TextField

--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -8,8 +8,7 @@ import Slider from '@mui/material/Slider';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 
-import Tooltip from '@/ComponentsLib/Tooltip';
-import InfoIcon from '@/components/Icons/InfoIcon';
+import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 
 const Input = styled(MuiInput)(
   ({ theme }) => `
@@ -121,28 +120,7 @@ export default function InputSlider({
           >
             <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
           </Typography>
-
-          <Tooltip
-            title={labelHint}
-            placement="top"
-          >
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                height: '100%',
-                width: '16px',
-                cursor: 'pointer',
-                pointerEvents: 'auto',
-              }}
-            >
-              <InfoIcon
-                width={16}
-                height={16}
-              />
-            </Box>
-          </Tooltip>
+          <InfoTooltip infoTooltip={labelHint} />
         </Box>
       ) : (
         <Typography


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4901

## Summary

| Where | What | Why |
|-------|------|-----|
| InfoTooltip.jsx (new) | Created reusable `InfoTooltip` component with `data-info-tooltip` attribute | **Main fix:** Extract repeated Tooltip+Box+InfoIcon pattern into single component |
| textFieldVariants.js:90-112 | Added `:has([data-info-tooltip])` CSS rules for InputLabel overflow/maxWidth | Fix icon clipping in MUI TextField labels (theme variants > slotProps specificity) |
| InputBase.jsx:274-278 | Added `!important` for overflow/maxWidth on needsLabelUnclip | Override theme styles when label contains InfoTooltip |
| SingleSelect.jsx | Refactored to use InfoTooltip, moved inline sx to singleSelectStyles function | Consistent pattern, cleaner code |
| InfoLabelWithTooltip.jsx | Simplified to use InfoTooltip internally | Remove duplicate tooltip logic |
| CommonStringField.jsx | Replaced FormInput with Input.StyledInputEnhancer | Fix `fieldName` prop DOM warning (StyledInputEnhancer supports it) |
| 22 other files | Replaced inline Tooltip+Box+InfoIcon with InfoTooltip | Consistent pattern across codebase |

**Root cause:** Tooltip with info icon pattern was duplicated across 28 files with inconsistent implementations. Icon clipping occurred because MUI theme variants have higher CSS specificity than component slotProps. Created centralized InfoTooltip component with `data-info-tooltip` attribute for theme-level CSS targeting.

<img width="904" height="286" alt="Screenshot 2026-05-15 152531" src="https://github.com/user-attachments/assets/45f513da-f9c0-401f-af44-f79ff84e3726" />
<img width="207" height="865" alt="Screenshot 2026-05-15 152549" src="https://github.com/user-attachments/assets/6f55ba06-8ea8-4071-a5d2-a273ddfae2a5" />
