### PR TITLE
fix: [EL-4978] show  internal tools in pipeline editor on chat page

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
@@ -11,10 +11,8 @@ import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import { useAvailableInternalTools } from '@/[fsd]/shared/lib/hooks';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { markAllDuplicatesByMultipleKeys } from '@/common/utils';
-import { useIsFrom } from '@/hooks/useIsFromSpecificPageHooks';
 import ToolCard from '@/pages/Applications/Components/Tools/ToolCard';
 import ToolMenu from '@/pages/Applications/Components/Tools/ToolMenu';
-import RouteDefinitions from '@/routes';
 
 const ApplicationTools = memo(props => {
   const {
@@ -25,10 +23,9 @@ const ApplicationTools = memo(props => {
     title = 'Toolkits',
     hidePythonSandbox = false,
     entityProjectId,
+    isPipeline = false,
   } = props;
   const sortedToolsRef = useRef(null);
-
-  const isFromPipeline = useIsFrom(RouteDefinitions.Pipelines);
 
   const { values } = useFormikContext();
   const { toolkitSchemas } = useGetCurrentToolkitSchemas();
@@ -87,12 +84,11 @@ const ApplicationTools = memo(props => {
 
   // For pipeline pages show only the attachments card; for agent pages show all available tools.
   const pipelineVisibleTools = useMemo(
-    () =>
-      isFromPipeline ? sortedInternalTools.filter(t => t.name === 'attachments') : displayedInternalTools,
-    [isFromPipeline, sortedInternalTools, displayedInternalTools],
+    () => (isPipeline ? sortedInternalTools.filter(t => t.name === 'attachments') : displayedInternalTools),
+    [isPipeline, sortedInternalTools, displayedInternalTools],
   );
 
-  const shouldShowInternalTools = isFromPipeline
+  const shouldShowInternalTools = isPipeline
     ? pipelineVisibleTools.length > 0
     : !hidePythonSandbox && sortedInternalTools.length > 0;
 
@@ -153,7 +149,7 @@ const ApplicationTools = memo(props => {
                       />
                     ))}
                   </Box>
-                  {!isFromPipeline && canToggleTools && (
+                  {!isPipeline && canToggleTools && (
                     <Box sx={styles.showMoreContainer}>
                       <Typography
                         onClick={() => setShowAllInternalTools(!showAllInternalTools)}

--- a/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
+++ b/src/pages/Applications/Components/Applications/PipelineConfigurationForm.jsx
@@ -30,6 +30,7 @@ const PipelineConfigurationForm = memo(props => {
         title={'Toolkits'}
         style={styles.applicationTools}
         applicationId={applicationId}
+        isPipeline
         disabled={isDisabled}
         hidePythonSandbox={hidePythonSandbox}
         onAttachmentToolChange={onAttachmentToolChange}


### PR DESCRIPTION
<img width="1276" height="888" alt="image" src="https://github.com/user-attachments/assets/525356f6-3ea8-4218-8838-dff910c36d61" />
<img width="1276" height="888" alt="image" src="https://github.com/user-attachments/assets/6e347fbe-9e36-462b-aea8-a212ae952349" />
<img width="1276" height="888" alt="image" src="https://github.com/user-attachments/assets/85d3b8ea-a99b-488c-aeb5-35444103cbea" />


## Summary

Fixes pipeline configuration on the chat page so the Internal Tools section is shown the same way it is on the
pipeline page.

## Root Cause

`ApplicationTools` determined whether it was rendering a pipeline by checking the current route. That worked
on the dedicated pipeline page, but failed inside the chat page because the pipeline editor is mounted under a
chat URL.

As a result, the shared configuration component did not enter pipeline mode and the pipeline-specific Internal
Tools block was not rendered there.

## Changes

- Replace route-based pipeline detection in `ApplicationTools` with an explicit `isPipeline` prop.
- Pass `isPipeline` from `PipelineConfigurationForm` so pipeline behavior is preserved wherever the form is
  mounted.
- Keep the existing pipeline behavior of showing only the attachments internal tool and hiding the generic
  "Show all / Show less" control.

## Result

- The pipeline page keeps the current Internal Tools behavior.
- The chat page pipeline editor now shows the same Internal Tools section for pipelines.



