### PR TITLE
fix: [EL-0000] Fixed ui issues of applications page

### DIFF
--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
@@ -90,7 +90,10 @@ const ApplicationCatalog = memo(() => {
           cardDetails={
             <Box sx={styles.cardDetails}>
               <Box>
-                <Typography sx={styles.cardDescription}>{application.shortDescription}</Typography>
+                <Typography sx={styles.cardDescription}>
+                  <Box component="b">Use it to: </Box>
+                  {application.shortDescription}
+                </Typography>
                 <Box sx={styles.additionalDescription}>
                   <Typography sx={styles.cardDescription}>
                     <Box component="b">Includes: </Box>

--- a/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
+++ b/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
@@ -3,6 +3,8 @@ import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import { Box } from '@mui/material';
+
 import { AuthorInformation } from '@/[fsd]/entities/author/ui';
 import { EmptyStatePage } from '@/[fsd]/entities/empty-state-page';
 import { useLoadToolkits } from '@/[fsd]/features/toolkits/lib/hooks';
@@ -20,7 +22,6 @@ import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 import RouteDefinitions from '@/routes';
 import { actions as tagsActions } from '@/slices/tags';
-import { rightInfoPanelStyle } from '@/styles/RightInfoPanelStyle';
 
 const ToolkitsList = memo(props => {
   const {
@@ -32,7 +33,7 @@ const ToolkitsList = memo(props => {
     isApplication = false,
   } = props;
   const navigate = useNavigate();
-  const styles = getStyles();
+  const styles = toolkitsListStyles();
   const { selectedTypes } = useTypes();
   const dispatch = useDispatch();
   const { query } = useSelector(state => state.search);
@@ -74,7 +75,7 @@ const ToolkitsList = memo(props => {
 
   const rightPanelContent = useMemo(
     () => (
-      <div style={rightInfoPanelStyle}>
+      <Box style={styles.rightInfoPanelContainer}>
         <ToolkitTypesPanel
           tagList={tagList}
           title="Types"
@@ -85,9 +86,9 @@ const ToolkitsList = memo(props => {
         ) : (
           <TeamMates entityType="toolkit" />
         )}
-      </div>
+      </Box>
     ),
-    [tagList, styles.rightInfoPanel, selectedProjectId, privateProjectId, authorId, isLoadingAuthor],
+    [tagList, styles, selectedProjectId, privateProjectId, authorId, isLoadingAuthor],
   );
 
   // Navigate to New Toolkit page for private projects with no toolkits
@@ -226,8 +227,13 @@ const ToolkitsList = memo(props => {
 });
 
 /** @type {MuiSx} */
-const getStyles = () => ({
+const toolkitsListStyles = () => ({
   rightInfoPanel: { flex: 1 },
+  rightInfoPanelContainer: {
+    height: '100dvh',
+    display: 'flex',
+    flexDirection: 'column',
+  },
 });
 
 ToolkitsList.displayName = 'ToolkitsList';


### PR DESCRIPTION
Kate`s request

## Summary

| Where | What | Why |
|-------|------|-----|
| ToolkitsList.jsx:78 | Changed `<div style={rightInfoPanelStyle}>` to `<Box style={styles.rightInfoPanelContainer}>` | **Main fix:** Replaced shared style import with local component styles |
| ToolkitsList.jsx:230-234 | Added `rightInfoPanelContainer` style with `height: '100dvh'` | **Main fix:** Uses modern `dvh` unit instead of `calc(100vh - 70px)` for better mobile viewport handling |
| ToolkitsList.jsx:6 | Added `Box` import from MUI | Needed for new JSX element |
| ToolkitsList.jsx:23 | Removed `rightInfoPanelStyle` import | Cleanup: no longer needed after refactoring |
| ToolkitsList.jsx:36 | Renamed `getStyles()` to `toolkitsListStyles()` | Consistency: more descriptive function name |
| ApplicationCatalog.jsx:93-95 | Added `<Box component="b">Use it to: </Box>` prefix to shortDescription | Enhancement: Adds context label before application description |

**Root cause:** The right panel height was using a hardcoded `calc(100vh - 70px)` from a shared style file, which didn't adapt well to different viewport sizes. Refactored to use local styles with `100dvh` (dynamic viewport height) for better cross-device compatibility. Secondary change adds "Use it to:" label for clarity in app catalog cards.

<img width="664" height="428" alt="Screenshot 2026-05-22 150239" src="https://github.com/user-attachments/assets/e62b53d0-eee6-46e9-8479-9736a3fba2f8" />

**BEFORE**
<img width="1512" height="757" alt="image (22)" src="https://github.com/user-attachments/assets/617ebaa9-3739-4f5a-a77d-92ad7c440d9e" />

**AFTER**
<img width="1242" height="942" alt="image" src="https://github.com/user-attachments/assets/291cc42c-ab73-42e2-acff-ed1064d631b4" />

