### PR TITLE
fix: [EL-4987] Removed the icon raising

### DIFF
--- a/src/[fsd]/shared/ui/tooltip/InfoTooltip.jsx
+++ b/src/[fsd]/shared/ui/tooltip/InfoTooltip.jsx
@@ -123,7 +123,6 @@ const infoTooltipStyles = () => ({
     height: '100%',
     position: 'relative',
     cursor: 'pointer',
-    bottom: '0.25rem',
     overflow: 'visible',
     '& :hover': { opacity: 0.8 },
   },


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4987
<img width="207" height="184" alt="image" src="https://github.com/user-attachments/assets/fda8f41c-9679-4315-ab6b-f65fe69f4793" />
