### PR TITLE
fix: [EL-4644] Add per-conversation LLM override for published agents

### DIFF
--- a/src/[fsd]/widgets/LLMModelSelector/ui/LLMModelSelector.jsx
+++ b/src/[fsd]/widgets/LLMModelSelector/ui/LLMModelSelector.jsx
@@ -27,6 +27,7 @@ const LLMModelSelector = memo(props => {
     showSettingsEntry = true,
     modelTooltip = 'Select LLM Model',
     settingsTooltip = 'Model Settings',
+    onResetToDefaults,
   } = props;
 
   const theme = useTheme();
@@ -175,6 +176,7 @@ const LLMModelSelector = memo(props => {
           llmSettings={llmSettings}
           showWebhookSecret={showWebhookSecret}
           showStepsLimit={showStepsLimit}
+          onResetToDefaults={onResetToDefaults}
         />
       )}
     </>

--- a/src/[fsd]/widgets/LLMModelSelector/ui/LLMSettingsDialog.jsx
+++ b/src/[fsd]/widgets/LLMModelSelector/ui/LLMSettingsDialog.jsx
@@ -16,6 +16,7 @@ const LLMSettingsDialog = memo(props => {
     onCancel,
     showWebhookSecret = false,
     showStepsLimit = false,
+    onResetToDefaults,
   } = props;
 
   const [localSettings, setLocalSettings] = useState(llmSettings);
@@ -58,6 +59,20 @@ const LLMSettingsDialog = memo(props => {
       }
       actions={
         <>
+          {onResetToDefaults && (
+            <Button
+              variant="elitea"
+              color="secondary"
+              onClick={() => {
+                onResetToDefaults();
+                onCancel();
+              }}
+              disableRipple
+              sx={{ marginRight: 'auto' }}
+            >
+              Reset to defaults
+            </Button>
+          )}
           <Button
             variant="elitea"
             color="secondary"

--- a/src/hooks/chat/useEditAgent.js
+++ b/src/hooks/chat/useEditAgent.js
@@ -20,6 +20,22 @@ const useEditAgent = ({ activeParticipant, setActiveParticipant, onChangePartici
   // Store whether we're in create mode
   const [isCreateMode, setIsCreateMode] = useState(false);
 
+  // Keep editingAgent in sync with activeParticipant while the editor is open.
+  // This ensures changes persisted via onChangeParticipantSettings (e.g. LLM override resets)
+  // are reflected in the editor without requiring a page refresh.
+  useEffect(() => {
+    if (
+      isEditingAgent &&
+      !isCreateMode &&
+      editingAgent &&
+      activeParticipant &&
+      editingAgent.id === activeParticipant.id
+    ) {
+      setEditingAgent(activeParticipant);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeParticipant, isEditingAgent, isCreateMode, editingAgent?.id]);
+
   /**
    * Show the agent editor for a participant
    */

--- a/src/pages/NewChat/AgentEditor.jsx
+++ b/src/pages/NewChat/AgentEditor.jsx
@@ -38,6 +38,8 @@ const AgentEditorContent = memo(props => {
     isPublic,
     onConversationStartersChange,
     entityProjectId,
+    // When provided, public-agent model changes save to entity_settings (per-conversation override)
+    onPublicLlmOverride,
   } = props;
   const { setFieldValue } = useFormikContext();
 
@@ -55,6 +57,9 @@ const AgentEditorContent = memo(props => {
     [setFieldValue],
   );
 
+  // Model selector is enabled when user can edit the agent OR when a conversation override is available
+  const canEditModel = canEditIt || !!onPublicLlmOverride;
+
   return (
     <>
       <ApplicationValidator
@@ -67,9 +72,14 @@ const AgentEditorContent = memo(props => {
           <LLMModelSelectorWrapper
             projectId={projectId}
             onLLMSettingsChange={onLLMSettingsChange}
-            disabled={!canEditIt}
-            modelTooltip={isPublic ? 'Model configuration is locked for Public agents' : undefined}
-            settingsTooltip={isPublic ? 'Model settings are locked for Public agents' : undefined}
+            disabled={!canEditModel}
+            modelTooltip={
+              isPublic && !onPublicLlmOverride ? 'Model configuration is locked for Public agents' : undefined
+            }
+            settingsTooltip={
+              isPublic && !onPublicLlmOverride ? 'Model settings are locked for Public agents' : undefined
+            }
+            onPublicLlmOverride={onPublicLlmOverride}
           />
         )}
         {isCreateMode ? (
@@ -103,6 +113,8 @@ const AgentEditor = memo(
     onAttachmentToolChange,
     onAgentDirtyStateChange,
     onConversationStartersChange,
+    // Callback to save per-conversation LLM override for published public agents
+    onConversationLlmOverride,
   }) => {
     const trackEvent = useTrackEvent();
 
@@ -182,13 +194,20 @@ const AgentEditor = memo(
         if (isValidVersion) {
           // Valid version details - use them for form initialization
           const applicationName = agent?.meta?.name || agent?.name || '';
+          // For public agents, display any per-conversation LLM override in the model selector
+          const entityLlmOverride = isPublishedAgent ? (agent?.entity_settings?.llm_settings ?? null) : null;
 
           if (versionDetails.version_details) {
+            const baseLlmSettings = versionDetails.version_details.llm_settings;
             return {
               ...versionDetails,
               id: agentId,
               name: applicationName,
-              llm_settings: versionDetails.version_details.llm_settings,
+              llm_settings: entityLlmOverride || baseLlmSettings,
+              version_details: {
+                ...versionDetails.version_details,
+                llm_settings: entityLlmOverride || baseLlmSettings,
+              },
             };
           }
 
@@ -198,7 +217,7 @@ const AgentEditor = memo(
             name: applicationName,
             version_details: {
               ...versionDetails,
-              llm_settings: versionDetails.llm_settings,
+              llm_settings: entityLlmOverride || versionDetails.llm_settings,
             },
           };
         }
@@ -233,7 +252,16 @@ const AgentEditor = memo(
       }
 
       return {};
-    }, [isCreateMode, versionDetails, agent, agentId, createInitialValues, versionId, projectId]);
+    }, [
+      isCreateMode,
+      versionDetails,
+      agent,
+      agentId,
+      createInitialValues,
+      versionId,
+      projectId,
+      isPublishedAgent,
+    ]);
 
     const handleDiscard = useCallback(() => {
       // Reset the form to initial values
@@ -313,6 +341,9 @@ const AgentEditor = memo(
             isPublic={isPublic}
             onConversationStartersChange={onConversationStartersChange}
             entityProjectId={agent?.entity_meta?.project_id}
+            onPublicLlmOverride={
+              isPublic && onConversationLlmOverride ? onConversationLlmOverride : undefined
+            }
           />
         </BaseEditor>
       </InstructionsInputRefProvider>

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -268,7 +268,7 @@ const NewChat = props => {
     llmSettings => {
       if (!editingAgent) return;
       const updatedParticipant = {
-        ...(editingAgent || {}),
+        ...editingAgent,
         entity_settings: {
           ...(editingAgent.entity_settings || {}),
           llm_settings: llmSettings ?? undefined,

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -263,6 +263,22 @@ const NewChat = props => {
     onCloseAgentEditor();
   }, [markAgentEditorClosed, onCloseAgentEditor, resetEditorConversationStarters]);
 
+  // Save per-conversation LLM override for a published public agent from the AgentEditor panel
+  const handleConversationLlmOverride = useCallback(
+    llmSettings => {
+      if (!editingAgent) return;
+      const updatedParticipant = {
+        ...(editingAgent || {}),
+        entity_settings: {
+          ...(editingAgent.entity_settings || {}),
+          llm_settings: llmSettings ?? undefined,
+        },
+      };
+      onChangeParticipantSettings(updatedParticipant, true);
+    },
+    [editingAgent, onChangeParticipantSettings],
+  );
+
   // Wrap onClosePipelineEditor to mark explicit close
   const handleClosePipelineEditor = useCallback(() => {
     markPipelineEditorClosed();
@@ -1425,6 +1441,7 @@ const NewChat = props => {
                 isCreateMode={isCreateMode}
                 onAgentDirtyStateChange={handleEditorDirtyStateChange}
                 onConversationStartersChange={handleEditorConversationStartersChange}
+                onConversationLlmOverride={handleConversationLlmOverride}
                 activeAgentId={
                   activeParticipant?.entity_name === ChatParticipantType.Applications
                     ? activeParticipant.entity_meta?.id

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -60,10 +60,6 @@ const NewChatInput = forwardRef((props, ref) => {
     // New prop to indicate if we're on agents page
     isAgentsPage = false,
 
-    // Published agent from public project (agent studio) — allows per-conversation LLM override
-    isPublishedPublicAgent = false,
-    onResetLLMSettings,
-
     // LLM Settings props for modal dialog
     llmSettings = {},
     onSetLLMSettings,
@@ -286,7 +282,7 @@ const NewChatInput = forwardRef((props, ref) => {
                     onRefreshParticipantDetails={onRefreshParticipantDetails}
                   />
                 )}
-              {(isAgentsPage || isPublishedPublicAgent || !activeParticipant) && (
+              {(isAgentsPage || !activeParticipant) && (
                 <LLMModelSelector
                   selectedModel={selectedModel}
                   onSelectModel={onSelectModel}
@@ -296,10 +292,9 @@ const NewChatInput = forwardRef((props, ref) => {
                   onSetLLMSettings={onSetLLMSettings}
                   showWebhookSecret={showWebhookSecret}
                   showStepsLimit={showStepsLimit}
-                  onResetToDefaults={isPublishedPublicAgent ? onResetLLMSettings : undefined}
                 />
               )}
-              {!isAgentsPage && !isPublishedPublicAgent && activeParticipant && (
+              {!isAgentsPage && activeParticipant && (
                 <Tooltip title="Switch to model">
                   <Box component="span">
                     <IconButton

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -60,6 +60,10 @@ const NewChatInput = forwardRef((props, ref) => {
     // New prop to indicate if we're on agents page
     isAgentsPage = false,
 
+    // Published agent from public project (agent studio) — allows per-conversation LLM override
+    isPublishedPublicAgent = false,
+    onResetLLMSettings,
+
     // LLM Settings props for modal dialog
     llmSettings = {},
     onSetLLMSettings,
@@ -282,7 +286,7 @@ const NewChatInput = forwardRef((props, ref) => {
                     onRefreshParticipantDetails={onRefreshParticipantDetails}
                   />
                 )}
-              {(isAgentsPage || !activeParticipant) && (
+              {(isAgentsPage || isPublishedPublicAgent || !activeParticipant) && (
                 <LLMModelSelector
                   selectedModel={selectedModel}
                   onSelectModel={onSelectModel}
@@ -292,9 +296,10 @@ const NewChatInput = forwardRef((props, ref) => {
                   onSetLLMSettings={onSetLLMSettings}
                   showWebhookSecret={showWebhookSecret}
                   showStepsLimit={showStepsLimit}
+                  onResetToDefaults={isPublishedPublicAgent ? onResetLLMSettings : undefined}
                 />
               )}
-              {!isAgentsPage && activeParticipant && (
+              {!isAgentsPage && !isPublishedPublicAgent && activeParticipant && (
                 <Tooltip title="Switch to model">
                   <Box component="span">
                     <IconButton

--- a/src/pages/NewChat/components/LLMModelSelectorWrapper.jsx
+++ b/src/pages/NewChat/components/LLMModelSelectorWrapper.jsx
@@ -19,6 +19,8 @@ const LLMModelSelectorWrapper = ({
   disabled,
   modelTooltip,
   settingsTooltip,
+  // When provided (for public agents), model changes save to entity_settings instead of agent version
+  onPublicLlmOverride,
 }) => {
   const {
     values: { version_details = {} },
@@ -74,19 +76,19 @@ const LLMModelSelectorWrapper = ({
       };
       setFieldValue('version_details.llm_settings', newSettings);
       onLLMSettingsChange?.(pev => ({ ...pev, ...newSettings }));
+      onPublicLlmOverride?.(newSettings);
     },
-    [onLLMSettingsChange, setFieldValue, version_details?.llm_settings],
+    [onLLMSettingsChange, onPublicLlmOverride, setFieldValue, version_details?.llm_settings],
   );
 
   const handleSetLLMSettings = useCallback(
     settings => {
       onLLMSettingsChange?.(prev => ({ ...prev, ...settings }));
-      setFieldValue('version_details.llm_settings', {
-        ...version_details?.llm_settings,
-        ...settings,
-      });
+      const fullSettings = { ...version_details?.llm_settings, ...settings };
+      setFieldValue('version_details.llm_settings', fullSettings);
+      onPublicLlmOverride?.(fullSettings);
     },
-    [onLLMSettingsChange, setFieldValue, version_details?.llm_settings],
+    [onLLMSettingsChange, onPublicLlmOverride, setFieldValue, version_details?.llm_settings],
   );
 
   if (!modelList.length) return <Box sx={{ p: 2 }}>Loading models...</Box>;
@@ -102,6 +104,7 @@ const LLMModelSelectorWrapper = ({
         disabled={isDisabled}
         modelTooltip={modelTooltip}
         settingsTooltip={settingsTooltip}
+        onResetToDefaults={onPublicLlmOverride ? () => onPublicLlmOverride(null) : undefined}
       />
     </Box>
   );


### PR DESCRIPTION
Implement per-conversation LLM settings override for published public agents. The UI reset button now correctly updates the model name display immediately after reset by syncing editingAgent from activeParticipant via useEffect. LLM model selector and agent editor updated to support saving and resetting per-conversation llm_settings overrides for public published participants. Connected issue: https://github.com/EliteaAI/elitea_issues/issues/4644