### PR TITLE
fix: [EL-4941] chat agent editing error message

### DIFF
--- a/src/hooks/application/useSaveVersion.js
+++ b/src/hooks/application/useSaveVersion.js
@@ -56,7 +56,7 @@ const useSaveVersion = () => {
 
   const onSave = useCallback(async () => {
     if ((await onSaveTools()) === false) {
-      return; // Stop if toolkit save failed
+      return false; // Stop if toolkit save failed
     }
     const { nodes, edges } = isFromPipeline
       ? calculateNodesAndEdges(yamlCode, ORIENTATION.vertical, flowNodes)
@@ -105,45 +105,52 @@ const useSaveVersion = () => {
         },
       },
     });
-    const cloneData = deepClone(data);
+    reset();
+
     if (error) {
       toastError(buildErrorMessage(error));
-    } else {
-      toastSuccess(`The ${isFromPipeline ? 'pipeline' : 'agent'} has been updated`);
-      dispatch(
-        eliteaApi.util.updateQueryData('applicationDetails', { applicationId, projectId }, () => {
-          return {
-            ...cloneData,
-          };
-        }),
-      );
-      const savedVersionDetails = {
-        ...version_details,
-        instructions: !isFromPipeline ? version_details.instructions : yamlCode,
-      };
-      dispatch(
-        eliteaApi.util.updateQueryData(
-          'getApplicationVersionDetail',
-          { applicationId, projectId, versionId: version_details?.id },
-          () => {
-            return {
-              ...savedVersionDetails, // Please note that update application API always returns the base version details, so we need to use the version details from the form which is the selected one.
-            };
-          },
-        ),
-      );
-      // Only update URL name if NOT in chat (name should remain conversation name in chat)
-      if (!isFromChat) {
-        handleChangeName(name);
-      }
-      resetForm?.({
-        values: {
-          ...cloneData,
-          version_details: savedVersionDetails, // Please note that update application API always returns the base version details, so we need to use the version details from the form which is the selected one.
-        },
-      });
+      return false;
     }
-    reset();
+
+    const cloneData = deepClone(data);
+    toastSuccess(`The ${isFromPipeline ? 'pipeline' : 'agent'} has been updated`);
+    dispatch(
+      eliteaApi.util.updateQueryData('applicationDetails', { applicationId, projectId }, () => {
+        return {
+          ...cloneData,
+        };
+      }),
+    );
+    // savedVersionDetails uses cleanedLlmSettings so downstream callers (e.g. entity_settings PUT)
+    // send llm_settings that exactly match what was stored in DB, avoiding the validation mismatch.
+    const savedVersionDetails = {
+      ...version_details,
+      llm_settings: cleanedLlmSettings,
+      instructions: !isFromPipeline ? version_details.instructions : yamlCode,
+    };
+    dispatch(
+      eliteaApi.util.updateQueryData(
+        'getApplicationVersionDetail',
+        { applicationId, projectId, versionId: version_details?.id },
+        () => {
+          return {
+            ...savedVersionDetails, // Please note that update application API always returns the base version details, so we need to use the version details from the form which is the selected one.
+          };
+        },
+      ),
+    );
+    // Only update URL name if NOT in chat (name should remain conversation name in chat)
+    if (!isFromChat) {
+      handleChangeName(name);
+    }
+    resetForm?.({
+      values: {
+        ...cloneData,
+        version_details: savedVersionDetails, // Please note that update application API always returns the base version details, so we need to use the version details from the form which is the selected one.
+      },
+    });
+
+    return savedVersionDetails;
   }, [
     onSaveTools,
     isFromPipeline,

--- a/src/hooks/chat/useEditAgent.js
+++ b/src/hooks/chat/useEditAgent.js
@@ -91,6 +91,9 @@ const useEditAgent = ({ activeParticipant, setActiveParticipant, onChangePartici
             variables: syncedKeysVariables,
             // Update version_id to reflect the saved version
             version_id: savedData.version_details?.id || activeParticipant.entity_settings?.version_id,
+            // Always use the saved version's llm_settings to avoid carrying forward stale overrides
+            // from a prior version context (e.g., published version llm_settings on an unpublished version)
+            llm_settings: savedData.version_details?.llm_settings,
           },
         };
 

--- a/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
+++ b/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
@@ -25,9 +25,11 @@ export default function SaveApplicationButton({ onSuccess }) {
 
   // Enhanced save function with callback support
   const handleSave = useCallback(async () => {
-    await onSave();
-    // Call the success callback with the current form values
-    onSuccess?.(values);
+    // onSave returns savedVersionDetails (with cleaned llm_settings) on success, false on failure
+    const savedVersionDetails = await onSave();
+    if (savedVersionDetails) {
+      onSuccess?.({ ...values, version_details: savedVersionDetails });
+    }
   }, [onSave, onSuccess, values]);
 
   // Check if there are validation errors in state variables (cached in Redux)


### PR DESCRIPTION
 Root cause: useSaveVersion.onSave() saved to DB with cleanedLlmSettings (e.g.,           
  reasoning_effort removed for unsupported models), but then SaveApplicationButton passed  
  the pre-save Formik values (with raw/uncleaned llm_settings) to onSuccess.               
  handleAgentSaved then used those raw llm_settings to build entity_settings, and the      
  backend compared them against what was actually in DB — they differed → 400.             
                                                                                           
  Fix:                                                                                     
  1. useSaveVersion.onSave(): uses cleanedLlmSettings in savedVersionDetails (aligning     
  cache + Formik reset with what was actually saved to DB), then returns                   
  savedVersionDetails directly instead of a boolean                     
  2. SaveApplicationButton.handleSave(): uses the returned savedVersionDetails to build    
  savedData passed to onSuccess, ensuring version_details.llm_settings matches what's in DB
                                                                                           
  Now handleAgentSaved receives savedData with version_details.llm_settings = 
  cleanedLlmSettings, which exactly matches the DB baseline, so the backend validation     
  passes and llm_settings gets stripped cleanly.  