### PR TITLE
fix: [EL-4932] page crash when opening agent detail with non-string conversation_starters values

### DIFF
--- a/src/[fsd]/features/agent/lib/helpers/conversationStarters.helpers.js
+++ b/src/[fsd]/features/agent/lib/helpers/conversationStarters.helpers.js
@@ -1,1 +1,1 @@
-export const convertStarterToString = value => (value === null || value === undefined ? '' : String(value));
+export const toString = value => (value === null || value === undefined ? '' : String(value));

--- a/src/[fsd]/features/agent/lib/helpers/conversationStarters.helpers.js
+++ b/src/[fsd]/features/agent/lib/helpers/conversationStarters.helpers.js
@@ -1,0 +1,1 @@
+export const convertStarterToString = value => (value === null || value === undefined ? '' : String(value));

--- a/src/[fsd]/features/agent/lib/helpers/index.js
+++ b/src/[fsd]/features/agent/lib/helpers/index.js
@@ -1,1 +1,2 @@
 export * as ParseYamlToMermaidHelpers from './parseYamlToMermaid.helpers';
+export * as conversationStartersHelpers from './conversationStarters.helpers';

--- a/src/[fsd]/features/agents-studio/ui/AgentConversationStarters.jsx
+++ b/src/[fsd]/features/agents-studio/ui/AgentConversationStarters.jsx
@@ -11,9 +11,7 @@ const AgentConversationStarters = memo(props => {
 
   const filteredStarters = useMemo(
     () =>
-      conversation_starters?.filter(starter =>
-        conversationStartersHelpers.convertStarterToString(starter).trim(),
-      ) || [],
+      conversation_starters?.filter(starter => conversationStartersHelpers.toString(starter).trim()) || [],
     [conversation_starters],
   );
 

--- a/src/[fsd]/features/agents-studio/ui/AgentConversationStarters.jsx
+++ b/src/[fsd]/features/agents-studio/ui/AgentConversationStarters.jsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
+import { conversationStartersHelpers } from '../../agent/lib/helpers';
 import AgentConversationStarterItem from './AgentConversationStarterItem';
 
 const AgentConversationStarters = memo(props => {
@@ -9,7 +10,10 @@ const AgentConversationStarters = memo(props => {
   const styles = agentConversationStartersStyles();
 
   const filteredStarters = useMemo(
-    () => conversation_starters?.filter(starter => starter?.trim()) || [],
+    () =>
+      conversation_starters?.filter(starter =>
+        conversationStartersHelpers.convertStarterToString(starter).trim(),
+      ) || [],
     [conversation_starters],
   );
 

--- a/src/components/ConversationStarters.jsx
+++ b/src/components/ConversationStarters.jsx
@@ -5,6 +5,7 @@ import { useFormikContext } from 'formik';
 import { Box, ListItem, Typography } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
+import { conversationStartersHelpers } from '@/[fsd]/features/agent/lib/helpers';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
 import { Input } from '@/[fsd]/shared/ui';
@@ -30,7 +31,8 @@ const ConversationStarters = memo(props => {
   const { toggleFieldFocus, isFocused } = useFieldFocus();
   const valuesPath = 'version_details.conversation_starters';
   const values = useMemo(
-    () => version_details?.conversation_starters || [],
+    () =>
+      (version_details?.conversation_starters || []).map(conversationStartersHelpers.convertStarterToString),
     [version_details?.conversation_starters],
   );
   const styles = conversationStartersStyles(values.length === 0);

--- a/src/components/ConversationStarters.jsx
+++ b/src/components/ConversationStarters.jsx
@@ -31,8 +31,7 @@ const ConversationStarters = memo(props => {
   const { toggleFieldFocus, isFocused } = useFieldFocus();
   const valuesPath = 'version_details.conversation_starters';
   const values = useMemo(
-    () =>
-      (version_details?.conversation_starters || []).map(conversationStartersHelpers.convertStarterToString),
+    () => (version_details?.conversation_starters || []).map(conversationStartersHelpers.toString),
     [version_details?.conversation_starters],
   );
   const styles = conversationStartersStyles(values.length === 0);

--- a/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
+++ b/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 
 import { Button } from '@mui/material';
 
+import { conversationStartersHelpers } from '@/[fsd]/features/agent/lib/helpers';
 import { useFormDirtyExcluding } from '@/[fsd]/shared/lib/hooks';
 import { StyledCircleProgress } from '@/components/Chat/StyledComponents';
 import useSaveVersion from '@/hooks/application/useSaveVersion';
@@ -35,7 +36,10 @@ export default function SaveApplicationButton({ onSuccess }) {
   }, [stateValidationErrors]);
 
   const hasEmptyStarters = useMemo(
-    () => (values?.version_details?.conversation_starters || []).some(s => !s?.trim()),
+    () =>
+      (values?.version_details?.conversation_starters || []).some(
+        s => !conversationStartersHelpers.convertStarterToString(s).trim(),
+      ),
     [values?.version_details?.conversation_starters],
   );
 

--- a/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
+++ b/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
@@ -38,7 +38,7 @@ export default function SaveApplicationButton({ onSuccess }) {
   const hasEmptyStarters = useMemo(
     () =>
       (values?.version_details?.conversation_starters || []).some(
-        s => !conversationStartersHelpers.convertStarterToString(s).trim(),
+        s => !conversationStartersHelpers.toString(s).trim(),
       ),
     [values?.version_details?.conversation_starters],
   );

--- a/src/pages/NewChat/ChatConversationStarters.jsx
+++ b/src/pages/NewChat/ChatConversationStarters.jsx
@@ -17,9 +17,7 @@ const ChatConversationStarters = memo(props => {
 
   const filteredStarters = useMemo(
     () =>
-      conversation_starters?.filter(starter =>
-        conversationStartersHelpers.convertStarterToString(starter).trim(),
-      ) || [],
+      conversation_starters?.filter(starter => conversationStartersHelpers.toString(starter).trim()) || [],
     [conversation_starters],
   );
 

--- a/src/pages/NewChat/ChatConversationStarters.jsx
+++ b/src/pages/NewChat/ChatConversationStarters.jsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { Box } from '@mui/material';
 
+import { conversationStartersHelpers } from '@/[fsd]/features/agent/lib/helpers';
 import { EllipsisTextWithTooltip } from '@/components/ConversationStarters';
 
 const ChatConversationStarters = memo(props => {
@@ -15,7 +16,10 @@ const ChatConversationStarters = memo(props => {
   );
 
   const filteredStarters = useMemo(
-    () => conversation_starters?.filter(item => item?.trim()) || [],
+    () =>
+      conversation_starters?.filter(starter =>
+        conversationStartersHelpers.convertStarterToString(starter).trim(),
+      ) || [],
     [conversation_starters],
   );
 


### PR DESCRIPTION
fix: [EL-4932] page crash when opening agent detail with non-string conversation_starters values