### PR TITLE
fix: [EL-4660] Implement automatic token refresh for SharePoint toolkit using refresh tokens

### DIFF
--- a/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js
+++ b/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js
@@ -1,4 +1,5 @@
 import { McpAuthConstants } from '@/[fsd]/features/mcp/lib/constants';
+
 import { triggerProactiveRefresh } from './mcpAuthFlow.helpers';
 
 const REFRESH_CHECK_INTERVAL_MS = 60 * 1000; // Check for refresh needs every 60 seconds
@@ -7,7 +8,7 @@ const PROACTIVE_REFRESH_THRESHOLD = 0.75; // Refresh at 75% of token lifetime
 
 const pendingRefreshes = new Set();
 let lastRefreshCheckTime = 0;
-let refreshQueue = [];
+const refreshQueue = [];
 let isProcessingRefreshQueue = false;
 
 const safeParse = value => {
@@ -331,7 +332,7 @@ export const getServersNeedingRefresh = () => {
   return serversToRefresh;
 };
 
-const processRefreshQueue = async triggerProactiveRefresh => {
+const processRefreshQueue = async () => {
   if (isProcessingRefreshQueue || refreshQueue.length === 0) return;
 
   isProcessingRefreshQueue = true;
@@ -370,19 +371,20 @@ export const getAllTokens = () => {
   const tokens = loadTokens();
   const result = {};
 
-  // Collect valid tokens - BE expects Dict[str, Dict] (URL -> {access_token, session_id})
-  // session_id is important for maintaining stateful MCP connections
+  // Collect tokens - BE expects Dict[str, Dict] (URL -> {access_token, session_id, refresh_token})
+  // session_id is important for maintaining stateful MCP connections.
+  // Expired tokens that still have a refresh_token are included (access_token: null) so the
+  // BE can perform a token refresh before making API calls, without requiring re-authorization.
   Object.entries(tokens).forEach(([key, value]) => {
-    if (
-      !isExpired(value) &&
-      value?.access_token &&
-      value.access_token !== McpAuthConstants.MCP_CONNECTION_VERIFIED
-    ) {
-      result[key] = {
-        access_token: value.access_token,
-        session_id: value.session_id || null,
-      };
-    }
+    if (!value?.access_token || value.access_token === McpAuthConstants.MCP_CONNECTION_VERIFIED) return;
+    const expired = isExpired(value);
+    // Skip expired tokens that have no refresh_token — BE can't do anything with them
+    if (expired && !value.refresh_token) return;
+    result[key] = {
+      access_token: expired ? null : value.access_token,
+      session_id: expired ? null : value.session_id || null,
+      ...(value.refresh_token && { refresh_token: value.refresh_token }),
+    };
   });
 
   // Rate-limited refresh check
@@ -397,7 +399,7 @@ export const getAllTokens = () => {
   if (serversToRefresh.length > 0) {
     addToRefreshQueue(serversToRefresh);
 
-    processRefreshQueue(triggerProactiveRefresh);
+    processRefreshQueue();
   }
 
   return result;

--- a/src/[fsd]/features/mcp/ui/modal/McpAuthModal.jsx
+++ b/src/[fsd]/features/mcp/ui/modal/McpAuthModal.jsx
@@ -65,7 +65,7 @@ const McpAuthModal = memo(props => {
 
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
-  const [scope, setScope] = useState(convertScopes(scopes) || convertScopes(resourceScopes));
+  const [scope, setScope] = useState(convertScopes(resourceScopes) || convertScopes(scopes));
   const [authLoading, setAuthLoading] = useState(false);
   const [authError, setAuthError] = useState('');
   const [authSuccess, setAuthSuccess] = useState(false);
@@ -88,7 +88,7 @@ const McpAuthModal = memo(props => {
         setClientSecret('');
         setSaveCredentials(false);
       }
-      setScope(convertScopes(scopes) || convertScopes(resourceScopes));
+      setScope(convertScopes(resourceScopes) || convertScopes(scopes));
       setAuthError('');
       setAuthSuccess(false);
     }


### PR DESCRIPTION
# Implementation: Automatic Token Refresh for SharePoint Toolkit
## Issue: EliteaAI/elitea_issues#4660

**Title:** [Enhancement] Implement automatic token refresh for SharePoint toolkit using refresh tokens  
**Milestone:** R-2.0.3  
**Labels:** `eng:backend`, `feat:credentials`, `feat:toolkits`, `int:oauth`, `int:sharepoint`, `nfr:usability`

---

## 1. Problem Statement

The SharePoint toolkit (delegated OAuth flow) had the following issues:
- `offline_access` scope was never included in the Azure AD authorization request → Azure AD never returned `refresh_token`
- Frontend `McpAuthModal.jsx` had a scope precedence bug: user's configured `formScopes` (e.g. `["https://graph.microsoft.com/.default"]`) took precedence over backend-computed `resourceScopes` (which includes `offline_access`), so even after the backend started injecting `offline_access`, it was being discarded
- `getAllTokens()` excluded expired tokens entirely → backend never received `refresh_token` when access token was expired
- Write operations (`POST`, `DELETE`, file uploads, OneNote) had no 401-retry logic, unlike `GET` which already had it

---

## 2. System Architecture

### Token Flow (after fix)

```
User clicks Logon
    → McpAuthModal opens
    → scope state initialized from resourceScopes first (includes offline_access), fallback to formScopes
    → startMcpAuthFlow() builds authorization URL with offline_access in scope
    → Azure AD login popup
    → Authorization code returned
    → Frontend calls backend proxy: POST /api/v2/{project_id}/mcp_oauth (grant_type=authorization_code)
    → Backend calls Azure AD token endpoint
    → Token response: {access_token, refresh_token, expires_in}
    → Token stored in sessionStorage via McpAuthHelpers.setAccessToken() — includes refresh_token

Agent runs SharePoint tool:
    → getAllTokens() returns {url: {access_token, session_id, refresh_token}} for valid tokens
    → For expired tokens with refresh_token: {access_token: null, refresh_token: "..."}
    → mcp_tokens passed in message payload to backend
    → SDK extracts access_token + refresh_token from mcp_tokens for SharepointGraphWrapper
    → Graph API calls use access_token
    → On 401: _try_refresh_token() refreshes via Azure AD, retries the call
    → If refresh_token itself expired/invalid: McpAuthorizationRequired raised → user sees login prompt

Proactive refresh (background):
    → getAllTokens() called on every chat message send
    → needsProactiveRefresh() fires at 75% of token lifetime
    → triggerProactiveRefresh() → POST /mcp/oauth (grant_type=refresh_token) → new tokens stored
```

### Key Files

| File | Location | Role |
|------|----------|------|
| `SharepointConfiguration` | `elitea-sdk/elitea_sdk/configurations/sharepoint.py` | Credential model, auth flow metadata, `_build_mcp_authorization_required` |
| `SharepointToolkit.__init__` | `elitea-sdk/elitea_sdk/tools/sharepoint/__init__.py` | Token + refresh_token extraction, McpAuthorizationRequired guard |
| `SharepointApiWrapper` | `elitea-sdk/elitea_sdk/tools/sharepoint/api_wrapper.py` | Factory wrapper, selects backend |
| `SharepointGraphWrapper` | `elitea-sdk/elitea_sdk/tools/sharepoint/graph_wrapper.py` | Graph API calls, `_try_refresh_token()`, 401-retry |
| `mcp_oauth_proxy.py` | `elitea_core/api/v2/mcp_oauth_proxy.py` | Backend token exchange/refresh proxy |
| `McpAuthModal.jsx` | `EliteaUI/src/[fsd]/features/mcp/ui/modal/McpAuthModal.jsx` | OAuth login modal, scope state |
| `mcpAuth.helpers.js` | `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js` | Token storage, `getAllTokens()`, proactive refresh check |
| `mcpAuthFlow.helpers.js` | `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuthFlow.helpers.js` | OAuth flow, `triggerProactiveRefresh()` |

---

## 3. Changes Implemented

### Change 1 — Always inject `offline_access` into authorization scopes

**File:** `elitea-sdk/elitea_sdk/configurations/sharepoint.py`  
**Method:** `_build_mcp_authorization_required()`

`offline_access` is now unconditionally prepended to `effective_scopes` (previously was gated by `auto_refresh_token`). This ensures Azure AD always returns a `refresh_token` in the delegated OAuth flow.

```python
# Always inject offline_access — required for Azure AD to return refresh_token
effective_scopes = list(scopes or [])
if "offline_access" not in effective_scopes:
    effective_scopes.insert(0, "offline_access")
```

The `auto_refresh_token` field remains in the model and schema for UI display purposes.

---

### Change 2 — Fix scope precedence bug in `McpAuthModal.jsx`

**File:** `EliteaUI/src/[fsd]/features/mcp/ui/modal/McpAuthModal.jsx`

The `scope` state was initialized with `formScopes` taking precedence over `resourceScopes`. Since `formScopes` (user's configured scopes, e.g. `["https://graph.microsoft.com/.default"]`) is non-empty, `offline_access` from `resourceScopes` was discarded and never sent to Azure AD.

```javascript
// BEFORE (buggy):
const [scope, setScope] = useState(convertScopes(scopes) || convertScopes(resourceScopes));
// In useEffect:
setScope(convertScopes(scopes) || convertScopes(resourceScopes));

// AFTER (fixed):
const [scope, setScope] = useState(convertScopes(resourceScopes) || convertScopes(scopes));
// In useEffect:
setScope(convertScopes(resourceScopes) || convertScopes(scopes));
```

`resourceScopes` = `resource_metadata.scopes_supported` from the backend, which always includes `offline_access`. This is the authoritative scope list.

---

### Change 3 — Include expired tokens with `refresh_token` in `getAllTokens()`

**File:** `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js`  
**Function:** `getAllTokens()`

Previously, expired tokens were skipped entirely. This meant the backend never received `refresh_token` once the access token expired, making the backend 401-retry useless.

```javascript
// AFTER:
Object.entries(tokens).forEach(([key, value]) => {
  if (!value?.access_token || value.access_token === McpAuthConstants.MCP_CONNECTION_VERIFIED) return;
  const expired = isExpired(value);
  // Skip expired tokens with no refresh_token — BE can't do anything with them
  if (expired && !value.refresh_token) return;
  result[key] = {
    access_token: expired ? null : value.access_token,
    session_id: expired ? null : (value.session_id || null),
    ...(value.refresh_token && { refresh_token: value.refresh_token }),
  };
});
```

Behavior by case:
- **Valid token, has `refresh_token`**: sends `access_token` + `refresh_token` (same as before, plus `refresh_token`)
- **Valid token, no `refresh_token`**: sends `access_token` only (same as before)
- **Expired token, has `refresh_token`**: sends `access_token: null` + `refresh_token` → BE refreshes before use
- **Expired token, no `refresh_token`**: skipped (no point sending, BE can't help)
- **`MCP_CONNECTION_VERIFIED` marker**: skipped (unchanged)

---

### Change 4 — 401-retry for all write operations in `SharepointGraphWrapper`

**File:** `elitea-sdk/elitea_sdk/tools/sharepoint/graph_wrapper.py`

`_get()` and `_get_raw()` already had 401-retry. Added the same pattern to all write methods:

| Method | HTTP verb | Change |
|--------|-----------|--------|
| `_post()` | POST | On 401: `_try_refresh_token()` → retry |
| `_delete()` | DELETE | On 401: `_try_refresh_token()` → retry |
| `_upload_small_file()` | PUT | On 401: `_try_refresh_token()` → retry with fresh token |
| `_upload_large_file()` (each chunk) | PUT | On 401: `_try_refresh_token()` → retry chunk with fresh token |
| `onenote_create_page()` | POST | On 401: `_try_refresh_token()` → retry |
| `onenote_update_page()` | PATCH | On 401: `_try_refresh_token()` → retry |

`_try_refresh_token()` (pre-existing): POSTs `grant_type=refresh_token` to Azure AD using `self._refresh_token`. Updates `self._token` and `self._refresh_token` in memory. Returns `True` on success.

`self._refresh_token` is populated at toolkit initialization from `mcp_tokens[key].refresh_token` (via `__init__.py` Phase 2 wiring, pre-existing).

---

## 4. Acceptance Criteria Status

| # | Criterion | Status | Notes |
|---|-----------|--------|-------|
| 1 | `auto_refresh_token` checkbox in credential config | ✅ Pre-existing | Field exists in `SharepointConfiguration`, shown in "Delegated" subsection |
| 2 | OAuth request includes `offline_access` when enabled | ✅ Implemented | Now always included (Change 1), not gated by checkbox |
| 3 | `access_token` and `refresh_token` received and stored | ✅ Implemented | Change 1 + Change 2 together ensure Azure AD returns `refresh_token` |
| 4 | System detects expired/near-expiry tokens | ✅ Pre-existing | `needsProactiveRefresh()` at 75% of token lifetime |
| 5 | Automatic refresh using stored `refresh_token` | ✅ Pre-existing | `triggerProactiveRefresh()` → backend OAuth proxy |
| 6 | New token used for subsequent API calls without user interaction | ✅ Pre-existing | Fresh `access_token` returned to sessionStorage, sent in next request |
| 7 | Failed API requests retried after token refresh | ✅ Implemented | Change 3 (expired tokens send `refresh_token` to BE) + Change 4 (all write methods have 401-retry) |
| 8 | Re-authentication prompted when `refresh_token` is invalid/expired | ✅ Pre-existing | `refreshAccessToken()` calls `logout()` on failure → re-auth modal shown |
| 9 | Token refresh operations logged | ✅ Pre-existing | `logging.info("SharePoint: access token refreshed successfully via refresh_token")` |
| 10 | Works with scheduled tasks and long-running operations | ⚠️ Out of scope | Architectural gap — see below |

### AC #10 — Architectural Gap

Scheduled tasks run in a server-side background daemon thread (`scheduling/module.py`). They have no HTTP request context and no access to browser `sessionStorage`. OAuth tokens are ephemeral browser-side credentials sent per-request by the frontend.

`Schedule.run()` calls the RPC function with static `rpc_kwargs` frozen at schedule creation time — there is no injection point for current `mcp_tokens`. The scheduler has no user session to query tokens from.

**To support AC #10 properly would require a dedicated server-side token persistence feature:**
- After OAuth flow completes, persist `access_token` + `refresh_token` to the database (encrypted), keyed by `toolkit_id` + `user_id`
- Scheduled tasks look up tokens from the database and refresh as needed

This is out of scope for this story and requires a separate initiative.

---

## 5. Files Changed

### `elitea-sdk` repository

| File | Change |
|------|--------|
| `elitea_sdk/configurations/sharepoint.py` | Always inject `offline_access` into `effective_scopes` in `_build_mcp_authorization_required()` |
| `elitea_sdk/tools/sharepoint/graph_wrapper.py` | Add 401-retry to `_post()`, `_delete()`, `_upload_small_file()`, `_upload_large_file()` (chunks), `onenote_create_page()`, `onenote_update_page()` |

### `EliteaUI` repository

| File | Change |
|------|--------|
| `EliteaUI/src/[fsd]/features/mcp/ui/modal/McpAuthModal.jsx` | Fix scope precedence: `resourceScopes` before `formScopes` in both `useState` and `useEffect` |
| `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js` | `getAllTokens()` — include expired tokens with `refresh_token` (`access_token: null`) |

### No changes needed
- `elitea_core/api/v2/mcp_oauth_proxy.py` — already supports both `authorization_code` and `refresh_token` grant types
- `elitea_core/models/pd/mcp_oauth.py` — already has `refresh_token` field
- `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuthFlow.helpers.js` — proactive refresh already implemented
- `elitea_sdk/tools/sharepoint/__init__.py` — `refresh_token` extraction and forwarding to wrapper already implemented

---

## 6. Testing Notes

### Manual Test — Full Refresh Flow

1. Configure a SharePoint credential with `oauth_discovery_endpoint` set (delegated flow)
2. Click Logon — authenticate with a user account
3. Open browser DevTools → Application → Session Storage → find `mc_mcp_tokens`
4. Confirm the token entry has both `access_token` and `refresh_token` fields
5. Set token `expires_at` to a past timestamp (devtools hack to simulate expiry)
6. Send a chat message that invokes a SharePoint write operation (e.g. upload a file)
7. Verify: `getAllTokens()` sends `{access_token: null, refresh_token: "..."}` → backend `_try_refresh_token()` fires → operation retries and succeeds
8. Check backend logs for: `"SharePoint: access token refreshed successfully via refresh_token"`

### Manual Test — Proactive Refresh

1. Complete setup above, confirm `refresh_token` is in sessionStorage
2. Set `expires_at` to 80%+ of token lifetime (simulate near-expiry but not yet expired)
3. Wait 60 seconds (refresh check interval)
4. Observe `triggerProactiveRefresh` fires in the background
5. Run any SharePoint tool — confirm it succeeds with the refreshed token, no re-auth prompt
