### PR TITLE
[EL-4889] Hide special projects from dropdown for non-admin users

### DIFF
--- a/src/api/project.js
+++ b/src/api/project.js
@@ -15,7 +15,7 @@ export const projectApi = eliteaApi
       projectList: build.query({
         query: () => {
           return {
-            url: '/projects/project/' + PROJECT_MODE + '/' + PUBLIC_PROJECT_ID,
+            url: '/projects/project/' + PROJECT_MODE + '/' + PUBLIC_PROJECT_ID + '?check_public_role=true',
             method: 'GET',
           };
         },


### PR DESCRIPTION
## Summary
- Add `check_public_role=true` parameter to project list API call
- Enables server-side filtering of special projects (Agent Studio, Support Assistant) from the project dropdown
- Users without admin role in these projects won't see them in the dropdown

## Related Issue
https://github.com/EliteaAI/elitea_issues/issues/4889

## Test plan
- [ ] Login as a user with viewer role in Support Assistant project
- [ ] Verify Support Assistant does NOT appear in project dropdown
- [ ] Login as a user with admin role in Support Assistant project  
- [ ] Verify Support Assistant DOES appear in project dropdown
- [ ] Same for Agent Studio (public project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)