### PR TITLE
fix: [EL-5105] disable voice input when chat is speaking mode

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
@@ -91,10 +91,15 @@ const ToolBase = memo(props => {
       sectionProps,
       enableEditEliteaTitle,
     );
-    setToolErrors(prev => ({
-      ...prev,
-      ...requiredPropertiesError,
-    }));
+    setToolErrors(prev => {
+      const merged = { ...prev };
+      Object.entries(requiredPropertiesError).forEach(([key, value]) => {
+        if (value === false || typeof prev[key] !== 'string') {
+          merged[key] = value;
+        }
+      });
+      return merged;
+    });
   }, [
     schema?.required,
     settings,

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -368,7 +368,7 @@ const NewChatInput = forwardRef((props, ref) => {
         },
       }}
       clearInputAfterSend={clearInputAfterSubmit}
-      disabledSend={disabledSend}
+      disabledSend={disabledSend || isRecording}
       disabledInput={isLoading}
       onSend={handleSend}
       onNormalKeyDown={onNormalKeyDown}


### PR DESCRIPTION
- disable voice input when chat is speaking mode
- keep tool validation error when it's a string error which means the validation error is not a required prop missing error