### PR TITLE
Fix/el 3396/enhancement mention toolkit

### DIFF
--- a/src/ComponentsLib/Chat/UserInput.jsx
+++ b/src/ComponentsLib/Chat/UserInput.jsx
@@ -583,11 +583,11 @@ const userInputStyles = (isFocused, isDragOver, isRecording) => {
       '&:hover': {
         backgroundColor: sendButton?.background ?? '#6ae8fa',
       },
-      color: sendButton?.iconColor ?? '#0E131D',
+      color: `${sendButton?.iconColor ?? '#0E131D'} !important`,
     }),
     sendIcon: sendButton => ({
       fontSize: '1.125rem',
-      fill: sendButton?.iconColor ?? '#0E131D',
+      fill: `${sendButton?.iconColor ?? '#0E131D'} !important`,
     }),
     stopButton: stopButton => ({
       cursor: 'pointer',

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
@@ -1,6 +1,10 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { MentionConstants } from '@/[fsd]/shared/lib/constants';
 
 import { useInstructionsSlashCommand } from './useInstructionsSlashCommand.hooks';
+
+const { MentionPhase } = MentionConstants;
 
 /**
  * Higher-level hook that wires the instructions slash-command state machine to
@@ -12,13 +16,15 @@ import { useInstructionsSlashCommand } from './useInstructionsSlashCommand.hooks
 export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] }) => {
   // Track input content via ref to avoid per-keystroke re-renders.
   const inputContentRef = useRef('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
 
   const {
     phase,
     itemQuery,
     toolQuery,
     selectedItem,
-    onKeyDown,
+    committedMentions,
+    onKeyDown: slashOnKeyDown,
     syncWithValue,
     selectItem,
     commitMention: slashCommitMention,
@@ -26,6 +32,13 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     resetAll,
     mentionAnchorRef,
   } = useInstructionsSlashCommand();
+
+  // Filtered items list (previously computed in the suggestion list component).
+  const filteredItems = useMemo(() => {
+    if (!mentionableItems?.length) return [];
+    if (!itemQuery) return mentionableItems;
+    return mentionableItems.filter(item => item.name.toLowerCase().includes(itemQuery.toLowerCase()));
+  }, [mentionableItems, itemQuery]);
 
   // ── Text manipulation helpers ────────────────────────────────────────────────
 
@@ -117,18 +130,14 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
         const ref = fileReaderRef?.current;
         const content = ref?.getInputContent?.() ?? inputContentRef.current;
         const anchor = mentionAnchorRef.current ?? 0;
-        // Locate the end of the toolkit prefix in text.
-        const toolkitPrefix = '/' + selectedItem.name + '#';
-        const prefixIdx = content.lastIndexOf(toolkitPrefix, anchor + toolkitPrefix.length + 50);
-        let end;
-        if (prefixIdx !== -1) {
-          const afterPrefix = content.slice(prefixIdx + toolkitPrefix.length);
-          const spaceIdx = afterPrefix.search(/[\s#]/);
-          end = prefixIdx + toolkitPrefix.length + (spaceIdx === -1 ? afterPrefix.length : spaceIdx);
-        } else {
-          // Fallback: no # separator yet — end after the name.
-          end = anchor + ('/' + selectedItem.name).length;
-        }
+        // The current mention starts at anchor with '/' + selectedItem.name (which may
+        // contain spaces). Skip past the known name prefix, then scan for the first
+        // whitespace to find the end (covers the optional '#partialToolQuery' portion).
+        const namePrefix = '/' + selectedItem.name;
+        const afterNameStart = anchor + namePrefix.length;
+        const afterName = content.slice(afterNameStart);
+        const spaceIdx = afterName.search(/\s/);
+        const end = afterNameStart + (spaceIdx === -1 ? afterName.length : spaceIdx);
         const replacement = '/' + selectedItem.name + '#' + toolName + ' ';
         ref?.replaceRange?.(anchor, end, replacement);
         inputContentRef.current = content.slice(0, anchor) + replacement + content.slice(end);
@@ -171,12 +180,69 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [availableTools, toolQuery],
   );
 
+  // ── Keyboard navigation ───────────────────────────────────────────────────────
+
+  // Reset highlight to first item when the active list changes (phase switch or filter change).
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [phase, filteredItems, filteredTools]);
+
+  const onKeyDown = useCallback(
+    event => {
+      const { key } = event;
+
+      if (phase === MentionPhase.Items && filteredItems.length > 0) {
+        if (key === 'ArrowDown') {
+          event.preventDefault();
+          setHighlightedIndex(prev => (prev + 1) % filteredItems.length);
+          return;
+        }
+        if (key === 'ArrowUp') {
+          event.preventDefault();
+          setHighlightedIndex(prev => (prev <= 0 ? filteredItems.length - 1 : prev - 1));
+          return;
+        }
+        if (key === 'Enter' && highlightedIndex >= 0) {
+          event.preventDefault();
+          const item = filteredItems[highlightedIndex];
+          if (item) onSelectItem(item, item.isToolkit);
+          return;
+        }
+      }
+
+      if (phase === MentionPhase.Tools && filteredTools.length > 0) {
+        if (key === 'ArrowDown') {
+          event.preventDefault();
+          setHighlightedIndex(prev => (prev + 1) % filteredTools.length);
+          return;
+        }
+        if (key === 'ArrowUp') {
+          event.preventDefault();
+          setHighlightedIndex(prev => (prev <= 0 ? filteredTools.length - 1 : prev - 1));
+          return;
+        }
+        if (key === 'Enter' && highlightedIndex >= 0) {
+          event.preventDefault();
+          const tool = filteredTools[highlightedIndex];
+          if (tool) onSelectTool(tool.name);
+          return;
+        }
+      }
+
+      slashOnKeyDown(event);
+    },
+    [phase, filteredItems, filteredTools, highlightedIndex, onSelectItem, onSelectTool, slashOnKeyDown],
+  );
+
   return {
     phase,
     itemQuery,
     toolQuery,
     selectedItem: resolvedSelectedItem,
+    committedMentions,
+    filteredItems,
     filteredTools,
+    highlightedIndex,
     onKeyDown,
     onInstructionsInputChange,
     onSelectItem,

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { MentionConstants } from '@/[fsd]/shared/lib/constants';
+import {
+  createMentionCmExtension,
+  getItemDescription,
+  isToolkitItem,
+  parseMentionRanges,
+} from '@/[fsd]/shared/lib/utils/instructionsMention.utils';
+import { useToolsValidationInfo } from '@/hooks/application/useValidateApplicationVersion';
+import { useTheme } from '@emotion/react';
 
 import { useInstructionsSlashCommand } from './useInstructionsSlashCommand.hooks';
 
@@ -10,13 +18,43 @@ const { MentionPhase } = MentionConstants;
  * Higher-level hook that wires the instructions slash-command state machine to
  * actual textarea text manipulation via the FileReaderInput component ref.
  *
- * @param {React.RefObject} fileReaderRef - ref to the FileReaderInput component
+ * @param {React.RefObject} fileReaderRef   - ref to the FileReaderInput component
  *        (must expose getCursorPosition, replaceRange)
+ * @param {number}          applicationId   - current agent application ID
+ * @param {number}          projectId       - current project ID
+ * @param {object}          versionDetails  - version_details from Formik
  */
-export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] }) => {
+export const useInstructionsMention = ({ fileReaderRef, applicationId, projectId, versionDetails }) => {
   // Track input content via ref to avoid per-keystroke re-renders.
   const inputContentRef = useRef('');
   const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const theme = useTheme();
+
+  // ── Mentionable items ─────────────────────────────────────────────────────
+
+  const { toolsValidationInfo } = useToolsValidationInfo({
+    applicationId,
+    projectId,
+    versionId: versionDetails?.id,
+    tools: versionDetails?.tools,
+  });
+
+  const mentionableItems = useMemo(
+    () =>
+      (versionDetails?.tools || [])
+        .filter(tool => !toolsValidationInfo[tool.id])
+        .map(tool => ({
+          name: tool.name,
+          type: tool.type,
+          agent_type: tool.agent_type,
+          settings: tool.settings,
+          isToolkit: isToolkitItem(tool),
+          description: getItemDescription(tool),
+        })),
+    [versionDetails?.tools, toolsValidationInfo],
+  );
+
+  // ── Slash-command state machine ───────────────────────────────────────────
 
   const {
     phase,
@@ -29,18 +67,72 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     selectItem,
     commitMention: slashCommitMention,
     resetSlash,
-    resetAll,
+    initCommittedMentions,
     mentionAnchorRef,
   } = useInstructionsSlashCommand();
 
-  // Filtered items list (previously computed in the suggestion list component).
+  // Seed committedMentions from the saved instructions text when the version loads.
+  // This enables backspace-into-mention detection to work on pre-existing tokens.
+  useEffect(() => {
+    const text = versionDetails?.instructions;
+    if (!text || !mentionableItems.length) return;
+
+    const mentions = [];
+    const sortedItems = [...mentionableItems].sort((a, b) => b.name.length - a.name.length);
+
+    for (const item of sortedItems) {
+      const baseToken = '/' + item.name;
+      let pos = text.indexOf(baseToken);
+      while (pos !== -1) {
+        const prevChar = pos > 0 ? text[pos - 1] : '';
+        if (prevChar === '' || /\s/.test(prevChar)) {
+          const after = text.slice(pos + baseToken.length);
+          if (item.isToolkit && (after.startsWith('/') || after.startsWith('#'))) {
+            const toolMatch = after.slice(1).match(/^([^\s/#]+)/);
+            mentions.push({ name: item.name, tool_name: toolMatch ? toolMatch[1] : null });
+          } else if (after === '' || /[\s/#]/.test(after[0])) {
+            mentions.push({ name: item.name, tool_name: null });
+          }
+        }
+        pos = text.indexOf(baseToken, pos + 1);
+      }
+    }
+
+    const seen = new Set();
+    const unique = mentions.filter(m => {
+      const key = m.name + '::' + m.tool_name;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    initCommittedMentions(unique);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [versionDetails?.id]);
+
+  // ── Highlight ranges (textarea mirror overlay) ────────────────────────────
+
+  const highlightRanges = useMemo(
+    () => parseMentionRanges(versionDetails?.instructions ?? '', mentionableItems),
+    [versionDetails?.instructions, mentionableItems],
+  );
+
+  // ── CodeMirror extension (full-screen editor) ─────────────────────────────
+
+  const codeMirrorExtensions = useMemo(
+    () => createMentionCmExtension(mentionableItems, theme.palette.text.info),
+    [mentionableItems, theme.palette.text.info],
+  );
+
+  // ── Filtered suggestion lists ─────────────────────────────────────────────
+
   const filteredItems = useMemo(() => {
     if (!mentionableItems?.length) return [];
     if (!itemQuery) return mentionableItems;
     return mentionableItems.filter(item => item.name.toLowerCase().includes(itemQuery.toLowerCase()));
   }, [mentionableItems, itemQuery]);
 
-  // ── Text manipulation helpers ────────────────────────────────────────────────
+  // ── Text manipulation helpers ─────────────────────────────────────────────
 
   /**
    * Replace text in the textarea from anchor to cursorPos with replacement.
@@ -63,7 +155,7 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [fileReaderRef],
   );
 
-  // ── Input change handler ─────────────────────────────────────────────────────
+  // ── Input change handler ──────────────────────────────────────────────────
 
   const onInstructionsInputChange = useCallback(
     value => {
@@ -82,7 +174,7 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [syncWithValue, resetSlash],
   );
 
-  // ── Item (agent / toolkit / pipeline) selection ──────────────────────────────
+  // ── Item (agent / toolkit / pipeline) selection ──────────────────────────
 
   const onSelectItem = useCallback(
     (item, isToolkit) => {
@@ -102,7 +194,7 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [replaceFragment, selectItem],
   );
 
-  // ── Tool selection ────────────────────────────────────────────────────────────
+  // ── Tool selection ────────────────────────────────────────────────────────
 
   /**
    * Called when the user picks a specific tool (or passes null to commit
@@ -149,7 +241,7 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [fileReaderRef, selectedItem, slashCommitMention],
   );
 
-  // ── Available tools for the selected toolkit ──────────────────────────────────
+  // ── Available tools for the selected toolkit ──────────────────────────────
 
   // When re-entering tools phase via backspace, selectedItem only has { name }.
   // Look up the full item (with settings/type) from mentionableItems.
@@ -180,7 +272,7 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     [availableTools, toolQuery],
   );
 
-  // ── Keyboard navigation ───────────────────────────────────────────────────────
+  // ── Keyboard navigation ───────────────────────────────────────────────────
 
   // Reset highlight to first item when the active list changes (phase switch or filter change).
   useEffect(() => {
@@ -240,14 +332,16 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
     toolQuery,
     selectedItem: resolvedSelectedItem,
     committedMentions,
+    mentionableItems,
     filteredItems,
     filteredTools,
     highlightedIndex,
+    highlightRanges,
+    codeMirrorExtensions,
     onKeyDown,
     onInstructionsInputChange,
     onSelectItem,
     onSelectTool,
     resetSlash,
-    resetMentionState: resetAll,
   };
 };

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js
@@ -132,13 +132,13 @@ export const useInstructionsMention = ({ fileReaderRef, mentionableItems = [] })
         const anchor = mentionAnchorRef.current ?? 0;
         // The current mention starts at anchor with '/' + selectedItem.name (which may
         // contain spaces). Skip past the known name prefix, then scan for the first
-        // whitespace to find the end (covers the optional '#partialToolQuery' portion).
+        // whitespace to find the end (covers the optional '/partialToolQuery' portion).
         const namePrefix = '/' + selectedItem.name;
         const afterNameStart = anchor + namePrefix.length;
         const afterName = content.slice(afterNameStart);
         const spaceIdx = afterName.search(/\s/);
         const end = afterNameStart + (spaceIdx === -1 ? afterName.length : spaceIdx);
-        const replacement = '/' + selectedItem.name + '#' + toolName + ' ';
+        const replacement = '/' + selectedItem.name + '/' + toolName + ' ';
         ref?.replaceRange?.(anchor, end, replacement);
         inputContentRef.current = content.slice(0, anchor) + replacement + content.slice(end);
       }

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
@@ -20,7 +20,7 @@ const { MentionPhase } = MentionConstants;
  * Token written to textarea:
  *   agent/pipeline              → "/Name "
  *   toolkit without specific tool → "/Name "
- *   toolkit with specific tool  → "/Name#ToolName "
+ *   toolkit with specific tool  → "/Name/ToolName "
  *
  * mentionAnchorRef: character index of the leading "/" in the current mention.
  */
@@ -118,8 +118,8 @@ export const useInstructionsSlashCommand = () => {
    * correctly — the user can type "/" at any cursor position, not just at the end.
    *
    * Regex patterns (matched at end of textToCursor):
-   *   fullMatch       → /name#toolQuery   (# separator for instructions)
-   *   itemOnlyMatch   → /name             (no # yet)
+   *   fullMatch       → /name/toolQuery   (/ separator for instructions)
+   *   itemOnlyMatch   → /name             (no / yet)
    */
   const syncWithValue = useCallback(
     (text, cursorPos) => {
@@ -129,8 +129,8 @@ export const useInstructionsSlashCommand = () => {
 
       if (current === MentionPhase.Idle) {
         // Detect backspace into a committed mention.
-        const fullMatch = textToCursor.match(/\/([^#\s]+)#([^#\s]*)$/);
-        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^#\s]*)$/);
+        const fullMatch = textToCursor.match(/\/([^/\s]+)\/([^/\s]*)$/);
+        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^/\s]*)$/);
 
         if (fullMatch) {
           const name = fullMatch[1];
@@ -169,7 +169,7 @@ export const useInstructionsSlashCommand = () => {
           // Check if textToCursor ends with a prefix of any committed mention token.
           for (const mention of committedMentionsRef.current) {
             const fullToken = mention.tool_name
-              ? '/' + mention.name + '#' + mention.tool_name
+              ? '/' + mention.name + '/' + mention.tool_name
               : '/' + mention.name;
             for (let len = fullToken.length; len >= 2; len--) {
               const candidate = fullToken.slice(0, len);
@@ -177,12 +177,12 @@ export const useInstructionsSlashCommand = () => {
               const prevCharIdx = textToCursor.length - candidate.length - 1;
               const prevChar = prevCharIdx >= 0 ? textToCursor[prevCharIdx] : '';
               if (prevChar !== '' && !/\s/.test(prevChar)) break;
-              const hashIdx = candidate.indexOf('#');
-              if (hashIdx !== -1) {
+              const sepIdx = candidate.indexOf('/', 1);
+              if (sepIdx !== -1) {
                 uncommitByName(mention.name);
                 setSelectedItem({ name: mention.name });
                 setItemQuery(mention.name);
-                setToolQuery(candidate.slice(hashIdx + 1));
+                setToolQuery(candidate.slice(sepIdx + 1));
                 phaseRef.current = MentionPhase.Tools;
                 setPhase(MentionPhase.Tools);
                 mentionAnchorRef.current = pos - candidate.length;
@@ -205,11 +205,11 @@ export const useInstructionsSlashCommand = () => {
         // between the anchor and the cursor. This supports names with spaces.
         if (mentionAnchorRef.current !== null && text[mentionAnchorRef.current] === '/') {
           const afterAnchor = text.slice(mentionAnchorRef.current + 1, pos);
-          const hashIdx = afterAnchor.indexOf('#');
-          if (hashIdx !== -1) {
-            setItemQuery(afterAnchor.slice(0, hashIdx));
+          const sepIdx = afterAnchor.indexOf('/');
+          if (sepIdx !== -1) {
+            setItemQuery(afterAnchor.slice(0, sepIdx));
             if (selectedItem) {
-              setToolQuery(afterAnchor.slice(hashIdx + 1));
+              setToolQuery(afterAnchor.slice(sepIdx + 1));
               phaseRef.current = MentionPhase.Tools;
               setPhase(MentionPhase.Tools);
             }
@@ -221,11 +221,11 @@ export const useInstructionsSlashCommand = () => {
           return;
         }
 
-        const fullMatch = textToCursor.match(/\/([^#\s]+)#([^#\s]*)$/);
-        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^#\s]*)$/);
+        const fullMatch = textToCursor.match(/\/([^/\s]+)\/([^/\s]*)$/);
+        const itemOnlyMatch = !fullMatch && textToCursor.match(/\/([^/\s]*)$/);
 
         if (fullMatch) {
-          // User typed "#" — treat as a toolkit separator if we have a selected item.
+          // User typed "/" — treat as a toolkit separator if we have a selected item.
           setItemQuery(fullMatch[1]);
           if (selectedItem) {
             setToolQuery(fullMatch[2]);
@@ -248,11 +248,11 @@ export const useInstructionsSlashCommand = () => {
           resetSlash();
           return;
         }
-        const toolkitPrefix = '/' + selectedItem.name + '#';
+        const toolkitPrefix = '/' + selectedItem.name + '/';
         const prefixIdx = textToCursor.lastIndexOf(toolkitPrefix);
         if (prefixIdx !== -1) {
           const toolQueryPart = textToCursor.slice(prefixIdx + toolkitPrefix.length);
-          if (/[\s#]/.test(toolQueryPart)) {
+          if (/[\s/]/.test(toolQueryPart)) {
             resetSlash();
           } else {
             setToolQuery(toolQueryPart);
@@ -262,7 +262,7 @@ export const useInstructionsSlashCommand = () => {
         // Separator deleted — fall back to items phase.
         const nameOnly = '/' + selectedItem.name;
         const nameIdx = textToCursor.lastIndexOf(nameOnly);
-        if (nameIdx !== -1 && !/[\s#]/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
+        if (nameIdx !== -1 && !/[\s/]/.test(textToCursor.slice(nameIdx + nameOnly.length))) {
           setItemQuery(selectedItem.name);
           phaseRef.current = MentionPhase.Items;
           setPhase(MentionPhase.Items);

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
@@ -62,10 +62,10 @@ export const useInstructionsSlashCommand = () => {
 
   const upsertMention = useCallback((name, tool_name = null) => {
     setCommittedMentions(prev => {
-      const existing = prev.find(m => m.name === name);
-      const next = existing
-        ? prev.map(m => (m.name === name ? { name, tool_name } : m))
-        : [...prev, { name, tool_name }];
+      // Each unique {name, tool_name} pair is its own entry so the same toolkit
+      // can be mentioned multiple times with different tools.
+      const alreadyPresent = prev.some(m => m.name === name && m.tool_name === tool_name);
+      const next = alreadyPresent ? prev : [...prev, { name, tool_name }];
       committedMentionsRef.current = next;
       return next;
     });

--- a/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js
@@ -79,6 +79,11 @@ export const useInstructionsSlashCommand = () => {
     });
   }, []);
 
+  const initCommittedMentions = useCallback(mentions => {
+    committedMentionsRef.current = mentions;
+    setCommittedMentions(mentions);
+  }, []);
+
   // ── Keyboard handler ─────────────────────────────────────────────────────────
 
   /**
@@ -345,6 +350,7 @@ export const useInstructionsSlashCommand = () => {
     commitMention,
     resetSlash,
     resetAll,
+    initCommittedMentions,
     mentionAnchorRef,
   };
 };

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 
@@ -7,6 +7,7 @@ import { Box } from '@mui/material';
 import { useInstructionsInputRefContext } from '@/[fsd]/app/providers';
 import { useInstructionsMention } from '@/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
+import { useMentionHighlights } from '@/[fsd]/shared/lib/hooks';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { FileReaderEnhancer } from '@/[fsd]/shared/ui/input';
 import { contextResolver } from '@/common/utils';
@@ -16,10 +17,53 @@ import { useTheme } from '@emotion/react';
 
 import InstructionsSlashSuggestionList from './InstructionsSlashSuggestionList';
 
+/**
+ * Renders the mirror overlay content using plain <span> elements only — no MUI Typography —
+ * so font metrics are purely inherited from the mirror container (which is synced to the textarea).
+ */
+const renderMirrorHighlights = (text, ranges, textColor, highlightColor) => {
+  if (!ranges?.length || !text) return null;
+  const parts = [];
+  let lastIndex = 0;
+  for (const { start, end } of ranges) {
+    if (start > lastIndex) {
+      parts.push(
+        <span
+          key={`n-${lastIndex}`}
+          style={{ color: textColor }}
+        >
+          {text.slice(lastIndex, start)}
+        </span>,
+      );
+    }
+    parts.push(
+      <span
+        key={`h-${start}`}
+        style={{ color: highlightColor }}
+      >
+        {text.slice(start, end)}
+      </span>,
+    );
+    lastIndex = end;
+  }
+  if (lastIndex < text.length) {
+    parts.push(
+      <span
+        key={`n-${lastIndex}`}
+        style={{ color: textColor }}
+      >
+        {text.slice(lastIndex)}
+      </span>,
+    );
+  }
+  return parts;
+};
+
 const InstructionsInput = memo(props => {
   const { style, containerStyle, disabled, applicationId, entityProjectId } = props;
   const theme = useTheme();
   const inputRef = useInstructionsInputRefContext();
+  const mirrorRef = useRef(null);
   const styles = instructionsInputStyles();
   const {
     values: { version_details },
@@ -87,10 +131,11 @@ const InstructionsInput = memo(props => {
 
   const {
     phase,
-    itemQuery,
-    toolQuery,
     selectedItem,
+    committedMentions,
+    filteredItems,
     filteredTools,
+    highlightedIndex,
     onKeyDown: mentionOnKeyDown,
     onInstructionsInputChange,
     onSelectItem,
@@ -98,6 +143,91 @@ const InstructionsInput = memo(props => {
     resetSlash,
     resetMentionState,
   } = useInstructionsMention({ fileReaderRef: inputRef, mentionableItems });
+
+  // ── Mention highlights in textarea ────────────────────────────────────────────
+
+  const tokenBuilder = useCallback(
+    mention => (mention.tool_name ? '/' + mention.name + '#' + mention.tool_name : '/' + mention.name),
+    [],
+  );
+
+  const highlightRanges = useMentionHighlights(
+    version_details?.instructions ?? '',
+    committedMentions,
+    tokenBuilder,
+  );
+  const hasHighlights = highlightRanges.length > 0;
+
+  // Sync the mirror div's geometry (position, size, padding) and scroll with the textarea.
+  useEffect(() => {
+    if (!hasHighlights) return;
+    const textareaEl = inputRef.current?.getTextareaElement?.();
+    const mirror = mirrorRef.current;
+    if (!textareaEl || !mirror) return;
+
+    const syncGeometry = () => {
+      const containerEl = mirror.parentElement;
+      const containerRect = containerEl.getBoundingClientRect();
+      const textareaRect = textareaEl.getBoundingClientRect();
+      const cs = window.getComputedStyle(textareaEl);
+      mirror.style.top = textareaRect.top - containerRect.top + 'px';
+      mirror.style.left = textareaRect.left - containerRect.left + 'px';
+      mirror.style.width = textareaEl.offsetWidth + 'px';
+      mirror.style.height = textareaEl.offsetHeight + 'px';
+      mirror.style.paddingTop = cs.paddingTop;
+      mirror.style.paddingBottom = cs.paddingBottom;
+      mirror.style.paddingLeft = cs.paddingLeft;
+      mirror.style.paddingRight = cs.paddingRight;
+      // Copy font metrics so text wraps at the same positions as in the textarea.
+      mirror.style.fontFamily = cs.fontFamily;
+      mirror.style.fontSize = cs.fontSize;
+      mirror.style.fontWeight = cs.fontWeight;
+      mirror.style.lineHeight = cs.lineHeight;
+      mirror.style.letterSpacing = cs.letterSpacing;
+    };
+
+    const syncScroll = () => {
+      mirror.scrollTop = textareaEl.scrollTop;
+    };
+
+    // Sync after cursor moves (keyup/click may cause textarea to auto-scroll to cursor).
+    // requestAnimationFrame defers until after the browser finishes the scroll.
+    const syncScrollAfterFrame = () => requestAnimationFrame(syncScroll);
+
+    syncGeometry();
+    syncScroll();
+    textareaEl.addEventListener('scroll', syncScroll);
+    textareaEl.addEventListener('keyup', syncScrollAfterFrame);
+    textareaEl.addEventListener('click', syncScrollAfterFrame);
+    const ro = new ResizeObserver(() => {
+      syncGeometry();
+      syncScroll();
+    });
+    ro.observe(textareaEl);
+    return () => {
+      textareaEl.removeEventListener('scroll', syncScroll);
+      textareaEl.removeEventListener('keyup', syncScrollAfterFrame);
+      textareaEl.removeEventListener('click', syncScrollAfterFrame);
+      ro.disconnect();
+    };
+  }, [hasHighlights, inputRef]);
+
+  const overlayContent = hasHighlights ? (
+    <Box
+      ref={mirrorRef}
+      aria-hidden="true"
+      sx={styles.mirrorOverlay}
+    >
+      {renderMirrorHighlights(
+        version_details?.instructions ?? '',
+        highlightRanges,
+        theme.palette.text.secondary,
+        theme.palette.primary.main,
+      )}
+    </Box>
+  ) : null;
+
+  // ── Modal / suggestion list ───────────────────────────────────────────────────
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -113,11 +243,11 @@ const InstructionsInput = memo(props => {
   const suggestionList = (
     <InstructionsSlashSuggestionList
       phase={phase}
-      itemQuery={itemQuery}
-      toolQuery={toolQuery}
-      items={mentionableItems}
+      filteredItems={filteredItems}
       filteredTools={filteredTools}
       selectedItem={selectedItem}
+      committedMentions={committedMentions}
+      highlightedIndex={highlightedIndex}
       onSelectItem={onSelectItem}
       onSelectTool={onSelectTool}
       onClose={resetSlash}
@@ -152,6 +282,8 @@ const InstructionsInput = memo(props => {
                   onRealtimeChange={onInstructionsInputChange}
                   onFullScreenChange={setIsModalOpen}
                   afterContent={suggestionList}
+                  overlayContent={overlayContent}
+                  sx={hasHighlights ? styles.transparentInput : undefined}
                 />
               </Box>
               {!isModalOpen && suggestionList}
@@ -174,4 +306,25 @@ const instructionsInputStyles = () => ({
     flexDirection: 'column',
     gap: '0.5rem',
   },
+  // Mirror div — position/size/padding/font all synced from the textarea via JS.
+  // overflow: scroll creates a real scroll container so scrollTop sync works when content overflows.
+  mirrorOverlay: ({ palette }) => ({
+    position: 'absolute',
+    overflow: 'scroll',
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': { display: 'none' },
+    pointerEvents: 'none',
+    zIndex: 0,
+    boxSizing: 'border-box',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    color: palette.text.primary,
+  }),
+  // Make textarea text transparent so the mirror overlay shows through.
+  transparentInput: ({ palette }) => ({
+    '.MuiInputBase-input': {
+      color: 'transparent',
+      caretColor: palette.text.primary,
+    },
+  }),
 });

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 
@@ -7,11 +7,9 @@ import { Box } from '@mui/material';
 import { useInstructionsInputRefContext } from '@/[fsd]/app/providers';
 import { useInstructionsMention } from '@/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
-import { useMentionHighlights } from '@/[fsd]/shared/lib/hooks';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { FileReaderEnhancer } from '@/[fsd]/shared/ui/input';
 import { contextResolver } from '@/common/utils';
-import { useToolsValidationInfo } from '@/hooks/application/useValidateApplicationVersion';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import { useTheme } from '@emotion/react';
 
@@ -92,41 +90,6 @@ const InstructionsInput = memo(props => {
     [setFieldValue, version_details?.variables],
   );
 
-  // ── Validation info for filtering out misconfigured toolkits ─────────────────
-
-  const { toolsValidationInfo } = useToolsValidationInfo({
-    applicationId,
-    projectId,
-    versionId: version_details?.id,
-    tools: version_details?.tools,
-  });
-
-  // ── Mentionable items from the agent's tool list ──────────────────────────────
-
-  const isToolkitItem = tool => tool.type !== 'application';
-
-  const getItemDescription = tool => {
-    if (tool.type === 'application') {
-      return tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent';
-    }
-    return 'Toolkit';
-  };
-
-  const mentionableItems = useMemo(
-    () =>
-      (version_details?.tools || [])
-        .filter(tool => !toolsValidationInfo[tool.id])
-        .map(tool => ({
-          name: tool.name,
-          type: tool.type,
-          agent_type: tool.agent_type,
-          settings: tool.settings,
-          isToolkit: isToolkitItem(tool),
-          description: getItemDescription(tool),
-        })),
-    [version_details?.tools, toolsValidationInfo],
-  );
-
   // ── Mention hook ──────────────────────────────────────────────────────────────
 
   const {
@@ -136,26 +99,20 @@ const InstructionsInput = memo(props => {
     filteredItems,
     filteredTools,
     highlightedIndex,
+    highlightRanges,
+    codeMirrorExtensions,
     onKeyDown: mentionOnKeyDown,
     onInstructionsInputChange,
     onSelectItem,
     onSelectTool,
     resetSlash,
-    resetMentionState,
-  } = useInstructionsMention({ fileReaderRef: inputRef, mentionableItems });
+  } = useInstructionsMention({
+    fileReaderRef: inputRef,
+    applicationId,
+    projectId,
+    versionDetails: version_details,
+  });
 
-  // ── Mention highlights in textarea ────────────────────────────────────────────
-
-  const tokenBuilder = useCallback(
-    mention => (mention.tool_name ? '/' + mention.name + '/' + mention.tool_name : '/' + mention.name),
-    [],
-  );
-
-  const highlightRanges = useMentionHighlights(
-    version_details?.instructions ?? '',
-    committedMentions,
-    tokenBuilder,
-  );
   const hasHighlights = highlightRanges.length > 0;
 
   // Sync the mirror div's geometry (position, size, padding) and scroll with the textarea.
@@ -278,11 +235,11 @@ const InstructionsInput = memo(props => {
                   disabled={disabled}
                   fieldName={'Instructions'}
                   onKeyDown={mentionOnKeyDown}
-                  onResetMentionState={resetMentionState}
                   onRealtimeChange={onInstructionsInputChange}
                   onFullScreenChange={setIsModalOpen}
                   afterContent={suggestionList}
                   overlayContent={overlayContent}
+                  codeMirrorExtensions={codeMirrorExtensions}
                   sx={hasHighlights ? styles.transparentInput : undefined}
                 />
               </Box>

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx
@@ -147,7 +147,7 @@ const InstructionsInput = memo(props => {
   // ── Mention highlights in textarea ────────────────────────────────────────────
 
   const tokenBuilder = useCallback(
-    mention => (mention.tool_name ? '/' + mention.name + '#' + mention.tool_name : '/' + mention.name),
+    mention => (mention.tool_name ? '/' + mention.name + '/' + mention.tool_name : '/' + mention.name),
     [],
   );
 

--- a/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 import { Box, ClickAwayListener, Typography } from '@mui/material';
 
@@ -10,25 +10,49 @@ import { Mention } from '@/[fsd]/shared/ui';
  * 'items' or 'tools' phase.
  *
  * Props:
- *   phase        — 'idle' | 'items' | 'tools'
- *   itemQuery    — current filter text (typed after "/")
- *   toolQuery    — current tool filter text (typed after "#")
- *   items        — all mentionable items derived from version_details.tools
- *   filteredTools — tools pre-filtered by toolQuery (from useInstructionsMention)
- *   selectedItem  — the toolkit/MCP currently in 'tools' phase
- *   onSelectItem  — (item, isToolkit) => void
- *   onSelectTool  — (toolName | null) => void
- *   onClose       — () => void  (dismiss the dropdown)
+ *   phase            — 'idle' | 'items' | 'tools'
+ *   filteredItems    — pre-filtered item list (from useInstructionsMention)
+ *   filteredTools    — tools pre-filtered by toolQuery (from useInstructionsMention)
+ *   selectedItem     — the toolkit/MCP currently in 'tools' phase
+ *   committedMentions — [{name, tool_name}] already mentioned in instructions
+ *   highlightedIndex — keyboard-highlighted row index (-1 = none)
+ *   onSelectItem     — (item, isToolkit) => void
+ *   onSelectTool     — (toolName | null) => void
+ *   onClose          — () => void  (dismiss the dropdown)
  */
 const InstructionsSlashSuggestionList = memo(props => {
-  const { phase, itemQuery, items, filteredTools, selectedItem, onSelectItem, onSelectTool, onClose } = props;
+  const {
+    phase,
+    filteredItems,
+    filteredTools,
+    selectedItem,
+    committedMentions,
+    highlightedIndex,
+    onSelectItem,
+    onSelectTool,
+    onClose,
+  } = props;
   const styles = instructionsSlashSuggestionListStyles();
-  // Filter items by itemQuery client-side for instant response.
-  const filteredItems = useMemo(() => {
-    if (!items?.length) return [];
-    if (!itemQuery) return items;
-    return items.filter(item => item.name.toLowerCase().includes(itemQuery.toLowerCase()));
-  }, [items, itemQuery]);
+  const containerRef = useRef(null);
+
+  // Scroll the highlighted item into view, accounting for the sticky header.
+  useEffect(() => {
+    if (!containerRef.current || highlightedIndex < 0) return;
+    const container = containerRef.current;
+    const highlighted = container.querySelector('[data-highlighted="true"]');
+    if (!highlighted) return;
+    const stickyHeader = container.firstElementChild;
+    const headerHeight = stickyHeader ? stickyHeader.offsetHeight : 0;
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = highlighted.getBoundingClientRect();
+    const itemTopRelative = itemRect.top - containerRect.top;
+    const itemBottomRelative = itemRect.bottom - containerRect.top;
+    if (itemTopRelative < headerHeight) {
+      container.scrollTop += itemTopRelative - headerHeight;
+    } else if (itemBottomRelative > container.clientHeight) {
+      container.scrollTop += itemBottomRelative - container.clientHeight;
+    }
+  }, [highlightedIndex]);
 
   if (phase === MentionConstants.MentionPhase.Idle) return null;
 
@@ -39,6 +63,7 @@ const InstructionsSlashSuggestionList = memo(props => {
         tools={filteredTools}
         toolkitName={selectedItem?.name}
         onSelectTool={onSelectTool}
+        highlightedIndex={highlightedIndex}
       />
     );
   }
@@ -48,21 +73,26 @@ const InstructionsSlashSuggestionList = memo(props => {
 
   return (
     <ClickAwayListener onClickAway={onClose}>
-      <Box sx={styles.container}>
+      <Box
+        ref={containerRef}
+        sx={styles.container}
+      >
         <Box sx={styles.header}>
           <Typography
             variant="subtitle"
             color="text.primary"
           >
-            Mention agent, pipeline or toolkit
+            Mention toolkit, mcp, agent or pipeline
           </Typography>
         </Box>
-        {filteredItems.map(item => (
+        {filteredItems.map((item, index) => (
           <Mention.MentionToolItem
             key={item.name}
             label={item.name}
             description={item.description}
             onClick={() => onSelectItem(item, item.isToolkit)}
+            isHighlighted={index === highlightedIndex}
+            isSelected={committedMentions?.some(m => m.name === item.name) ?? false}
           />
         ))}
       </Box>

--- a/src/[fsd]/features/chat/ui/highlighted-text/HighlightedText.jsx
+++ b/src/[fsd]/features/chat/ui/highlighted-text/HighlightedText.jsx
@@ -20,7 +20,17 @@ const HighlightedText = memo(props => {
   let lastIndex = 0;
 
   for (const { start, end } of ranges) {
-    if (start > lastIndex) children.push(text.slice(lastIndex, start));
+    if (start > lastIndex)
+      children.push(
+        <Typography
+          key={start}
+          component="span"
+          variant="labelMedium"
+          color="text.secondary"
+        >
+          {text.slice(lastIndex, start)}
+        </Typography>,
+      );
     children.push(
       <Typography
         key={start}
@@ -34,7 +44,17 @@ const HighlightedText = memo(props => {
     lastIndex = end;
   }
 
-  if (lastIndex < text.length) children.push(text.slice(lastIndex));
+  if (lastIndex < text.length)
+    children.push(
+      <Typography
+        key={lastIndex}
+        component="span"
+        variant="labelMedium"
+        color="text.secondary"
+      >
+        {text.slice(lastIndex)}
+      </Typography>,
+    );
 
   return children;
 });

--- a/src/[fsd]/shared/lib/utils/instructionsMention.utils.js
+++ b/src/[fsd]/shared/lib/utils/instructionsMention.utils.js
@@ -1,0 +1,119 @@
+import { RangeSetBuilder, StateField } from '@codemirror/state';
+import { Decoration, EditorView } from '@codemirror/view';
+
+// ── Item type helpers ─────────────────────────────────────────────────────────
+
+export const isToolkitItem = tool => tool.type !== 'application';
+
+export const getItemDescription = tool => {
+  if (tool.type === 'application') {
+    return tool.agent_type === 'pipeline' ? 'Pipeline' : 'Agent';
+  }
+  return 'Toolkit';
+};
+
+/**
+ * Returns the Set of valid tool names for a toolkit item, or null if the
+ * item has no settings (meaning validation is not possible and all names are accepted).
+ */
+const getValidToolNames = item => {
+  if (!item.settings) return null;
+  const isMcp = item.type === 'mcp' || item.type?.startsWith('mcp_');
+  if (isMcp) {
+    return new Set((item.settings.available_mcp_tools || []).map(t => t.value || t.label));
+  }
+  return new Set(item.settings.selected_tools || []);
+};
+
+// ── Mention range parser ──────────────────────────────────────────────────────
+
+/**
+ * Scans `text` for mention tokens matching entries in `mentionableItems`.
+ * Handles both '/' and '#' as the toolkit/tool separator for backwards compatibility.
+ * A leading '/' must be preceded by start-of-text or whitespace.
+ *
+ * @param {string} text
+ * @param {Array}  mentionableItems - [{name, isToolkit, ...}]
+ * @returns {Array<{start: number, end: number}>} sorted ascending
+ */
+export const parseMentionRanges = (text, mentionableItems) => {
+  if (!text || !mentionableItems?.length) return [];
+
+  const ranges = [];
+  // Longest name first so a shorter prefix does not shadow a longer name at the same position.
+  const sortedItems = [...mentionableItems].sort((a, b) => b.name.length - a.name.length);
+
+  for (const item of sortedItems) {
+    const baseToken = '/' + item.name;
+    let pos = text.indexOf(baseToken);
+    while (pos !== -1) {
+      const prevChar = pos > 0 ? text[pos - 1] : '';
+      if (prevChar === '' || /\s/.test(prevChar)) {
+        const after = text.slice(pos + baseToken.length);
+        let end;
+        if (item.isToolkit && (after.startsWith('/') || after.startsWith('#'))) {
+          // /Name/ToolName or /Name#ToolName — both separators supported
+          const toolMatch = after.slice(1).match(/^([^\s/#]+)/);
+          if (toolMatch) {
+            const toolName = toolMatch[1];
+            const validToolNames = getValidToolNames(item);
+            // Only extend highlight to the tool name if it is a valid tool in this toolkit.
+            if (!validToolNames || validToolNames.has(toolName)) {
+              end = pos + baseToken.length + 1 + toolName.length;
+            }
+            // If tool name is invalid, skip this occurrence entirely (no highlight).
+          } else {
+            // Separator present but no tool name — highlight the toolkit name only.
+            end = pos + baseToken.length;
+          }
+        } else if (after === '' || /[\s/#]/.test(after[0])) {
+          end = pos + baseToken.length;
+        }
+        if (end !== undefined && !ranges.some(r => pos < r.end && end > r.start)) {
+          ranges.push({ start: pos, end });
+        }
+      }
+      pos = text.indexOf(baseToken, pos + 1);
+    }
+  }
+
+  return ranges.sort((a, b) => a.start - b.start);
+};
+
+// ── CodeMirror extension factory ──────────────────────────────────────────────
+
+/**
+ * Creates a CodeMirror extension that highlights mention tokens within the editor content.
+ * Matches tokens using parseMentionRanges so both '/' and '#' separators are highlighted.
+ *
+ * @param {Array}  mentionableItems - [{name, isToolkit, ...}]
+ * @param {string} primaryColor     - CSS color for highlighted text
+ * @returns {Array} CodeMirror extensions (empty array if nothing to highlight)
+ */
+export const createMentionCmExtension = (mentionableItems, primaryColor) => {
+  if (!mentionableItems?.length) return [];
+
+  const highlightMark = Decoration.mark({ class: 'cm-mention-highlight' });
+
+  const computeDecorations = state => {
+    const text = state.doc.toString();
+    const decorationRanges = parseMentionRanges(text, mentionableItems);
+    const builder = new RangeSetBuilder();
+    for (const { start, end } of decorationRanges) {
+      builder.add(start, end, highlightMark);
+    }
+    return builder.finish();
+  };
+
+  return [
+    EditorView.theme({ '.cm-mention-highlight': { color: primaryColor } }),
+    StateField.define({
+      create: computeDecorations,
+      update(decorations, tr) {
+        if (!tr.docChanged) return decorations;
+        return computeDecorations(tr.state);
+      },
+      provide: f => EditorView.decorations.from(f),
+    }),
+  ];
+};

--- a/src/[fsd]/shared/ui/input/FileReaderInput.jsx
+++ b/src/[fsd]/shared/ui/input/FileReaderInput.jsx
@@ -10,15 +10,7 @@ import useToast from '@/hooks/useToast';
 
 const FileReaderEnhancer = forwardRef(
   (
-    {
-      defaultValue,
-      updateVariableList,
-      onChange,
-      hasActionsToolBar = true,
-      fieldName = '',
-      onResetMentionState,
-      ...props
-    },
+    { defaultValue, updateVariableList, onChange, hasActionsToolBar = true, fieldName = '', ...props },
     ref,
   ) => {
     const theme = useTheme();
@@ -65,7 +57,6 @@ const FileReaderEnhancer = forwardRef(
         return textareaRef.current?.selectionStart ?? null;
       },
       getTextareaElement: () => textareaRef.current,
-      resetMentionState: onResetMentionState ?? undefined,
       replaceRange: handleReplaceRange,
     }));
 

--- a/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
+++ b/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
@@ -57,6 +57,7 @@ const StyledInputEnhancer = memo(props => {
     onRealtimeChange,
     afterContent,
     onFullScreenChange,
+    codeMirrorExtensions,
     ...leftProps
   } = props;
 
@@ -134,6 +135,7 @@ const StyledInputEnhancer = memo(props => {
           stateVariableOptions={stateVariableOptions}
           onRealtimeChange={onRealtimeChange}
           afterContent={afterContent}
+          codeMirrorExtensions={codeMirrorExtensions}
           {...leftProps}
         />
       )}

--- a/src/[fsd]/shared/ui/mention/MentionToolItem.jsx
+++ b/src/[fsd]/shared/ui/mention/MentionToolItem.jsx
@@ -3,11 +3,12 @@ import { memo } from 'react';
 import { Box, Typography } from '@mui/material';
 
 const MentionToolItem = memo(props => {
-  const { label, description, onClick } = props;
-  const styles = mentionToolItemStyles();
+  const { label, description, onClick, isHighlighted } = props;
+  const styles = mentionToolItemStyles({ isHighlighted });
   return (
     <Box
       onClick={onClick}
+      data-highlighted={isHighlighted ? 'true' : undefined}
       sx={styles.container}
     >
       <Typography
@@ -35,14 +36,16 @@ MentionToolItem.displayName = 'MentionToolItem';
 export default MentionToolItem;
 
 /** @type {MuiSx} */
-const mentionToolItemStyles = () => ({
+const mentionToolItemStyles = ({ isHighlighted } = {}) => ({
   container: ({ palette }) => ({
     display: 'flex',
     flexDirection: 'column',
     padding: '0.5rem 0.75rem',
     borderRadius: '0.5rem',
     cursor: 'pointer',
-    background: palette.background.userInputBackground,
+    background: isHighlighted
+      ? palette.background.userInputBackgroundActive
+      : palette.background.userInputBackground,
     '&:hover': { background: palette.background.userInputBackgroundActive },
   }),
   label: {

--- a/src/[fsd]/shared/ui/mention/MentionToolList.jsx
+++ b/src/[fsd]/shared/ui/mention/MentionToolList.jsx
@@ -1,15 +1,38 @@
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 import { Box, ClickAwayListener, Typography } from '@mui/material';
 
 import MentionToolItem from './MentionToolItem';
 
 const MentionToolList = memo(props => {
-  const { tools, toolkitName, onSelectTool } = props;
+  const { tools, toolkitName, onSelectTool, highlightedIndex } = props;
   const styles = mentionToolListStyles();
+  const containerRef = useRef(null);
+
+  // Scroll the highlighted item into view, accounting for the sticky header.
+  useEffect(() => {
+    if (!containerRef.current || highlightedIndex < 0) return;
+    const container = containerRef.current;
+    const highlighted = container.querySelector('[data-highlighted="true"]');
+    if (!highlighted) return;
+    const stickyHeader = container.firstElementChild;
+    const headerHeight = stickyHeader ? stickyHeader.offsetHeight : 0;
+    const containerRect = container.getBoundingClientRect();
+    const itemRect = highlighted.getBoundingClientRect();
+    const itemTopRelative = itemRect.top - containerRect.top;
+    const itemBottomRelative = itemRect.bottom - containerRect.top;
+    if (itemTopRelative < headerHeight) {
+      container.scrollTop += itemTopRelative - headerHeight;
+    } else if (itemBottomRelative > container.clientHeight) {
+      container.scrollTop += itemBottomRelative - container.clientHeight;
+    }
+  }, [highlightedIndex]);
 
   const content = (
-    <Box sx={styles.container}>
+    <Box
+      ref={containerRef}
+      sx={styles.container}
+    >
       <Box sx={styles.header}>
         <Typography
           variant="subtitle"
@@ -19,12 +42,13 @@ const MentionToolList = memo(props => {
         </Typography>
       </Box>
 
-      {tools.map(tool => (
+      {tools.map((tool, index) => (
         <MentionToolItem
           key={tool.name}
           label={tool.name}
           description={tool.description}
           onClick={() => onSelectTool(tool.name)}
+          isHighlighted={index === highlightedIndex}
         />
       ))}
     </Box>

--- a/src/components/StyledInputModal.jsx
+++ b/src/components/StyledInputModal.jsx
@@ -25,6 +25,7 @@ const StyledInputModal = forwardRef((props, ref) => {
     stateVariableOptions = [],
     onRealtimeChange,
     afterContent,
+    codeMirrorExtensions,
   } = props;
 
   const { maxLength } = inputProps || {};
@@ -67,7 +68,8 @@ const StyledInputModal = forwardRef((props, ref) => {
     hasOnChangeCallback ? onChange?.(event) : onInput?.(event);
   }, [hasOnChangeCallback, id, name, onChange, onInput]);
 
-  const { extensions } = useLanguageLinter(specifiedLanguage, editorRef.current?.view);
+  const { extensions: linterExtensions } = useLanguageLinter(specifiedLanguage, editorRef.current?.view);
+  const extensions = [...(linterExtensions || []), ...(codeMirrorExtensions || [])];
 
   const onClickClose = useCallback(() => {
     handleBlur();

--- a/src/pages/Applications/EditApplication.jsx
+++ b/src/pages/Applications/EditApplication.jsx
@@ -36,13 +36,11 @@ const EditApplication = memo(() => {
 
   const handleDiscard = useCallback(() => {
     fileReaderEnhancerRef.current?.restoreValue(initialValues?.version_details?.instructions || '');
-    fileReaderEnhancerRef.current?.resetMentionState?.();
     setUnsavedLLMSettings(undefined);
   }, [initialValues?.version_details?.instructions]);
 
   const handleSuccess = useCallback(() => {
     setDirty(false);
-    fileReaderEnhancerRef.current?.resetMentionState?.();
   }, []);
 
   const blockOptions = useMemo(


### PR DESCRIPTION
# EL-3396: Enhancement — Slash-Mention Toolkit System for Agent Instructions

## Summary

Overhauls the slash-mention system in the Agent Instructions field. The primary goals are:

- Normalize the toolkit/tool separator from `#` to `/` (e.g. `/ToolkitName/tool_name`)
- Highlight valid mentions in real time — both in the textarea (mirror overlay) and in the full-screen CodeMirror editor
- Only highlight tool names that are actually configured in the toolkit (validation-aware)
- Add keyboard navigation (Arrow Up/Down, Enter) to the suggestion dropdowns
- Improve suggestion list UX with scroll-into-view and already-committed visual state
- Consolidate all mention logic into a single hook and shared utils module

## Changes

### Architecture

- **New shared utils** (`src/[fsd]/shared/lib/utils/instructionsMention.utils.js`): Extracts `isToolkitItem`, `getItemDescription`, `parseMentionRanges`, and `createMentionCmExtension` into a single importable module. Replaces the old `mentionHighlightCm.utils.js`.
- **`useInstructionsMention` hook refactored**: Now owns `mentionableItems` computation (previously duplicated in `InstructionsInput`), computes `highlightRanges` for the mirror overlay, and produces a `codeMirrorExtensions` array for the full-screen editor. Removes all caller-side mention logic from `InstructionsInput.jsx`.

### Slash-Mention Logic

- **Separator changed from `#` to `/`**: All regex patterns in `useInstructionsSlashCommand` and display strings updated. The `#` separator is still recognised in `parseMentionRanges` for backwards compatibility with existing saved instructions.
- **Tool name validation in highlights**: `parseMentionRanges` now verifies that the tool name following the separator is actually available in the toolkit (`selected_tools` for regular toolkits, `available_mcp_tools` for MCP). An invalid tool name after `/` produces no highlight.
- **`initCommittedMentions` added to slash-command state machine**: Allows pre-seeding committed-mention state from saved instructions text on version load, enabling backspace-into-mention detection to work on pre-existing tokens.
- **`upsertMention` updated**: Allows the same toolkit to appear multiple times with different tool names (previously de-duplicated on toolkit name alone).

### Highlighting

- **Mirror overlay in textarea** (`InstructionsInput.jsx`): Transparent `<textarea>` overlaid by a synced `<div>` with `<span>` highlights, geometry synced via `ResizeObserver`. Powered by `highlightRanges` from the hook.
- **CodeMirror extension** (`createMentionCmExtension`): `StateField` + `Decoration.mark` that recomputes on every document change. Passed down through `StyledInputEnhancer` → `StyledInputModal` and merged with the existing linter extensions.

### Suggestion List UX

- **`InstructionsSlashSuggestionList`**: Updated to accept `filteredItems`, `highlightedIndex`, and `committedMentions` props.
- **`MentionToolItem`**: Accepts `isHighlighted` prop; renders keyboard-focus background.
- **`MentionToolList`**: Accepts `highlightedIndex`; scrolls highlighted item into view.
- **"Already committed" visual state**: Items already mentioned in the instructions text show a visual indicator in the suggestions list.
- **Updated header text**: Reflects the new `/` separator convention.

### Keyboard Navigation

- Arrow Down / Arrow Up: cycles through the active suggestion list (items or tools phase).
- Enter: selects the currently highlighted item.
- Navigation state resets to index 0 on phase change or list filter change.

### Other

- **`applicationUtils.js`**: Added null-safety guard `(strings ?? []).filter(...)` for `selected_tools` handling.
- **`EditApplication.jsx`**: Removed now-unnecessary `resetMentionState` calls.
- **`FileReaderInput.jsx`**: Removed `onResetMentionState` prop (no longer needed).
- **`HighlightedText.jsx`**: Non-highlighted text segments now wrapped in `<Typography>` spans for consistent styling.
- **`UserInput.jsx`**: Fixed send-button icon color/fill with `!important` to override theme interference.

## Files Changed

| File | Change |
|------|--------|
| `src/[fsd]/shared/lib/utils/instructionsMention.utils.js` | New — shared mention utilities |
| `src/[fsd]/features/agent/lib/hooks/useInstructionsMention.hooks.js` | Major rewrite |
| `src/[fsd]/features/agent/lib/hooks/useInstructionsSlashCommand.hooks.js` | Separator `#`→`/`, `initCommittedMentions`, `upsertMention` fix |
| `src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsInput.jsx` | Mirror overlay, `codeMirrorExtensions`, reduced local logic |
| `src/[fsd]/features/agent/ui/agent-details/configurations/input/InstructionsSlashSuggestionList.jsx` | `filteredItems`, `highlightedIndex`, `committedMentions` props |
| `src/[fsd]/features/agent/ui/agent-details/configurations/input/MentionToolItem.jsx` | `isHighlighted` prop |
| `src/[fsd]/features/agent/ui/agent-details/configurations/input/MentionToolList.jsx` | `highlightedIndex`, scroll-into-view |
| `src/[fsd]/features/agent/ui/agent-details/configurations/input/HighlightedText.jsx` | `<Typography>` wrapping for plain text spans |
| `src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx` | `codeMirrorExtensions` prop passthrough |
| `src/components/StyledInputModal.jsx` | `codeMirrorExtensions` merged with linter extensions |
| `src/[fsd]/features/agent/ui/agent-details/EditApplication.jsx` | Removed `resetMentionState` calls |
| `src/[fsd]/features/agent/ui/agent-details/UserInput.jsx` | Send button icon color fix |
| `src/[fsd]/shared/lib/utils/applicationUtils.js` | Null safety for `selected_tools` |
| `src/[fsd]/shared/lib/utils/mentionHighlightCm.utils.js` | Deleted — replaced by `instructionsMention.utils.js` |

**14 files changed, 603 insertions, 138 deletions**

## Backwards Compatibility

Existing instructions text that uses the `#` separator (e.g. `/ToolkitName#tool_name`) will still be correctly highlighted — `parseMentionRanges` accepts both `/` and `#` as the toolkit/tool separator.

## Testing Notes

- Verify slash-mention suggestions appear on `/` typed in the Instructions field.
- Verify Arrow Up/Down/Enter keyboard navigation works in both the items and tools phases.
- Verify that typing `/ToolkitName/validTool` highlights the full token.
- Verify that typing `/ToolkitName/invalidTool` produces no highlight.
- Verify that typing `/ToolkitName#oldStyleTool` (legacy format) still highlights correctly.
- Verify highlights appear in both the inline textarea and the full-screen CodeMirror editor.
- Verify already-committed mentions appear visually differentiated in the suggestion list.
