### PR TITLE
fix: [EL-0000] InfoTooltip icon was being clipped in some places

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -431,7 +431,9 @@ const ToolBaseProperty = memo(props => {
       return (
         <SingleSelect
           showBorder
-          label={description ? renderLabelWithHint(required) : label}
+          label={label}
+          infoIconDescription={description}
+          required={required}
           onValueChange={value => editField(buildEditFieldPath(k), value)}
           value={validValue}
           options={options}

--- a/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
+++ b/src/[fsd]/shared/ui/label/InfoLabelWithTooltip.jsx
@@ -60,6 +60,10 @@ const infoLabelWithTooltipStyles = iconSize => ({
     display: 'flex',
     alignItems: 'center',
     gap: '0.5rem',
+    height: '1.5rem',
+    '[data-shrink="true"] &': {
+      height: '1.5rem',
+    },
   },
   label: ({ palette }) => ({
     color: palette.text.primary,


### PR DESCRIPTION
## Summary

InfoTooltip icon was being clipped in some places (e.g., Api Version field in ToolBaseProperty).

| Where | What | Why |
|-------|------|-----|
| ToolBaseProperty.jsx:431-443 | Changed `SingleSelect` to use `infoIconDescription={description}` prop instead of `renderLabelWithHint()` | **Main fix:** InfoTooltip was clipped due to `overflow: hidden` on InputLabel |
| InfoLabelWithTooltip.jsx:59-66 | Added `height: '1.5rem'` and `'[data-shrink="true"] &'` selector to container | Additional fix: consistent height when component is inside shrunk MUI labels |

**Root cause:** `SingleSelect` has special styles for `InputLabel` that set `overflow: visible` only when `infoIconDescription` prop is provided. Using `renderLabelWithHint()` bypassed this logic, causing the tooltip icon to be clipped. Solution: use the native `infoIconDescription` prop like `EmbeddingModelSelect` does.

BEFORE
<img width="246" height="135" alt="Screenshot 2026-05-18 145207" src="https://github.com/user-attachments/assets/5f21a375-94a3-4fa4-9b3d-e3293080c94a" />

AFTER
<img width="254" height="147" alt="image" src="https://github.com/user-attachments/assets/ff5baaac-b25b-450f-b216-35aecad65083" />


