### PR TITLE
feat: [EL-4963] Enhance a display of limit behavior for welcome message and conversations starte

### DIFF
--- a/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
+++ b/src/[fsd]/shared/ui/input/StyledInputEnhancer.jsx
@@ -58,6 +58,7 @@ const StyledInputEnhancer = memo(props => {
     afterContent,
     onFullScreenChange,
     codeMirrorExtensions,
+    showCharacterCounter,
     ...leftProps
   } = props;
 
@@ -136,6 +137,7 @@ const StyledInputEnhancer = memo(props => {
           onRealtimeChange={onRealtimeChange}
           afterContent={afterContent}
           codeMirrorExtensions={codeMirrorExtensions}
+          showCharacterCounter={showCharacterCounter}
           {...leftProps}
         />
       )}

--- a/src/[fsd]/shared/ui/text/CharacterCounter.jsx
+++ b/src/[fsd]/shared/ui/text/CharacterCounter.jsx
@@ -1,0 +1,22 @@
+import { memo } from 'react';
+
+import { Box, Typography } from '@mui/material';
+
+const CharacterCounter = memo(props => {
+  const { value, maxLength, textVariant = 'bodySmall' } = props;
+  const remaining = maxLength - value.length;
+  const isAtLimit = remaining === 0;
+
+  return (
+    <Box sx={({ palette }) => ({ color: isAtLimit ? palette.error.main : palette.secondary.main })}>
+      <Typography variant={textVariant}>
+        {`${remaining} characters left`}
+        {isAtLimit && '. You have reached the MAXIMUM character limit'}
+      </Typography>
+    </Box>
+  );
+});
+
+CharacterCounter.displayName = 'CharacterCounter';
+
+export default CharacterCounter;

--- a/src/[fsd]/shared/ui/text/index.js
+++ b/src/[fsd]/shared/ui/text/index.js
@@ -1,3 +1,4 @@
 export { default as AnimatedLoadingText } from './AnimatedLoadingText';
-export { default as TextWithLink } from './TextWithLink';
+export { default as CharacterCounter } from './CharacterCounter';
 export { default as EllipsisTypography } from './EllipsisTypography';
+export { default as TextWithLink } from './TextWithLink';

--- a/src/components/ConversationStarters.jsx
+++ b/src/components/ConversationStarters.jsx
@@ -9,7 +9,7 @@ import { conversationStartersHelpers } from '@/[fsd]/features/agent/lib/helpers'
 import { AGENT_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
-import { Input } from '@/[fsd]/shared/ui';
+import { Input, Text } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import PlusIcon from '@/assets/plus-icon.svg?react';
@@ -127,17 +127,16 @@ const ConversationStarters = memo(props => {
                         disabled={disabled}
                         fieldName="Conversation starter"
                         inputProps={{ maxLength: MAX_CONVERSATION_STARTER_LENGTH }}
+                        showCharacterCounter
                         inputRef={el => (inputRefs.current[index] = el)}
                         error={hasStarterError}
                         helperText={hasStarterError ? 'Conversation starter cannot be empty' : undefined}
                       />
                       {isFocused(starterFocusId) && value.length > 0 && (
-                        <Typography
-                          variant="bodySmall"
-                          sx={styles.characterCount}
-                        >
-                          {`${MAX_CONVERSATION_STARTER_LENGTH - value.length} characters left`}
-                        </Typography>
+                        <Text.CharacterCounter
+                          value={value}
+                          maxLength={MAX_CONVERSATION_STARTER_LENGTH}
+                        />
                       )}
                     </Box>
                     {!disabled && (
@@ -202,9 +201,6 @@ const conversationStartersStyles = isEmpty => ({
     },
   },
   inputWrapper: {
-    width: '100%',
-  },
-  characterCount: {
     width: '100%',
   },
   deleteButtonWrapper: {

--- a/src/components/StyledInputModal.jsx
+++ b/src/components/StyledInputModal.jsx
@@ -3,7 +3,7 @@ import { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, 
 import { Box } from '@mui/material';
 
 import { AIAssistantCodeMirrorInput } from '@/[fsd]/features/pipelines/ai-assistant/ui';
-import { Field, Modal } from '@/[fsd]/shared/ui';
+import { Field, Modal, Text } from '@/[fsd]/shared/ui';
 import { useLanguageLinter } from '@/hooks/useCodeMirrorLanguageExtensions';
 
 const StyledInputModal = forwardRef((props, ref) => {
@@ -26,6 +26,7 @@ const StyledInputModal = forwardRef((props, ref) => {
     onRealtimeChange,
     afterContent,
     codeMirrorExtensions,
+    showCharacterCounter = false,
   } = props;
 
   const { maxLength } = inputProps || {};
@@ -110,6 +111,15 @@ const StyledInputModal = forwardRef((props, ref) => {
     >
       <Box sx={styles.editorContainer}>
         <Box sx={styles.editorWrapper}>
+          {maxLength && showCharacterCounter && (
+            <Box sx={styles.limitWrapper}>
+              <Text.CharacterCounter
+                value={currentValue}
+                maxLength={maxLength}
+                textVariant="bodyMedium"
+              />
+            </Box>
+          )}
           {enableFStringAutocomplete ? (
             <AIAssistantCodeMirrorInput
               readOnly={disabled}
@@ -168,4 +178,9 @@ const styles = {
       borderRight: 'none',
     },
   }),
+  limitWrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '0.5rem',
+  },
 };

--- a/src/components/WelcomeMessage.jsx
+++ b/src/components/WelcomeMessage.jsx
@@ -1,11 +1,11 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Box, Typography, debounce } from '@mui/material';
+import { Box, debounce } from '@mui/material';
 
 import { AGENT_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
 import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
-import { Input } from '@/[fsd]/shared/ui';
+import { Input, Text } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { MAX_WELCOME_MESSAGE_LENGTH, PROMPT_PAYLOAD_KEY } from '@/common/constants';
 import { useTheme } from '@emotion/react';
@@ -66,6 +66,7 @@ const WelcomeMessage = memo(props => {
                   placeholder="Input your welcome message"
                   value={inputValue}
                   inputProps={{ maxLength: MAX_WELCOME_MESSAGE_LENGTH }}
+                  showCharacterCounter
                   onChange={handleInput}
                   onFocus={() => toggleFieldFocus(PROMPT_PAYLOAD_KEY.welcomeMessage)}
                   onBlur={() => toggleFieldFocus(null)}
@@ -74,9 +75,10 @@ const WelcomeMessage = memo(props => {
                   disabled={disabled}
                 />
                 {isFocused(PROMPT_PAYLOAD_KEY.welcomeMessage) && inputValue.length > 0 && (
-                  <Typography variant="bodySmall">
-                    {`${MAX_WELCOME_MESSAGE_LENGTH - inputValue.length} characters left`}
-                  </Typography>
+                  <Text.CharacterCounter
+                    value={inputValue}
+                    maxLength={MAX_WELCOME_MESSAGE_LENGTH}
+                  />
                 )}
               </Box>
             </>


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/4963

## Summary

| Where | What | Why |
|-------|------|-----|
| [fsd]/shared/ui/text/CharacterCounter.jsx | Created new shared component | **Main fix:** Extract reusable character counter with limit indicator |
| [fsd]/shared/ui/text/index.js | Added CharacterCounter export | Additional fix: expose component via barrel |
| ConversationStarters.jsx:12,135-140 | Replaced inline Typography with `Text.CharacterCounter` | Additional fix: use shared component, remove duplicate code |
| ConversationStarters.jsx:190,206-211 | Removed `limitWrapper` and `characterCount` styles, simplified `conversationStartersStyles` | Additional fix: cleanup unused styles after refactor |
| WelcomeMessage.jsx:3,8,79-82 | Replaced Typography with `Text.CharacterCounter` | Additional fix: use shared component |
| StyledInputModal.jsx:6,113-121 | Added `Text.CharacterCounter` conditionally for modal | Additional fix: show counter in expanded modal only for welcome_message/conversation_starters |

**Root cause:** Character limit indicator was duplicated across ConversationStarters and WelcomeMessage with identical logic. The color change on reaching limit didn't work in ConversationStarters because `styles.limitWrapper` compared `maxLength` with total starters count instead of individual text length. Extracted to shared `CharacterCounter` component that receives `value` and `maxLength` props directly, fixing the bug and eliminating duplication.

<img width="546" height="398" alt="Screenshot 2026-05-25 133633" src="https://github.com/user-attachments/assets/a4cc5334-0b04-44d1-a348-7355f1dead87" />
<img width="940" height="240" alt="Screenshot 2026-05-25 133546" src="https://github.com/user-attachments/assets/92b62332-4cf0-44da-9b4a-7641d21c284d" />
<img width="944" height="749" alt="Screenshot 2026-05-25 133615" src="https://github.com/user-attachments/assets/143fc10e-6e56-4dbd-b3be-72df17885e32" />

<img width="900" height="332" alt="Screenshot 2026-05-25 122605" src="https://github.com/user-attachments/assets/8507df0a-2651-45db-8d99-49728cc741b2" />
<img width="973" height="340" alt="Screenshot 2026-05-25 133659" src="https://github.com/user-attachments/assets/c94f102a-bab8-44fc-b667-252da517565d" />
<img width="981" height="665" alt="Screenshot 2026-05-25 133723" src="https://github.com/user-attachments/assets/82ae9ae4-6897-4d78-a062-d67fdc8cf030" />
