### PR TITLE
feat: [EL-3396] Autosuggest Mention for Agents, Pipelines, Toolkits, MCPs, and Tools in Instructions

### DIFF
--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+import { useInstructionsSlashCommand } from './useInstructionsSlashCommand.hooks';
+
+/**
+ * Higher-level hook that wires the instructions slash-command state machine to
+ * actual textarea text manipulation via the FileReaderInput component ref.
+ *
+ * @param {React.RefObject} fileReaderRef - ref to the FileReaderInput component
+ *        (must expose getCursorPosition, replaceRange)
+ */
+export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] }) => {
+  // Track input content via ref to avoid per-keystroke re-renders.
+  const inputContentRef = useRef('');
+
+  const {
+    phase,
+    itemQuery,
+    toolQuery,
+    selectedItem,
+    onKeyDown,
+    syncWithValue,
+    selectItem,
+    commitMention: slashCommitMention,
+    resetSlash,
+    resetAll,
+    mentionAnchorRef,
+  } = useInstructionsSlashCommand();
+
+  // ── Text manipulation helpers ────────────────────────────────────────────────
+
+  /**
+   * Replace text in the textarea from anchor to cursorPos with replacement.
+   * Falls back to append if the ref is not available.
+   */
+  const replaceFragment = useCallback(
+    (replacement, endOverride) => {
+      const ref = fileReaderRef?.current;
+      if (!ref) return;
+
+      const content = ref.getInputContent?.() ?? inputContentRef.current;
+      const anchor = mentionAnchorRef.current ?? 0;
+      const end = endOverride ?? ref.getCursorPosition?.() ?? content.length;
+
+      ref.replaceRange?.(anchor, end, replacement);
+      inputContentRef.current = content.slice(0, anchor) + replacement + content.slice(end);
+    },
+    // mentionAnchorRef and inputContentRef are refs — stable, excluded from deps intentionally
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fileReaderRef],
+  );
+
+  // ── Input change handler ─────────────────────────────────────────────────────
+
+  const onInstructionsInputChange = useCallback(
+    value => {
+      inputContentRef.current = value;
+      if (!value) {
+        resetSlash();
+        return;
+      }
+      // Read cursor position from the input element synchronously during the event.
+      // Falls back to end-of-text so the existing end-of-text behavior is preserved.
+      // fileReaderRef is a ref — stable, excluded from deps intentionally.
+      const cursorPos = fileReaderRef?.current?.getCursorPosition?.() ?? value.length;
+      syncWithValue(value, cursorPos);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [syncWithValue, resetSlash],
+  );
+
+  // ── Item (agent / toolkit / pipeline) selection ──────────────────────────────
+
+  const onSelectItem = useCallback(
+    (item, isToolkit) => {
+      if (!isToolkit) {
+        // Agent or pipeline: replace fragment and commit.
+        const replacement = '/' + item.name + ' ';
+        replaceFragment(replacement);
+        selectItem(item, false);
+        return;
+      }
+      // Toolkit/MCP: replace fragment with "/name" (no trailing space yet) and
+      // advance to 'tools' phase.
+      const replacement = '/' + item.name;
+      replaceFragment(replacement);
+      selectItem(item, true);
+    },
+    [replaceFragment, selectItem],
+  );
+
+  // ── Tool selection ────────────────────────────────────────────────────────────
+
+  /**
+   * Called when the user picks a specific tool (or passes null to commit
+   * the whole toolkit without a specific tool).
+   */
+  const onSelectTool = useCallback(
+    toolName => {
+      if (toolName === null) {
+        // Dismissed — commit toolkit-only mention.
+        if (selectedItem) {
+          const ref = fileReaderRef?.current;
+          const content = ref?.getInputContent?.() ?? inputContentRef.current;
+          const anchor = mentionAnchorRef.current ?? 0;
+          // Find end of the toolkit name in text.
+          const nameEnd = anchor + ('/' + selectedItem.name).length;
+          const replacement = '/' + selectedItem.name + ' ';
+          ref?.replaceRange?.(anchor, nameEnd, replacement);
+          inputContentRef.current = content.slice(0, anchor) + replacement + content.slice(nameEnd);
+        }
+        slashCommitMention(null);
+        return;
+      }
+      // Commit with specific tool.
+      if (selectedItem) {
+        const ref = fileReaderRef?.current;
+        const content = ref?.getInputContent?.() ?? inputContentRef.current;
+        const anchor = mentionAnchorRef.current ?? 0;
+        // Locate the end of the toolkit prefix in text.
+        const toolkitPrefix = '/' + selectedItem.name + '#';
+        const prefixIdx = content.lastIndexOf(toolkitPrefix, anchor + toolkitPrefix.length + 50);
+        let end;
+        if (prefixIdx !== -1) {
+          const afterPrefix = content.slice(prefixIdx + toolkitPrefix.length);
+          const spaceIdx = afterPrefix.search(/[\s#]/);
+          end = prefixIdx + toolkitPrefix.length + (spaceIdx === -1 ? afterPrefix.length : spaceIdx);
+        } else {
+          // Fallback: no # separator yet — end after the name.
+          end = anchor + ('/' + selectedItem.name).length;
+        }
+        const replacement = '/' + selectedItem.name + '#' + toolName + ' ';
+        ref?.replaceRange?.(anchor, end, replacement);
+        inputContentRef.current = content.slice(0, anchor) + replacement + content.slice(end);
+      }
+      slashCommitMention(toolName);
+    },
+    // mentionAnchorRef and inputContentRef are refs — stable, excluded intentionally
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fileReaderRef, selectedItem, slashCommitMention],
+  );
+
+  // ── Available tools for the selected toolkit ──────────────────────────────────
+
+  // When re-entering tools phase via backspace, selectedItem only has { name }.
+  // Look up the full item (with settings/type) from mentionableItems.
+  const resolvedSelectedItem = useMemo(() => {
+    if (!selectedItem) return null;
+    if (selectedItem.settings !== undefined) return selectedItem;
+    return mentionableItems.find(item => item.name === selectedItem.name) ?? selectedItem;
+  }, [selectedItem, mentionableItems]);
+
+  const availableTools = useMemo(() => {
+    if (!resolvedSelectedItem?.settings) return [];
+    const isMcp = resolvedSelectedItem.type === 'mcp' || resolvedSelectedItem.type?.startsWith('mcp_');
+    if (isMcp) {
+      return (resolvedSelectedItem.settings.available_mcp_tools || []).map(item => ({
+        name: item.value || item.label,
+        description: item.description || '',
+      }));
+    }
+    return (resolvedSelectedItem.settings.selected_tools || []).map(name => ({
+      name,
+      description: '',
+    }));
+  }, [resolvedSelectedItem]);
+
+  const filteredTools = useMemo(
+    () =>
+      availableTools.filter(tool => !toolQuery || tool.name.toLowerCase().includes(toolQuery.toLowerCase())),
+    [availableTools, toolQuery],
+  );
+
+  return {
+    phase,
+    itemQuery,
+    toolQuery,
+    selectedItem: resolvedSelectedItem,
+    filteredTools,
+    onKeyDown,
+    onInstructionsInputChange,
+    onSelectItem,
+    onSelectTool,
+    resetSlash,
+    resetMentionState: resetAll,
+  };
+};

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
@@ -1,0 +1,346 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * State machine for "/" slash-mention in the agent instructions textarea.
+ *
+ * Phases:
+ *   'idle'  → no active mention
+ *   'items' → user typed "/" and is filtering agents/pipelines/toolkits/MCPs
+ *   'tools' → user selected a toolkit/MCP; filtering its specific tools
+ *
+ * committedMentions: [{name, tool_name}]
+ *   name      — agent/toolkit name (appears as /name in text)
+ *   tool_name — specific tool within a toolkit (null for agents/pipelines or
+ *               when the whole toolkit is mentioned)
+ *
+ * Token written to textarea:
+ *   agent/pipeline              → "/Name "
+ *   toolkit without specific tool → "/Name "
+ *   toolkit with specific tool  → "/Name#ToolName "
+ *
+ * mentionAnchorRef: character index of the leading "/" in the current mention.
+ */
+export const useInstructionsSlashCommand = () => {
+  const [phase, setPhase] = useState('idle'); // 'idle' | 'items' | 'tools'
+  const phaseRef = useRef('idle');
+
+  const [itemQuery, setItemQuery] = useState('');
+  const [toolQuery, setToolQuery] = useState('');
+  const [selectedItem, setSelectedItem] = useState(null); // toolkit/MCP being drilled into
+  const [committedMentions, setCommittedMentions] = useState([]);
+
+  const committedMentionsRef = useRef([]);
+
+  // Character index of the leading "/" that started this mention.
+  const mentionAnchorRef = useRef(null);
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  const resetSlash = useCallback(() => {
+    phaseRef.current = 'idle';
+    setPhase('idle');
+    setItemQuery('');
+    setToolQuery('');
+    setSelectedItem(null);
+    mentionAnchorRef.current = null;
+  }, []);
+
+  const resetAll = useCallback(() => {
+    phaseRef.current = 'idle';
+    setPhase('idle');
+    setItemQuery('');
+    setToolQuery('');
+    setSelectedItem(null);
+    mentionAnchorRef.current = null;
+    setCommittedMentions([]);
+    committedMentionsRef.current = [];
+  }, []);
+
+  const upsertMention = useCallback((name, tool_name = null) => {
+    setCommittedMentions(prev => {
+      const existing = prev.find(m => m.name === name);
+      const next = existing
+        ? prev.map(m => (m.name === name ? { name, tool_name } : m))
+        : [...prev, { name, tool_name }];
+      committedMentionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const uncommitByName = useCallback(name => {
+    setCommittedMentions(prev => {
+      const next = prev.filter(m => m.name !== name);
+      committedMentionsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  // ── Keyboard handler ─────────────────────────────────────────────────────────
+
+  /**
+   * Handle "/" and "Escape" before the textarea value updates.
+   * Everything else is handled in syncWithValue.
+   */
+  const onKeyDown = useCallback(
+    event => {
+      const { key } = event;
+      const current = phaseRef.current;
+
+      if (current === 'idle' && key === '/') {
+        phaseRef.current = 'items';
+        setPhase('items');
+        setItemQuery('');
+        // For a textarea, selectionStart is the position where '/' will be inserted.
+        // For CodeMirror the property is absent — anchor is set later in syncWithValue.
+        mentionAnchorRef.current = event.target?.selectionStart ?? null;
+        return;
+      }
+
+      if (key === 'Escape' && current !== 'idle') {
+        resetSlash();
+      }
+    },
+    [resetSlash],
+  );
+
+  // ── Sync ─────────────────────────────────────────────────────────────────────
+
+  /**
+   * Called on every input event with the current textarea text and cursor position.
+   * Keeps hook state in sync with what the user actually typed.
+   *
+   * cursorPos is the caret offset in `text`. All pattern matching is performed
+   * on textToCursor (= text.slice(0, cursorPos)) so that mid-text mentions work
+   * correctly — the user can type "/" at any cursor position, not just at the end.
+   *
+   * Regex patterns (matched at end of textToCursor):
+   *   fullMatch       → /name#toolQuery   (# separator for instructions)
+   *   itemOnlyMatch   → /name             (no # yet)
+   */
+  const syncWithValue = useCallback(
+    (text, cursorPos) => {
+      const pos = cursorPos ?? text.length;
+      const textToCursor = text.slice(0, pos);
+      const current = phaseRef.current;
+
+      if (current === 'idle') {
+        // Detect backspace into a committed mention.
+        const fullMatch = textToCursor.match(/\/([^#\s]+)#([^#\s]*)$/);
+        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^#\s]*)$/);
+
+        if (fullMatch) {
+          const name = fullMatch[1];
+          const committedMatch = committedMentionsRef.current.find(
+            m => m.name.toLowerCase() === name.toLowerCase(),
+          );
+          if (committedMatch) {
+            uncommitByName(committedMatch.name);
+            setSelectedItem({ name: committedMatch.name });
+            setItemQuery(fullMatch[1]);
+            setToolQuery(fullMatch[2]);
+            phaseRef.current = 'tools';
+            setPhase('tools');
+            if (mentionAnchorRef.current === null) {
+              mentionAnchorRef.current = pos - fullMatch[0].length;
+            }
+          }
+        } else if (itemOnlyMatch) {
+          const name = itemOnlyMatch[1];
+          if (name.length > 0) {
+            const committedMatch = committedMentionsRef.current.find(m =>
+              m.name.toLowerCase().startsWith(name.toLowerCase()),
+            );
+            if (committedMatch) {
+              uncommitByName(committedMatch.name);
+              setItemQuery(name);
+              phaseRef.current = 'items';
+              setPhase('items');
+              if (mentionAnchorRef.current === null) {
+                mentionAnchorRef.current = pos - itemOnlyMatch[0].length;
+              }
+            }
+          }
+        } else {
+          // Fallback for mention names that contain spaces (e.g. "Github mcp").
+          // Check if textToCursor ends with a prefix of any committed mention token.
+          for (const mention of committedMentionsRef.current) {
+            const fullToken = mention.tool_name
+              ? '/' + mention.name + '#' + mention.tool_name
+              : '/' + mention.name;
+            for (let len = fullToken.length; len >= 2; len--) {
+              const candidate = fullToken.slice(0, len);
+              if (!textToCursor.endsWith(candidate)) continue;
+              const prevCharIdx = textToCursor.length - candidate.length - 1;
+              const prevChar = prevCharIdx >= 0 ? textToCursor[prevCharIdx] : '';
+              if (prevChar !== '' && !/\s/.test(prevChar)) break;
+              const hashIdx = candidate.indexOf('#');
+              if (hashIdx !== -1) {
+                uncommitByName(mention.name);
+                setSelectedItem({ name: mention.name });
+                setItemQuery(mention.name);
+                setToolQuery(candidate.slice(hashIdx + 1));
+                phaseRef.current = 'tools';
+                setPhase('tools');
+                mentionAnchorRef.current = pos - candidate.length;
+              } else {
+                uncommitByName(mention.name);
+                setItemQuery(candidate.slice(1));
+                phaseRef.current = 'items';
+                setPhase('items');
+                mentionAnchorRef.current = pos - candidate.length;
+              }
+              return;
+            }
+          }
+        }
+        return;
+      }
+
+      if (current === 'items') {
+        // When anchor is set and still points to '/', extract the query as the text
+        // between the anchor and the cursor. This supports names with spaces.
+        if (mentionAnchorRef.current !== null && text[mentionAnchorRef.current] === '/') {
+          const afterAnchor = text.slice(mentionAnchorRef.current + 1, pos);
+          const hashIdx = afterAnchor.indexOf('#');
+          if (hashIdx !== -1) {
+            setItemQuery(afterAnchor.slice(0, hashIdx));
+            if (selectedItem) {
+              setToolQuery(afterAnchor.slice(hashIdx + 1));
+              phaseRef.current = 'tools';
+              setPhase('tools');
+            }
+          } else if (afterAnchor.endsWith(' ') || afterAnchor.includes('\n')) {
+            resetSlash();
+          } else {
+            setItemQuery(afterAnchor);
+          }
+          return;
+        }
+
+        const fullMatch = textToCursor.match(/\/([^#\s]+)#([^#\s]*)$/);
+        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^#\s]*)$/);
+
+        if (fullMatch) {
+          // User typed "#" — treat as a toolkit separator if we have a selected item.
+          setItemQuery(fullMatch[1]);
+          if (selectedItem) {
+            setToolQuery(fullMatch[2]);
+            phaseRef.current = 'tools';
+            setPhase('tools');
+          }
+        } else if (itemOnlyMatch) {
+          setItemQuery(itemOnlyMatch[1]);
+          if (mentionAnchorRef.current === null) {
+            mentionAnchorRef.current = pos - itemOnlyMatch[0].length;
+          }
+        } else {
+          resetSlash();
+        }
+        return;
+      }
+
+      if (current === 'tools') {
+        if (!selectedItem) {
+          resetSlash();
+          return;
+        }
+        const toolkitPrefix = '/' + selectedItem.name + '#';
+        const prefixIdx = textToCursor.lastIndexOf(toolkitPrefix);
+        if (prefixIdx !== -1) {
+          const toolQueryPart = textToCursor.slice(prefixIdx + toolkitPrefix.length);
+          if (/[\s#]/.test(toolQueryPart)) {
+            resetSlash();
+          } else {
+            setToolQuery(toolQueryPart);
+          }
+          return;
+        }
+        // Separator deleted — fall back to items phase.
+        const nameOnly = '/' + selectedItem.name;
+        const nameIdx = textToCursor.lastIndexOf(nameOnly);
+        if (nameIdx !== -1 && !/[\s#]/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
+          setItemQuery(selectedItem.name);
+          phaseRef.current = 'items';
+          setPhase('items');
+        } else {
+          // User may be backspacing into the name itself (e.g. "Github mcp" → "Github mc").
+          // Check if textToCursor ends with a prefix of the toolkit name.
+          let recovered = false;
+          for (let len = nameOnly.length - 1; len >= 2; len--) {
+            const candidate = nameOnly.slice(0, len);
+            if (!textToCursor.endsWith(candidate)) continue;
+            const prevCharIdx = textToCursor.length - candidate.length - 1;
+            const prevChar = prevCharIdx >= 0 ? textToCursor[prevCharIdx] : '';
+            if (prevChar !== '' && !/\s/.test(prevChar)) break;
+            uncommitByName(selectedItem.name);
+            setItemQuery(candidate.slice(1));
+            phaseRef.current = 'items';
+            setPhase('items');
+            mentionAnchorRef.current = pos - candidate.length;
+            recovered = true;
+            break;
+          }
+          if (!recovered) resetSlash();
+        }
+      }
+    },
+    [resetSlash, selectedItem, uncommitByName],
+  );
+
+  // ── Selection handlers ────────────────────────────────────────────────────────
+
+  /**
+   * Called when the user picks an item from the dropdown.
+   * For agents/pipelines: commit immediately and go idle.
+   * For toolkits/MCPs: advance to 'tools' phase.
+   *
+   * @param {object} item - { name, type, settings?, agent_type? }
+   * @param {boolean} isToolkit - true when item is a toolkit or MCP
+   */
+  const selectItem = useCallback(
+    (item, isToolkit) => {
+      if (!isToolkit) {
+        // Agent or pipeline — commit directly.
+        upsertMention(item.name, null);
+        resetSlash();
+        return;
+      }
+      // Toolkit or MCP — drill into tools phase.
+      setSelectedItem(item);
+      setItemQuery(item.name);
+      setToolQuery('');
+      upsertMention(item.name, null);
+      phaseRef.current = 'tools';
+      setPhase('tools');
+    },
+    [resetSlash, upsertMention],
+  );
+
+  /**
+   * Commits the current toolkit mention with an optional specific tool.
+   * toolName = null → whole toolkit is mentioned, no specific tool.
+   */
+  const commitMention = useCallback(
+    (toolName = null) => {
+      if (!selectedItem) return;
+      upsertMention(selectedItem.name, toolName || null);
+      resetSlash();
+    },
+    [selectedItem, upsertMention, resetSlash],
+  );
+
+  return {
+    phase,
+    itemQuery,
+    toolQuery,
+    selectedItem,
+    committedMentions,
+    onKeyDown,
+    syncWithValue,
+    selectItem,
+    commitMention,
+    resetSlash,
+    resetAll,
+    mentionAnchorRef,
+  };
+};

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
@@ -1,5 +1,9 @@
 import { useCallback, useRef, useState } from 'react';
 
+import { MentionConstants } from '@/[fsd]/shared/lib/constants';
+
+const { MentionPhase } = MentionConstants;
+
 /**
  * State machine for "/" slash-mention in the agent instructions textarea.
  *
@@ -21,8 +25,8 @@ import { useCallback, useRef, useState } from 'react';
  * mentionAnchorRef: character index of the leading "/" in the current mention.
  */
 export const useInstructionsSlashCommand = () => {
-  const [phase, setPhase] = useState('idle'); // 'idle' | 'items' | 'tools'
-  const phaseRef = useRef('idle');
+  const [phase, setPhase] = useState(MentionPhase.Idle);
+  const phaseRef = useRef(MentionPhase.Idle);
 
   const [itemQuery, setItemQuery] = useState('');
   const [toolQuery, setToolQuery] = useState('');
@@ -37,8 +41,8 @@ export const useInstructionsSlashCommand = () => {
   // ── Helpers ──────────────────────────────────────────────────────────────────
 
   const resetSlash = useCallback(() => {
-    phaseRef.current = 'idle';
-    setPhase('idle');
+    phaseRef.current = MentionPhase.Idle;
+    setPhase(MentionPhase.Idle);
     setItemQuery('');
     setToolQuery('');
     setSelectedItem(null);
@@ -46,8 +50,8 @@ export const useInstructionsSlashCommand = () => {
   }, []);
 
   const resetAll = useCallback(() => {
-    phaseRef.current = 'idle';
-    setPhase('idle');
+    phaseRef.current = MentionPhase.Idle;
+    setPhase(MentionPhase.Idle);
     setItemQuery('');
     setToolQuery('');
     setSelectedItem(null);
@@ -86,9 +90,9 @@ export const useInstructionsSlashCommand = () => {
       const { key } = event;
       const current = phaseRef.current;
 
-      if (current === 'idle' && key === '/') {
-        phaseRef.current = 'items';
-        setPhase('items');
+      if (current === MentionPhase.Idle && key === '/') {
+        phaseRef.current = MentionPhase.Items;
+        setPhase(MentionPhase.Items);
         setItemQuery('');
         // For a textarea, selectionStart is the position where '/' will be inserted.
         // For CodeMirror the property is absent — anchor is set later in syncWithValue.
@@ -96,7 +100,7 @@ export const useInstructionsSlashCommand = () => {
         return;
       }
 
-      if (key === 'Escape' && current !== 'idle') {
+      if (key === 'Escape' && current !== MentionPhase.Idle) {
         resetSlash();
       }
     },
@@ -123,7 +127,7 @@ export const useInstructionsSlashCommand = () => {
       const textToCursor = text.slice(0, pos);
       const current = phaseRef.current;
 
-      if (current === 'idle') {
+      if (current === MentionPhase.Idle) {
         // Detect backspace into a committed mention.
         const fullMatch = textToCursor.match(/\/([^#\s]+)#([^#\s]*)$/);
         const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^#\s]*)$/);
@@ -138,8 +142,8 @@ export const useInstructionsSlashCommand = () => {
             setSelectedItem({ name: committedMatch.name });
             setItemQuery(fullMatch[1]);
             setToolQuery(fullMatch[2]);
-            phaseRef.current = 'tools';
-            setPhase('tools');
+            phaseRef.current = MentionPhase.Tools;
+            setPhase(MentionPhase.Tools);
             if (mentionAnchorRef.current === null) {
               mentionAnchorRef.current = pos - fullMatch[0].length;
             }
@@ -153,8 +157,8 @@ export const useInstructionsSlashCommand = () => {
             if (committedMatch) {
               uncommitByName(committedMatch.name);
               setItemQuery(name);
-              phaseRef.current = 'items';
-              setPhase('items');
+              phaseRef.current = MentionPhase.Items;
+              setPhase(MentionPhase.Items);
               if (mentionAnchorRef.current === null) {
                 mentionAnchorRef.current = pos - itemOnlyMatch[0].length;
               }
@@ -179,14 +183,14 @@ export const useInstructionsSlashCommand = () => {
                 setSelectedItem({ name: mention.name });
                 setItemQuery(mention.name);
                 setToolQuery(candidate.slice(hashIdx + 1));
-                phaseRef.current = 'tools';
-                setPhase('tools');
+                phaseRef.current = MentionPhase.Tools;
+                setPhase(MentionPhase.Tools);
                 mentionAnchorRef.current = pos - candidate.length;
               } else {
                 uncommitByName(mention.name);
                 setItemQuery(candidate.slice(1));
-                phaseRef.current = 'items';
-                setPhase('items');
+                phaseRef.current = MentionPhase.Items;
+                setPhase(MentionPhase.Items);
                 mentionAnchorRef.current = pos - candidate.length;
               }
               return;
@@ -196,7 +200,7 @@ export const useInstructionsSlashCommand = () => {
         return;
       }
 
-      if (current === 'items') {
+      if (current === MentionPhase.Items) {
         // When anchor is set and still points to '/', extract the query as the text
         // between the anchor and the cursor. This supports names with spaces.
         if (mentionAnchorRef.current !== null && text[mentionAnchorRef.current] === '/') {
@@ -206,8 +210,8 @@ export const useInstructionsSlashCommand = () => {
             setItemQuery(afterAnchor.slice(0, hashIdx));
             if (selectedItem) {
               setToolQuery(afterAnchor.slice(hashIdx + 1));
-              phaseRef.current = 'tools';
-              setPhase('tools');
+              phaseRef.current = MentionPhase.Tools;
+              setPhase(MentionPhase.Tools);
             }
           } else if (afterAnchor.endsWith(' ') || afterAnchor.includes('\n')) {
             resetSlash();
@@ -225,8 +229,8 @@ export const useInstructionsSlashCommand = () => {
           setItemQuery(fullMatch[1]);
           if (selectedItem) {
             setToolQuery(fullMatch[2]);
-            phaseRef.current = 'tools';
-            setPhase('tools');
+            phaseRef.current = MentionPhase.Tools;
+            setPhase(MentionPhase.Tools);
           }
         } else if (itemOnlyMatch) {
           setItemQuery(itemOnlyMatch[1]);
@@ -239,7 +243,7 @@ export const useInstructionsSlashCommand = () => {
         return;
       }
 
-      if (current === 'tools') {
+      if (current === MentionPhase.Tools) {
         if (!selectedItem) {
           resetSlash();
           return;
@@ -260,8 +264,8 @@ export const useInstructionsSlashCommand = () => {
         const nameIdx = textToCursor.lastIndexOf(nameOnly);
         if (nameIdx !== -1 && !/[\s#]/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
           setItemQuery(selectedItem.name);
-          phaseRef.current = 'items';
-          setPhase('items');
+          phaseRef.current = MentionPhase.Items;
+          setPhase(MentionPhase.Items);
         } else {
           // User may be backspacing into the name itself (e.g. "Github mcp" → "Github mc").
           // Check if textToCursor ends with a prefix of the toolkit name.
@@ -274,8 +278,8 @@ export const useInstructionsSlashCommand = () => {
             if (prevChar !== '' && !/\s/.test(prevChar)) break;
             uncommitByName(selectedItem.name);
             setItemQuery(candidate.slice(1));
-            phaseRef.current = 'items';
-            setPhase('items');
+            phaseRef.current = MentionPhase.Items;
+            setPhase(MentionPhase.Items);
             mentionAnchorRef.current = pos - candidate.length;
             recovered = true;
             break;
@@ -310,8 +314,8 @@ export const useInstructionsSlashCommand = () => {
       setItemQuery(item.name);
       setToolQuery('');
       upsertMention(item.name, null);
-      phaseRef.current = 'tools';
-      setPhase('tools');
+      phaseRef.current = MentionPhase.Tools;
+      setPhase(MentionPhase.Tools);
     },
     [resetSlash, upsertMention],
   );

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
@@ -1,23 +1,46 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 
 import { Box } from '@mui/material';
 
 import { useInstructionsInputRefContext } from '@/[fsd]/app/providers';
+import { useInstructionsMention } from '@/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { FileReaderEnhancer } from '@/[fsd]/shared/ui/input';
 import { contextResolver } from '@/common/utils';
+import { useToolsValidationInfo } from '@/hooks/application/useValidateApplicationVersion';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import { useTheme } from '@emotion/react';
 
-const InstructionsInput = memo(({ style, containerStyle, disabled }) => {
+import InstructionsSlashSuggestionList from './InstructionsSlashSuggestionList';
+
+/**
+ * Returns true when a tool entry is a toolkit or MCP (has selectable sub-tools).
+ * Agents and pipelines have type 'application'.
+ */
+const isToolkitItem = tool => tool.type !== 'application';
+
+const getItemDescription = tool => {
+  if (tool.type === 'application') {
+    return tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent';
+  }
+  return 'Toolkit';
+};
+
+const InstructionsInput = memo(props => {
+  const { style, containerStyle, disabled, applicationId, entityProjectId } = props;
   const theme = useTheme();
   const inputRef = useInstructionsInputRefContext();
+  const styles = instructionsInputStyles();
   const {
     values: { version_details },
     setFieldValue,
   } = useFormikContext();
+  const selectedProjectId = useSelectedProjectId();
+  const projectId = entityProjectId || selectedProjectId;
+
   const handleChange = useCallback(field => value => setFieldValue(field, value), [setFieldValue]);
 
   const updateVariableList = useCallback(
@@ -38,6 +61,73 @@ const InstructionsInput = memo(({ style, containerStyle, disabled }) => {
     [setFieldValue, version_details?.variables],
   );
 
+  // ── Validation info for filtering out misconfigured toolkits ─────────────────
+
+  const { toolsValidationInfo } = useToolsValidationInfo({
+    applicationId,
+    projectId,
+    versionId: version_details?.id,
+    tools: version_details?.tools,
+  });
+
+  // ── Mentionable items from the agent's tool list ──────────────────────────────
+
+  const mentionableItems = useMemo(
+    () =>
+      (version_details?.tools || [])
+        .filter(tool => !toolsValidationInfo[tool.id])
+        .map(tool => ({
+          name: tool.name,
+          type: tool.type,
+          agent_type: tool.agent_type,
+          settings: tool.settings,
+          isToolkit: isToolkitItem(tool),
+          description: getItemDescription(tool),
+        })),
+    [version_details?.tools, toolsValidationInfo],
+  );
+
+  // ── Mention hook ──────────────────────────────────────────────────────────────
+
+  const {
+    phase,
+    itemQuery,
+    toolQuery,
+    selectedItem,
+    filteredTools,
+    onKeyDown: mentionOnKeyDown,
+    onInstructionsInputChange,
+    onSelectItem,
+    onSelectTool,
+    resetSlash,
+    resetMentionState,
+  } = useInstructionsMention({ fileReaderRef: inputRef, mentionableItems });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Intercept onChange so the mention hook tracks the current textarea content.
+  const handleInstructionsChange = useCallback(
+    value => {
+      handleChange('version_details.instructions')(value);
+      onInstructionsInputChange(value);
+    },
+    [handleChange, onInstructionsInputChange],
+  );
+
+  const suggestionList = (
+    <InstructionsSlashSuggestionList
+      phase={phase}
+      itemQuery={itemQuery}
+      toolQuery={toolQuery}
+      items={mentionableItems}
+      filteredTools={filteredTools}
+      selectedItem={selectedItem}
+      onSelectItem={onSelectItem}
+      onSelectTool={onSelectTool}
+      onClose={resetSlash}
+    />
+  );
+
   return (
     <BasicAccordion
       style={style}
@@ -47,20 +137,28 @@ const InstructionsInput = memo(({ style, containerStyle, disabled }) => {
         {
           title: 'Instructions',
           content: (
-            <Box sx={containerStyle}>
-              <FileReaderEnhancer
-                ref={inputRef}
-                showexpandicon="true"
-                id="application-instructions"
-                placeholder="Guidelines for the AI agent"
-                defaultValue={version_details?.instructions}
-                onChange={handleChange('version_details.instructions')}
-                updateVariableList={updateVariableList}
-                key={version_details?.id}
-                multiline
-                disabled={disabled}
-                fieldName={'Instructions'}
-              />
+            <Box sx={styles.wrapper}>
+              <Box sx={containerStyle}>
+                <FileReaderEnhancer
+                  ref={inputRef}
+                  showexpandicon="true"
+                  id="application-instructions"
+                  placeholder="Guidelines for the AI agent"
+                  defaultValue={version_details?.instructions}
+                  onChange={handleInstructionsChange}
+                  updateVariableList={updateVariableList}
+                  key={version_details?.id}
+                  multiline
+                  disabled={disabled}
+                  fieldName={'Instructions'}
+                  onKeyDown={mentionOnKeyDown}
+                  onResetMentionState={resetMentionState}
+                  onRealtimeChange={onInstructionsInputChange}
+                  onFullScreenChange={setIsModalOpen}
+                  afterContent={suggestionList}
+                />
+              </Box>
+              {!isModalOpen && suggestionList}
             </Box>
           ),
         },
@@ -72,3 +170,12 @@ const InstructionsInput = memo(({ style, containerStyle, disabled }) => {
 InstructionsInput.displayName = 'InstructionsInput';
 
 export default InstructionsInput;
+
+/** @type {MuiSx} */
+const instructionsInputStyles = () => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+});

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
@@ -16,19 +16,6 @@ import { useTheme } from '@emotion/react';
 
 import InstructionsSlashSuggestionList from './InstructionsSlashSuggestionList';
 
-/**
- * Returns true when a tool entry is a toolkit or MCP (has selectable sub-tools).
- * Agents and pipelines have type 'application'.
- */
-const isToolkitItem = tool => tool.type !== 'application';
-
-const getItemDescription = tool => {
-  if (tool.type === 'application') {
-    return tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent';
-  }
-  return 'Toolkit';
-};
-
 const InstructionsInput = memo(props => {
   const { style, containerStyle, disabled, applicationId, entityProjectId } = props;
   const theme = useTheme();
@@ -71,6 +58,15 @@ const InstructionsInput = memo(props => {
   });
 
   // ── Mentionable items from the agent's tool list ──────────────────────────────
+
+  const isToolkitItem = tool => tool.type !== 'application';
+
+  const getItemDescription = tool => {
+    if (tool.type === 'application') {
+      return tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent';
+    }
+    return 'Toolkit';
+  };
 
   const mentionableItems = useMemo(
     () =>

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 
 import { Box, ClickAwayListener, Typography } from '@mui/material';
 
+import { MentionConstants } from '@/[fsd]/shared/lib/constants';
 import { Mention } from '@/[fsd]/shared/ui';
 
 /**
@@ -29,9 +30,9 @@ const InstructionsSlashSuggestionList = memo(props => {
     return items.filter(item => item.name.toLowerCase().includes(itemQuery.toLowerCase()));
   }, [items, itemQuery]);
 
-  if (phase === 'idle') return null;
+  if (phase === MentionConstants.MentionPhase.Idle) return null;
 
-  if (phase === 'tools') {
+  if (phase === MentionConstants.MentionPhase.Tools) {
     if (filteredTools.length === 0) return null;
     return (
       <Mention.MentionToolList

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
@@ -1,0 +1,103 @@
+import { memo, useMemo } from 'react';
+
+import { Box, ClickAwayListener, Typography } from '@mui/material';
+
+import { Mention } from '@/[fsd]/shared/ui';
+
+/**
+ * Dropdown rendered below the Instructions textarea while the user is in
+ * 'items' or 'tools' phase.
+ *
+ * Props:
+ *   phase        — 'idle' | 'items' | 'tools'
+ *   itemQuery    — current filter text (typed after "/")
+ *   toolQuery    — current tool filter text (typed after "#")
+ *   items        — all mentionable items derived from version_details.tools
+ *   filteredTools — tools pre-filtered by toolQuery (from useInstructionsMention)
+ *   selectedItem  — the toolkit/MCP currently in 'tools' phase
+ *   onSelectItem  — (item, isToolkit) => void
+ *   onSelectTool  — (toolName | null) => void
+ *   onClose       — () => void  (dismiss the dropdown)
+ */
+const InstructionsSlashSuggestionList = memo(props => {
+  const { phase, itemQuery, items, filteredTools, selectedItem, onSelectItem, onSelectTool, onClose } = props;
+  const styles = instructionsSlashSuggestionListStyles();
+  // Filter items by itemQuery client-side for instant response.
+  const filteredItems = useMemo(() => {
+    if (!items?.length) return [];
+    if (!itemQuery) return items;
+    return items.filter(item => item.name.toLowerCase().includes(itemQuery.toLowerCase()));
+  }, [items, itemQuery]);
+
+  if (phase === 'idle') return null;
+
+  if (phase === 'tools') {
+    if (filteredTools.length === 0) return null;
+    return (
+      <Mention.MentionToolList
+        tools={filteredTools}
+        toolkitName={selectedItem?.name}
+        onSelectTool={onSelectTool}
+      />
+    );
+  }
+
+  // phase === 'items'
+  if (filteredItems.length === 0) return null;
+
+  return (
+    <ClickAwayListener onClickAway={onClose}>
+      <Box sx={styles.container}>
+        <Box sx={styles.header}>
+          <Typography
+            variant="subtitle"
+            color="text.primary"
+          >
+            Mention agent, pipeline or toolkit
+          </Typography>
+        </Box>
+        {filteredItems.map(item => (
+          <Mention.MentionToolItem
+            key={item.name}
+            label={item.name}
+            description={item.description}
+            onClick={() => onSelectItem(item, item.isToolkit)}
+          />
+        ))}
+      </Box>
+    </ClickAwayListener>
+  );
+});
+
+InstructionsSlashSuggestionList.displayName = 'InstructionsSlashSuggestionList';
+
+export default InstructionsSlashSuggestionList;
+
+/** @type {MuiSx} */
+const instructionsSlashSuggestionListStyles = () => ({
+  container: ({ palette }) => ({
+    border: `1px solid ${palette.border.lines}`,
+    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '15.4375rem',
+    borderRadius: '1rem',
+    boxSizing: 'border-box',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    background: palette.background.secondary,
+    overflowY: 'auto',
+  }),
+  header: {
+    position: 'sticky',
+    top: '-0.75rem',
+    zIndex: 1,
+    height: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '1rem .75rem',
+    margin: '-0.75rem -0.75rem 0',
+    background: 'inherit',
+  },
+});

--- a/src/[fsd]/shared/lib/constants/index.js
+++ b/src/[fsd]/shared/lib/constants/index.js
@@ -3,3 +3,4 @@ export * as AccordionConstants from './accordion.constants.js';
 export * as LLMSettingsConstants from './llmSettings.constants.js';
 export * as ToolkitSocketConstants from './toolkitSocket.constants.js';
 export * as EnvironmentConstants from './environment.constants.js';
+export * as MentionConstants from './mention.constants.js';

--- a/src/[fsd]/shared/lib/constants/mention.constants.js
+++ b/src/[fsd]/shared/lib/constants/mention.constants.js
@@ -1,0 +1,5 @@
+export const MentionPhase = {
+  Idle: 'idle',
+  Items: 'items',
+  Tools: 'tools',
+};

--- a/src/[fsd]/shared/lib/hooks/index.js
+++ b/src/[fsd]/shared/lib/hooks/index.js
@@ -14,3 +14,4 @@ export * from './useContextExecutionEntity.hooks';
 export * from './useEnvironmentSettingByKey.hooks';
 export * from './useShowRunHistoryFromUrl.hooks';
 export * from './useDeleteConfirmationDisabled.hooks';
+export * from './useMentionHighlights.hooks';

--- a/src/[fsd]/shared/lib/hooks/useMentionHighlights.hooks.js
+++ b/src/[fsd]/shared/lib/hooks/useMentionHighlights.hooks.js
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+
+/**
+ * Generic hook that computes highlight ranges for committed mentions within text.
+ *
+ * @param {string} inputContent - current text
+ * @param {Array}  committedMentions - committed mention objects
+ * @param {function} tokenBuilder - (mention) => string token to search for
+ * @returns {Array<{start: number, end: number}>}
+ */
+export const useMentionHighlights = (inputContent, committedMentions, tokenBuilder) =>
+  useMemo(() => {
+    if (!committedMentions?.length || !inputContent) return [];
+
+    // Build unique token strings; sort longest-first to prevent sub-match shadowing.
+    const tokens = [...new Set(committedMentions.map(tokenBuilder))].sort((a, b) => b.length - a.length);
+
+    const ranges = [];
+
+    for (const token of tokens) {
+      let idx = inputContent.indexOf(token);
+      while (idx !== -1) {
+        const end = idx + token.length;
+        if (!ranges.some(r => idx < r.end && end > r.start)) {
+          ranges.push({ start: idx, end });
+        }
+        idx = inputContent.indexOf(token, idx + 1);
+      }
+    }
+
+    return ranges.sort((a, b) => a.start - b.start);
+  }, [inputContent, committedMentions, tokenBuilder]);

--- a/src/[fsd]/shared/ui/index.js
+++ b/src/[fsd]/shared/ui/index.js
@@ -18,3 +18,4 @@ export * as Select from './select';
 export { default as ScrollableContainer } from './scrollable-container';
 export * as Icon from './icon';
 export { default as Markdown } from './markdown';
+export * as Mention from './mention';

--- a/src/[fsd]/shared/ui/input/FileReaderInput.jsx
+++ b/src/[fsd]/shared/ui/input/FileReaderInput.jsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 
 import YAML from 'js-yaml';
 
@@ -10,28 +10,74 @@ import useToast from '@/hooks/useToast';
 
 const FileReaderEnhancer = forwardRef(
   (
-    { defaultValue, updateVariableList, onChange, hasActionsToolBar = true, fieldName = '', ...props },
+    {
+      defaultValue,
+      updateVariableList,
+      onChange,
+      hasActionsToolBar = true,
+      fieldName = '',
+      onResetMentionState,
+      ...props
+    },
     ref,
   ) => {
     const theme = useTheme();
     const [inputValue, setInputValue] = useState(defaultValue);
     const [highlightContext, setHighlightContext] = useState(false);
     const { toastError } = useToast();
+    const textareaRef = useRef(null);
+    const modalRef = useRef(null);
 
     useImperativeHandle(ref, () => ({
       restoreValue: (valueToRestore = '') => setInputValue(valueToRestore),
+      getInputContent: () => {
+        if (modalRef.current) return modalRef.current.getCurrentValue?.() ?? inputValue;
+        return textareaRef.current?.value ?? inputValue;
+      },
+      getCursorPosition: () => {
+        if (modalRef.current) return modalRef.current.getCursorPosition?.() ?? null;
+        return textareaRef.current?.selectionStart ?? null;
+      },
+      getTextareaElement: () => textareaRef.current,
+      resetMentionState: onResetMentionState ?? undefined,
+      replaceRange: (start, end, replacement) => {
+        const isModalOpen = !!modalRef.current;
+        const current = isModalOpen
+          ? (modalRef.current.getCurrentValue?.() ?? inputValue)
+          : (textareaRef.current?.value ?? inputValue);
+        const newValue = current.slice(0, start) + replacement + current.slice(end);
+        setInputValue(newValue);
+        updateVariableList(newValue);
+        onChange(newValue);
+        if (isModalOpen) {
+          modalRef.current.replaceRange?.(start, end, replacement);
+        } else {
+          // Restore cursor position after React re-render.
+          const cursorPos = start + replacement.length;
+          requestAnimationFrame(() => {
+            if (textareaRef.current) {
+              textareaRef.current.setSelectionRange(cursorPos, cursorPos);
+              textareaRef.current.focus();
+            }
+          });
+        }
+      },
     }));
+
+    const debouncedUpdateVariableList = useMemo(
+      () => debounce(value => updateVariableList(value), 500),
+      [updateVariableList],
+    );
 
     const handleInput = useCallback(
       event => {
         event.preventDefault();
-        setInputValue(event.target.value);
-        debounce(() => {
-          updateVariableList(event.target.value);
-          onChange(event.target.value);
-        }, 500)();
+        const value = event.target.value;
+        setInputValue(value);
+        onChange(value);
+        debouncedUpdateVariableList(value);
       },
-      [onChange, updateVariableList],
+      [onChange, debouncedUpdateVariableList],
     );
 
     const handleDragOver = useCallback(() => {
@@ -94,6 +140,8 @@ const FileReaderEnhancer = forwardRef(
         onBlur={handleBlur}
         hasActionsToolBar={hasActionsToolBar}
         fieldName={fieldName}
+        inputRef={textareaRef}
+        innerModalRef={modalRef}
         {...props}
       />
     );

--- a/src/[fsd]/shared/ui/input/FileReaderInput.jsx
+++ b/src/[fsd]/shared/ui/input/FileReaderInput.jsx
@@ -28,19 +28,8 @@ const FileReaderEnhancer = forwardRef(
     const textareaRef = useRef(null);
     const modalRef = useRef(null);
 
-    useImperativeHandle(ref, () => ({
-      restoreValue: (valueToRestore = '') => setInputValue(valueToRestore),
-      getInputContent: () => {
-        if (modalRef.current) return modalRef.current.getCurrentValue?.() ?? inputValue;
-        return textareaRef.current?.value ?? inputValue;
-      },
-      getCursorPosition: () => {
-        if (modalRef.current) return modalRef.current.getCursorPosition?.() ?? null;
-        return textareaRef.current?.selectionStart ?? null;
-      },
-      getTextareaElement: () => textareaRef.current,
-      resetMentionState: onResetMentionState ?? undefined,
-      replaceRange: (start, end, replacement) => {
+    const handleReplaceRange = useCallback(
+      (start, end, replacement) => {
         const isModalOpen = !!modalRef.current;
         const current = isModalOpen
           ? (modalRef.current.getCurrentValue?.() ?? inputValue)
@@ -62,6 +51,22 @@ const FileReaderEnhancer = forwardRef(
           });
         }
       },
+      [inputValue, onChange, updateVariableList],
+    );
+
+    useImperativeHandle(ref, () => ({
+      restoreValue: (valueToRestore = '') => setInputValue(valueToRestore),
+      getInputContent: () => {
+        if (modalRef.current) return modalRef.current.getCurrentValue?.() ?? inputValue;
+        return textareaRef.current?.value ?? inputValue;
+      },
+      getCursorPosition: () => {
+        if (modalRef.current) return modalRef.current.getCursorPosition?.() ?? null;
+        return textareaRef.current?.selectionStart ?? null;
+      },
+      getTextareaElement: () => textareaRef.current,
+      resetMentionState: onResetMentionState ?? undefined,
+      replaceRange: handleReplaceRange,
     }));
 
     const debouncedUpdateVariableList = useMemo(

--- a/src/[fsd]/shared/ui/input/InputBase.jsx
+++ b/src/[fsd]/shared/ui/input/InputBase.jsx
@@ -77,6 +77,7 @@ const InputBase = memo(props => {
     onKeyPress,
     value,
     containerProps = {},
+    overlayContent,
     InputLabelProps,
     maxRows = null,
     minRows = 3,
@@ -208,6 +209,7 @@ const InputBase = memo(props => {
         sx={styles.containerBox}
         {...containerProps}
       >
+        {overlayContent}
         {hasActionsToolBar && (isHovering || forceShowActionsToolbar) && (
           <InputActionsToolbar
             value={value}

--- a/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
+++ b/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
@@ -53,6 +53,10 @@ const StyledInputEnhancer = memo(props => {
     forceShowActionsToolbar,
     enableFStringAutocomplete,
     stateVariableOptions,
+    innerModalRef,
+    onRealtimeChange,
+    afterContent,
+    onFullScreenChange,
     ...leftProps
   } = props;
 
@@ -60,12 +64,14 @@ const StyledInputEnhancer = memo(props => {
 
   const handleOpenFullScreen = useCallback(() => {
     setShowFullScreenInputModel(true);
-  }, []);
+    onFullScreenChange?.(true);
+  }, [onFullScreenChange]);
 
   const handleCloseFullScreen = useCallback(() => {
     setShowFullScreenInputModel(false);
+    onFullScreenChange?.(false);
     onInputModalClose?.();
-  }, [onInputModalClose]);
+  }, [onFullScreenChange, onInputModalClose]);
 
   const handleChange = useCallback(
     event => {
@@ -112,6 +118,7 @@ const StyledInputEnhancer = memo(props => {
       />
       {showFullScreenInputModel && (
         <StyledInputModal
+          ref={innerModalRef}
           value={value}
           title={fieldName}
           key={showFullScreenInputModel}
@@ -125,6 +132,8 @@ const StyledInputEnhancer = memo(props => {
           specifiedLanguage={detectedLanguage}
           enableFStringAutocomplete={enableFStringAutocomplete}
           stateVariableOptions={stateVariableOptions}
+          onRealtimeChange={onRealtimeChange}
+          afterContent={afterContent}
           {...leftProps}
         />
       )}

--- a/src/[fsd]/shared/ui/mention/MentionToolItem.jsx
+++ b/src/[fsd]/shared/ui/mention/MentionToolItem.jsx
@@ -1,0 +1,59 @@
+import { memo } from 'react';
+
+import { Box, Typography } from '@mui/material';
+
+const MentionToolItem = memo(props => {
+  const { label, description, onClick } = props;
+  const styles = mentionToolItemStyles();
+  return (
+    <Box
+      onClick={onClick}
+      sx={styles.container}
+    >
+      <Typography
+        variant="headingSmall"
+        color="text.secondary"
+        sx={styles.label}
+      >
+        {label}
+      </Typography>
+      {description && (
+        <Typography
+          variant="bodySmall"
+          color="text.primary"
+          sx={styles.description}
+        >
+          {description}
+        </Typography>
+      )}
+    </Box>
+  );
+});
+
+MentionToolItem.displayName = 'MentionToolItem';
+
+export default MentionToolItem;
+
+/** @type {MuiSx} */
+const mentionToolItemStyles = () => ({
+  container: ({ palette }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.5rem',
+    cursor: 'pointer',
+    background: palette.background.userInputBackground,
+    '&:hover': { background: palette.background.userInputBackgroundActive },
+  }),
+  label: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  description: {
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 1,
+  },
+});

--- a/src/[fsd]/shared/ui/mention/MentionToolList.jsx
+++ b/src/[fsd]/shared/ui/mention/MentionToolList.jsx
@@ -1,0 +1,67 @@
+import { memo } from 'react';
+
+import { Box, ClickAwayListener, Typography } from '@mui/material';
+
+import MentionToolItem from './MentionToolItem';
+
+const MentionToolList = memo(props => {
+  const { tools, toolkitName, onSelectTool } = props;
+  const styles = mentionToolListStyles();
+
+  const content = (
+    <Box sx={styles.container}>
+      <Box sx={styles.header}>
+        <Typography
+          variant="subtitle"
+          color="text.primary"
+        >
+          {toolkitName} available tools
+        </Typography>
+      </Box>
+
+      {tools.map(tool => (
+        <MentionToolItem
+          key={tool.name}
+          label={tool.name}
+          description={tool.description}
+          onClick={() => onSelectTool(tool.name)}
+        />
+      ))}
+    </Box>
+  );
+
+  return <ClickAwayListener onClickAway={() => onSelectTool(null)}>{content}</ClickAwayListener>;
+});
+
+MentionToolList.displayName = 'MentionToolList';
+
+export default MentionToolList;
+
+/** @type {MuiSx} */
+const mentionToolListStyles = () => ({
+  container: ({ palette }) => ({
+    border: `1px solid ${palette.border.lines}`,
+    width: '100%',
+    maxWidth: '100%',
+    maxHeight: '15.4375rem',
+    borderRadius: '1rem',
+    boxSizing: 'border-box',
+    padding: '0.75rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    background: palette.background.secondary,
+    overflowY: 'auto',
+  }),
+  header: {
+    position: 'sticky',
+    top: '-0.75rem',
+    zIndex: 1,
+    height: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '1rem .75rem',
+    margin: '-0.75rem -0.75rem 0',
+    background: 'inherit',
+  },
+});

--- a/src/[fsd]/shared/ui/mention/index.js
+++ b/src/[fsd]/shared/ui/mention/index.js
@@ -1,0 +1,2 @@
+export { default as MentionToolItem } from './MentionToolItem';
+export { default as MentionToolList } from './MentionToolList';

--- a/src/components/StyledInputModal.jsx
+++ b/src/components/StyledInputModal.jsx
@@ -74,26 +74,28 @@ const StyledInputModal = forwardRef((props, ref) => {
     onClose?.();
   }, [handleBlur, onClose]);
 
+  const handleReplaceRange = useCallback((start, end, replacement) => {
+    const view = editorRef.current?.view;
+    if (!view) return;
+    suppressRealtimeRef.current = true;
+    try {
+      const cursorPos = start + replacement.length;
+      view.dispatch({
+        changes: { from: start, to: end, insert: replacement },
+        selection: { anchor: cursorPos },
+      });
+      const newValue = view.state.doc.toString();
+      currentValueRef.current = newValue;
+      setCurrentValue(newValue);
+    } catch {
+      suppressRealtimeRef.current = false;
+    }
+  }, []);
+
   useImperativeHandle(ref, () => ({
     getCurrentValue: () => editorRef.current?.view?.state?.doc?.toString() ?? currentValueRef.current,
     getCursorPosition: () => editorRef.current?.view?.state?.selection?.main?.head ?? null,
-    replaceRange: (start, end, replacement) => {
-      const view = editorRef.current?.view;
-      if (!view) return;
-      suppressRealtimeRef.current = true;
-      try {
-        const cursorPos = start + replacement.length;
-        view.dispatch({
-          changes: { from: start, to: end, insert: replacement },
-          selection: { anchor: cursorPos },
-        });
-        const newValue = view.state.doc.toString();
-        currentValueRef.current = newValue;
-        setCurrentValue(newValue);
-      } catch {
-        suppressRealtimeRef.current = false;
-      }
-    },
+    replaceRange: handleReplaceRange,
   }));
 
   return (

--- a/src/components/StyledInputModal.jsx
+++ b/src/components/StyledInputModal.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 import { Box } from '@mui/material';
 
@@ -6,7 +6,7 @@ import { AIAssistantCodeMirrorInput } from '@/[fsd]/features/pipelines/ai-assist
 import { Field, Modal } from '@/[fsd]/shared/ui';
 import { useLanguageLinter } from '@/hooks/useCodeMirrorLanguageExtensions';
 
-const StyledInputModal = memo(props => {
+const StyledInputModal = forwardRef((props, ref) => {
   const {
     open,
     onClose,
@@ -23,38 +23,49 @@ const StyledInputModal = memo(props => {
     disabled,
     enableFStringAutocomplete = false,
     stateVariableOptions = [],
+    onRealtimeChange,
+    afterContent,
   } = props;
 
   const { maxLength } = inputProps || {};
 
   const [currentValue, setCurrentValue] = useState(value);
+  const currentValueRef = useRef(value);
   const editorRef = useRef();
+  const suppressRealtimeRef = useRef(false);
 
   useEffect(() => {
     if (open) {
       setCurrentValue(value);
+      currentValueRef.current = value;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const onNotifyChange = useCallback(
     newValue => {
+      currentValueRef.current = newValue;
       setCurrentValue(newValue);
+      if (suppressRealtimeRef.current) {
+        suppressRealtimeRef.current = false;
+        return;
+      }
+      onRealtimeChange?.(newValue);
     },
-    [setCurrentValue],
+    [onRealtimeChange],
   );
 
   const handleBlur = useCallback(() => {
     const event = {
       preventDefault: () => {},
       target: {
-        value: currentValue,
+        value: currentValueRef.current,
         name,
         id,
       },
     };
     hasOnChangeCallback ? onChange?.(event) : onInput?.(event);
-  }, [currentValue, hasOnChangeCallback, id, name, onChange, onInput]);
+  }, [hasOnChangeCallback, id, name, onChange, onInput]);
 
   const { extensions } = useLanguageLinter(specifiedLanguage, editorRef.current?.view);
 
@@ -62,6 +73,28 @@ const StyledInputModal = memo(props => {
     handleBlur();
     onClose?.();
   }, [handleBlur, onClose]);
+
+  useImperativeHandle(ref, () => ({
+    getCurrentValue: () => editorRef.current?.view?.state?.doc?.toString() ?? currentValueRef.current,
+    getCursorPosition: () => editorRef.current?.view?.state?.selection?.main?.head ?? null,
+    replaceRange: (start, end, replacement) => {
+      const view = editorRef.current?.view;
+      if (!view) return;
+      suppressRealtimeRef.current = true;
+      try {
+        const cursorPos = start + replacement.length;
+        view.dispatch({
+          changes: { from: start, to: end, insert: replacement },
+          selection: { anchor: cursorPos },
+        });
+        const newValue = view.state.doc.toString();
+        currentValueRef.current = newValue;
+        setCurrentValue(newValue);
+      } catch {
+        suppressRealtimeRef.current = false;
+      }
+    },
+  }));
 
   return (
     <Modal.StyledInputModalBase
@@ -99,13 +132,14 @@ const StyledInputModal = memo(props => {
           )}
         </Box>
       </Box>
+      {afterContent}
     </Modal.StyledInputModalBase>
   );
 });
 
 StyledInputModal.displayName = 'StyledInputModal';
 
-export default StyledInputModal;
+export default memo(StyledInputModal);
 
 /** @type {MuiSx} */
 const styles = {

--- a/src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx
@@ -29,6 +29,8 @@ const ApplicationConfigurationForm = memo(props => {
       <AgentInput.InstructionsInput
         style={styles.contextSection}
         disabled={isDisabled}
+        applicationId={applicationId}
+        entityProjectId={entityProjectId}
       />
       <ApplicationVariables style={styles.section} />
       <AgentInput.WelcomeMessageInput

--- a/src/pages/Applications/EditApplication.jsx
+++ b/src/pages/Applications/EditApplication.jsx
@@ -36,11 +36,13 @@ const EditApplication = memo(() => {
 
   const handleDiscard = useCallback(() => {
     fileReaderEnhancerRef.current?.restoreValue(initialValues?.version_details?.instructions || '');
+    fileReaderEnhancerRef.current?.resetMentionState?.();
     setUnsavedLLMSettings(undefined);
   }, [initialValues?.version_details?.instructions]);
 
   const handleSuccess = useCallback(() => {
     setDirty(false);
+    fileReaderEnhancerRef.current?.resetMentionState?.();
   }, []);
 
   const blockOptions = useMemo(


### PR DESCRIPTION
# Implementation: Autosuggest Mentions in Agent Instructions Editor

**Story:** [EliteaAI/elitea_issues#3396](https://github.com/EliteaAI/elitea_issues/issues/3396)  
**Milestone:** R-2.0.3

---

## 1. Overview

Add `/`-triggered autosuggest in the **Agent Instructions** textarea so users can quickly reference already-added Agents, Pipelines, Toolkits, and MCPs. When a Toolkit or MCP is selected, a second dropdown offers optional tool selection. Mentions can be typed at **any cursor position**, not only at the end of the input.

This mirrors the chat slash-mention system but has four key differences:

| Aspect | Chat | Instructions |
|---|---|---|
| Data source | `activeConversation.participants` | `formik.values.version_details.tools` |
| Item types in dropdown | Toolkits + MCPs only | Agents + Pipelines + Toolkits + MCPs |
| Tool separator | `/` (e.g. `/Jira/getIssue`) | `#` (e.g. `/Jira#getIssue`) |
| Second-phase trigger | User types `/` again | Automatic after toolkit/MCP selection |

---

## 2. FSD Layer Rules Applied

```
app → pages → widgets → features → entities → shared
```

- Features at the same layer **must not** import from each other directly.
- `MentionToolList` and `MentionToolItem` components used by this feature live inside `features/chat/ui/`. The `agent` feature imports them from `shared/ui/mention/` instead.
- Reusable hook logic shared between features lives in `shared/lib/hooks/`.
- Feature-specific logic (state machine, data wiring) stays inside the `agent` feature slice.

---

## 3. Mention Format

| Selection | Inserted text |
|---|---|
| Agent | `/AgentName ` |
| Pipeline | `/PipelineName ` |
| Toolkit (no tool) | `/ToolkitName ` |
| Toolkit + Tool | `/ToolkitName#ToolName ` |
| MCP (no tool) | `/McpName ` |
| MCP + Tool | `/McpName#ToolName ` |

---

## 4. Eligibility / Filtering Rules

Items are sourced from `formik.values.version_details.tools`. Misconfigured items are filtered out using `useToolsValidationInfo`. Any tool with a non-null entry in `toolsValidationInfo[tool.id]` is silently excluded from the dropdown.

```js
// In InstructionsInput
const { toolsValidationInfo } = useToolsValidationInfo({
  applicationId,
  projectId,
  versionId: version_details?.id,
  tools: version_details?.tools,
});

const mentionableItems = useMemo(
  () =>
    (version_details?.tools || [])
      .filter(tool => !toolsValidationInfo[tool.id])
      .map(tool => ({
        name: tool.name,
        type: tool.type,
        agent_type: tool.agent_type,
        settings: tool.settings,
        isToolkit: tool.type !== 'application',
        description: tool.type === 'application'
          ? (tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent')
          : 'Toolkit',
      })),
  [version_details?.tools, toolsValidationInfo],
);
```

`applicationId` and `entityProjectId` are passed down from `ApplicationConfigurationForm` → `InstructionsInput`.

---

## 5. Files Changed

### 5.1 New files in `features/agent/`

```
src/[fsd]/features/agent/
├── lib/
│   └── hooks/
│       ├── useInstructionsSlashCommand.hooks.js   ← phase state machine
│       └── useInstructionsMention.hooks.js         ← top-level hook (data wiring + text manipulation)
└── ui/
    └── agent-details/
        └── configurations/
            └── input/
                ├── InstructionsSlashSuggestionList.jsx  ← phase-switching dropdown
                └── InstructionsMentionItem.jsx           ← single row (type badge + name)
```

### 5.2 Modified files

```
src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx
src/components/StyledInputModal.jsx
```

### 5.3 Shared layer (pre-existing, consumed)

```
src/[fsd]/shared/
├── lib/hooks/useMentionHighlights.hooks.js   ← not used by agent feature
└── ui/mention/
    ├── MentionToolList.jsx
    └── MentionToolItem.jsx
```

`MentionToolList` and `MentionToolItem` are used inside `InstructionsSlashSuggestionList` for the tools phase.

---

## 6. State Machine — `useInstructionsSlashCommand`

`src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js`

### Phases

```
'idle'   → user types '/'        → 'items'   (list agents/pipelines/toolkits/MCPs)
'items'  + select Toolkit/MCP    → 'tools'   (list specific tools)
'items'  + select Agent/Pipeline → 'idle'    (mention committed)
'tools'  + select tool           → 'idle'    (mention committed with tool)
'tools'  + Escape or ClickAway   → 'idle'    (committed without tool)
any      + Escape                → 'idle'    (dismiss)
```

### State variables

```js
const [phase, setPhase] = useState('idle');          // 'idle' | 'items' | 'tools'
const phaseRef = useRef('idle');                      // stale-closure-safe mirror
const [itemQuery, setItemQuery] = useState('');       // text typed after '/'
const [toolQuery, setToolQuery] = useState('');       // text typed after '#'
const [selectedItem, setSelectedItem] = useState(null); // toolkit/MCP in 'tools' phase
const [committedMentions, setCommittedMentions] = useState([]);
const committedMentionsRef = useRef([]);              // stale-closure-safe mirror
const mentionAnchorRef = useRef(null);                // char index of the leading '/'
```

`phaseRef` and `committedMentionsRef` mirror their state counterparts so async callbacks always read the latest value without needing to be recreated on every state change.

### `onKeyDown(event)`

- `'/'` in `'idle'` → set phase to `'items'`, record `mentionAnchorRef = event.target?.selectionStart` (null for CodeMirror — filled later by `syncWithValue`).
- `Escape` in non-idle → `resetSlash()`.

### `syncWithValue(text, cursorPos)`

Called on every input event with the full text and current cursor position. Uses `textToCursor = text.slice(0, cursorPos)` for all pattern matching so mentions work at **any cursor position**.

- **`'idle'` phase**: Detects if the user backspaced into a committed mention token (e.g. `/Name#Tool` or `/Name`) and re-enters the appropriate phase.
- **`'items'` phase**: Extracts `itemQuery` from the text between the anchor and the cursor. Resets if the fragment ends with a space or newline.
- **`'tools'` phase**: Tracks `toolQuery` from the text after the `#` separator. Falls back to `'items'` phase if `#` is deleted, and handles partial backspace into the toolkit name.

### Committed mention shape

```js
{ name: string, tool_name: string | null }
// tool_name is null for agents, pipelines, and whole-toolkit mentions
```

---

## 7. Top-Level Hook — `useInstructionsMention`

`src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js`

Wires the state machine to text manipulation on the `FileReaderEnhancer` ref. Accepts `{ fileReaderRef, mentionableItems }`.

### Key design decisions

- **No `inputContent` state.** The current textarea value is tracked in `inputContentRef` (a `useRef`) so that per-keystroke text changes do **not** trigger a React re-render of `InstructionsInput`. The ref is used only as a fallback when `fileReaderRef.current.getInputContent()` is unavailable.
- **No highlight ranges.** The feature exposes no `highlightRanges` or `inputContent` — only the dropdown state needed for the suggestion UI.

### Text manipulation

`replaceFragment(replacement, endOverride)` — replaces text from `mentionAnchorRef` to the current cursor position with `replacement`, calling `fileReaderRef.current.replaceRange(anchor, end, replacement)`.

### Tool availability

`resolvedSelectedItem` looks up the full item (with `settings`) from `mentionableItems` when `selectedItem` only has `{ name }` (re-entry via backspace). `availableTools` and `filteredTools` are derived from `resolvedSelectedItem.settings`.

### Returned API

```js
{
  phase,             // 'idle' | 'items' | 'tools'
  itemQuery,         // current filter string for items dropdown
  toolQuery,         // current filter string for tools dropdown
  selectedItem,      // resolved item with full settings
  filteredTools,     // tools filtered by toolQuery
  onKeyDown,
  onInstructionsInputChange,
  onSelectItem,
  onSelectTool,
  resetSlash,
  resetMentionState, // full reset including committed mentions
}
```

---

## 8. UI Components

### 8.1 `InstructionsMentionItem`

`src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsMentionItem.jsx`

Single row in the items dropdown. Shows the item name and a type badge ("Agent", "Pipeline", "Toolkit").

### 8.2 `InstructionsSlashSuggestionList`

`src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx`

Phase-switching dropdown.

- `phase === 'idle'` → renders nothing.
- `phase === 'items'` → renders `InstructionsMentionItem` rows filtered by `itemQuery`. Calls `onSelectItem(item, isToolkit)`.
- `phase === 'tools'` → renders `MentionToolList` (from `shared/ui/mention/`) filtered by `toolQuery`. A "Use whole toolkit" entry at the top calls `onSelectTool(null)`. Wrapped in `ClickAwayListener` that also calls `onSelectTool(null)` on click-away.

---

## 9. Modified: `InstructionsInput`

`src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx`

Key additions:

1. Accepts `applicationId` and `entityProjectId` props (passed from `ApplicationConfigurationForm`).
2. Derives `projectId` from `entityProjectId ?? useSelectedProjectId()`.
3. Calls `useToolsValidationInfo` to build `mentionableItems` (excludes misconfigured tools).
4. Calls `useInstructionsMention({ fileReaderRef: inputRef, mentionableItems })`.
5. `handleInstructionsChange` merges formik `setFieldValue` + `onInstructionsInputChange`.
6. `onKeyDown` passed via `onKeyDown` prop to `FileReaderEnhancer`.
7. `onRealtimeChange` passed to `FileReaderEnhancer` so CodeMirror changes also sync the mention state.
8. `onResetMentionState` passed to `FileReaderEnhancer` to reset on version switch (`key={version_details?.id}`).
9. `InstructionsSlashSuggestionList` rendered below the input (outside the modal; `afterContent` prop carries it into the full-screen modal).

### Styles

`instructionsInputStyles` is an arrow function returning the style object, following FE convention.

---

## 10. Modified: `ApplicationConfigurationForm`

`src/pages/Applications/Components/Applications/ApplicationConfigurationForm.jsx`

Passes `applicationId` and `entityProjectId` to `AgentInput.InstructionsInput` so the hook can resolve `useToolsValidationInfo`:

```jsx
<AgentInput.InstructionsInput
  style={styles.contextSection}
  disabled={isDisabled}
  applicationId={applicationId}
  entityProjectId={entityProjectId}
/>
```

---

## 11. Modified: `StyledInputModal` (CodeMirror Full-Screen)

`src/components/StyledInputModal.jsx`

### Problem

When the user selects a toolkit in the full-screen CodeMirror modal, `selectItem` sets phase to `'tools'`. However, `view.dispatch` in `replaceRange` triggers CodeMirror's update listener which fires `notifyChange` with a 30 ms debounce. That delayed `notifyChange` → `onRealtimeChange` → `syncWithValue` call sees `/ToolkitName` (no `#`) in `'tools'` phase and interprets it as "separator deleted", reverting the phase back to `'items'`.

### Fix — `suppressRealtimeRef`

```js
const suppressRealtimeRef = useRef(false);

const onNotifyChange = useCallback(newValue => {
  currentValueRef.current = newValue;
  setCurrentValue(newValue);
  if (suppressRealtimeRef.current) {
    suppressRealtimeRef.current = false;
    return; // skip — fired by programmatic replaceRange, not user input
  }
  onRealtimeChange?.(newValue);
}, [onRealtimeChange]);

// In useImperativeHandle → replaceRange:
replaceRange: (start, end, replacement) => {
  const view = editorRef.current?.view;
  if (!view) return;
  suppressRealtimeRef.current = true;
  try {
    const cursorPos = start + replacement.length;
    view.dispatch({
      changes: { from: start, to: end, insert: replacement },
      selection: { anchor: cursorPos },
    });
    const newValue = view.state.doc.toString();
    currentValueRef.current = newValue;
    setCurrentValue(newValue);
  } catch {
    suppressRealtimeRef.current = false; // guard: reset if dispatch throws
  }
},
```

The flag suppresses exactly one `onRealtimeChange` call — the debounced one triggered by the programmatic `view.dispatch`. The catch block resets the flag if `view.dispatch` throws so future user-typed changes are never accidentally dropped.

---

## 12. Acceptance Criteria Mapping

| AC | File | Implementation |
|---|---|---|
| Dropdown opens on `/` | `useInstructionsSlashCommand` | `'/' in idle → 'items'` phase; `InstructionsSlashSuggestionList` renders |
| Only valid items shown | `InstructionsInput.mentionableItems` | Filtered via `useToolsValidationInfo`; misconfigured tools excluded |
| Toolkit/MCP tool second dropdown | `useInstructionsSlashCommand.selectItem` | Toolkit/MCP → `'tools'` phase; `MentionToolList` from `shared` |
| Toolkit/MCP format | `useInstructionsMention.onSelectTool` | `null` → `/name `; tool → `/name#toolName ` |
| Agent/Pipeline format | `useInstructionsMention.onSelectItem` | Inserts `/name ` directly |
| Mention at any cursor position | `useInstructionsSlashCommand.syncWithValue` | Uses `textToCursor = text.slice(0, cursorPos)` throughout |
| Full-screen modal tool list | `StyledInputModal.suppressRealtimeRef` | Suppresses the 30 ms debounced CodeMirror `notifyChange` after `replaceRange` |
| No error for non-matching | `InstructionsSlashSuggestionList` | Empty-state message; `syncWithValue` resets on backspace past anchor |
