### PR TITLE
fix: [EL-4989] Fixed padding for select field

### DIFF
--- a/src/[fsd]/shared/ui/select/singleSelectVariants.js
+++ b/src/[fsd]/shared/ui/select/singleSelectVariants.js
@@ -102,8 +102,7 @@ export const getSingleSelectShowBorderSx = theme => {
     },
     verticalAlign: 'bottom',
     '& .MuiInputBase-root.MuiInput-root': {
-      padding: '0.75rem',
-      marginTop: '1.25rem',
+      padding: '0 0.75rem',
     },
     '& label, & label.Mui-error, .MuiFormLabel-asterisk.Mui-error': {
       color: colors.default.label.color,


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4989

BEFORE
<img width="2010" height="1060" alt="image" src="https://github.com/user-attachments/assets/13332635-c356-4754-8185-25a0920d795b" />

AFTER
<img width="573" height="182" alt="Screenshot 2026-05-21 231323" src="https://github.com/user-attachments/assets/d664f3b1-52c6-4918-babb-305975bd2f6d" />
