### PR TITLE
fix: [EL-5023] SharePoint Credentials — Mandatory Auto-Refresh Token Prevents Saving Edited

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolSection.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolSection.jsx
@@ -27,6 +27,7 @@ const ToolSection = memo(props => {
     disableConfigFields = false,
     disabled,
     validationErrorMessages,
+    checkboxAsteriskRequired = true,
   } = props;
 
   const styles = sectionStyles();
@@ -199,14 +200,19 @@ const ToolSection = memo(props => {
   useEffect(() => {
     if (required) {
       const requiredPropertiesError = {};
-      fields.forEach(field => (requiredPropertiesError[field] = !settings[field]));
+      fields.forEach(field => {
+        const propSchema = schema?.properties?.[field];
+        const isBooleanField =
+          propSchema?.type === 'boolean' || propSchema?.anyOf?.some(item => item.type === 'boolean');
+        requiredPropertiesError[field] = isBooleanField ? false : !settings[field];
+      });
       notSelectedFields.forEach(field => (requiredPropertiesError[field] = false));
       setToolErrors(prevState => ({
         ...prevState,
         ...requiredPropertiesError,
       }));
     }
-  }, [setToolErrors, settings, required, fields, notSelectedFields, selectedOption]);
+  }, [setToolErrors, settings, required, fields, notSelectedFields, selectedOption, schema?.properties]);
 
   // For disabled fields (especially for auth section), handle differently
   if (disableConfigFields) {
@@ -283,7 +289,10 @@ const ToolSection = memo(props => {
         />
       </Box>
       {sectionProps.map(([k, v]) => {
-        const isRequired = showOnlyConfigurationFields ? !showOnlyConfigurationFields : required;
+        const isBooleanField = v?.type === 'boolean' || v?.anyOf?.some(item => item.type === 'boolean');
+        const isRequired = showOnlyConfigurationFields
+          ? !showOnlyConfigurationFields
+          : required && !(isBooleanField && !checkboxAsteriskRequired);
         return (
           <ToolkitForm.ToolBaseProperty
             key={k}


### PR DESCRIPTION
# Fix: SharePoint Auto-Refresh Token Blocks Save When Unchecked

**Issue**: EliteaAI/elitea_issues#5023  
**Label**: `eng:frontend`

---

## Root Cause

Two bugs in `ToolSection.jsx` cause this issue.

### Bug 1 — Save button disabled when checkbox is unchecked

**File**: `EliteaUI/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolSection.jsx`  
**Lines**: 199–209

```js
useEffect(() => {
  if (required) {
    const requiredPropertiesError = {};
    fields.forEach(field => (requiredPropertiesError[field] = !settings[field]));  // ← BUG
    notSelectedFields.forEach(field => (requiredPropertiesError[field] = false));
    setToolErrors(prevState => ({ ...prevState, ...requiredPropertiesError }));
  }
}, [setToolErrors, settings, required, fields, notSelectedFields, selectedOption]);
```

The validation does `!settings[field]` for every field. For the boolean `auto_refresh_token`:
- When **checked** → `settings.auto_refresh_token = true` → `!true = false` → no error ✓
- When **unchecked** → `settings.auto_refresh_token = false` → `!false = true` → error set → Save disabled ✗

The Pydantic model generates `auto_refresh_token` as `anyOf: [{type: boolean}, {type: null}]` (because it is `Optional[bool]`), so `propSchema.type` is undefined — not `"boolean"`. The existing `validateRequiredFields` helper in `toolBase.helpers.js:126` already handles this correctly but it is **not used** in `ToolSection`'s effect.

### Bug 2 — Asterisk shown on the checkbox

**File**: `ToolSection.jsx` line 286, 298

```jsx
const isRequired = showOnlyConfigurationFields ? !showOnlyConfigurationFields : required;
// ...
<ToolkitForm.ToolBaseProperty
  required={isRequired}  // ← passes true for ALL fields when section.required === true
```

`checkboxAsteriskRequired={false}` is passed from `CredentialForm` → `ToolBase` → `ToolSection` (via `ToolBase.jsx:429`) but `ToolSection` **never destructures or uses it**, so boolean fields always receive `required={true}` and show an asterisk.

---

## Fix

### `ToolSection.jsx` — two changes

**Change 1**: In the validation `useEffect`, skip boolean fields (same logic as `validateRequiredFields` helper).

```js
// Before (line 202):
fields.forEach(field => (requiredPropertiesError[field] = !settings[field]));

// After:
fields.forEach(field => {
  const propSchema = schema?.properties?.[field];
  const isBooleanField =
    propSchema?.type === 'boolean' ||
    propSchema?.anyOf?.some(item => item.type === 'boolean');
  requiredPropertiesError[field] = isBooleanField ? false : !settings[field];
});
```

**Change 2**: Destructure `checkboxAsteriskRequired` from props and use it to suppress the asterisk on boolean fields.

```jsx
// Add to props destructuring (line ~12):
checkboxAsteriskRequired = true,

// In the sectionProps.map render (line ~286):
const isBooleanField =
  v?.type === 'boolean' || v?.anyOf?.some(item => item.type === 'boolean');
const isRequired =
  showOnlyConfigurationFields
    ? !showOnlyConfigurationFields
    : required && !(isBooleanField && !checkboxAsteriskRequired);

// Pass to ToolBaseProperty:
required={isRequired}
```

---

## Files to Change

| File | Location |
|------|----------|
| `EliteaUI/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolSection.jsx` | Props destructuring, validation `useEffect`, `sectionProps.map` render |

---

## Full Diff

### `ToolSection.jsx`

```diff
 const ToolSection = memo(props => {
   const {
     sectionKey,
     subsections,
     required,
     schema = { properties: {} },
     showValidation,
     toolErrors,
     settings,
     editField,
     handleInputChange,
     setToolErrors,
     setEditToolDetail,
     setNotSelectedFields,
     specifiedProjectId,
     showOnlyConfigurationFields = false,
     disableConfigFields = false,
     disabled,
     validationErrorMessages,
+    checkboxAsteriskRequired = true,
   } = props;
```

```diff
   useEffect(() => {
     if (required) {
       const requiredPropertiesError = {};
-      fields.forEach(field => (requiredPropertiesError[field] = !settings[field]));
+      fields.forEach(field => {
+        const propSchema = schema?.properties?.[field];
+        const isBooleanField =
+          propSchema?.type === 'boolean' ||
+          propSchema?.anyOf?.some(item => item.type === 'boolean');
+        requiredPropertiesError[field] = isBooleanField ? false : !settings[field];
+      });
       notSelectedFields.forEach(field => (requiredPropertiesError[field] = false));
       setToolErrors(prevState => ({
         ...prevState,
         ...requiredPropertiesError,
       }));
     }
   }, [setToolErrors, settings, required, fields, notSelectedFields, selectedOption]);
```

```diff
     {sectionProps.map(([k, v]) => {
-      const isRequired = showOnlyConfigurationFields ? !showOnlyConfigurationFields : required;
+      const isBooleanField =
+        v?.type === 'boolean' || v?.anyOf?.some(item => item.type === 'boolean');
+      const isRequired =
+        showOnlyConfigurationFields
+          ? !showOnlyConfigurationFields
+          : required && !(isBooleanField && !checkboxAsteriskRequired);
       return (
         <ToolkitForm.ToolBaseProperty
           key={k}
           k={k}
           v={v}
           theme={theme}
           showValidation={showValidation}
           toolErrors={toolErrors}
           settings={settings}
           editField={editField}
           handleInputChange={handleInputChange}
           required={isRequired}
```

---

## Why This Is Safe

- The fix only affects boolean fields (`type === 'boolean'` or `anyOf` containing boolean).
- Non-boolean required fields in sections are validated exactly as before.
- `checkboxAsteriskRequired` already defaults to `true`, so behaviour for all other toolkits is unchanged.
- The `CredentialForm` already passes `checkboxAsteriskRequired={false}`, which is what triggers the asterisk suppression for SharePoint credentials.
