### PR TITLE
fix(toolkit-chat):[EL-4915] display error and debug info separately

### DIFF
--- a/src/[fsd]/features/toolkits/indexes/lib/helpers/indexChat.helpers.js
+++ b/src/[fsd]/features/toolkits/indexes/lib/helpers/indexChat.helpers.js
@@ -196,6 +196,10 @@ export const generateChatMessageBasedOnResponse = ({ message, chatHistory, onFin
             toolAction.execution_time_seconds = (endTime - startTime) / 1000;
           }
         }
+
+        if (response_metadata?.finish_reason === 'error') {
+          msg.content = convertJsonToString(message?.content ?? '');
+        }
       }
 
       return updatedHistory;
@@ -278,8 +282,6 @@ export const generateChatMessageBasedOnResponse = ({ message, chatHistory, onFin
         msg.isLoading = false;
         msg.isStreaming = false;
         msg.exception = message.content;
-        // Update visible content to show error message instead of "Testing tool..."
-        msg.content = convertJsonToString(message.content);
 
         onFinish(IndexStatuses.fail);
       } else {


### PR DESCRIPTION
Separate human friendly error message from debug  trace. Previous fix #160 resolved stuck "Testing tool..." message, but introduced regression  how error messages are displayed

Connected to: https://github.com/EliteaAI/elitea_issues/issues/4915