### PR TITLE
fix: [EL-5027] Disable clicking handle for application card

### DIFF
--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
@@ -81,6 +81,7 @@ const ApplicationCatalog = memo(() => {
       return (
         <EntityCard
           disableCardActions
+          disableCardClick
           hideCardBottom
           data={application}
           viewMode={ViewMode.Owner}

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -35,6 +35,7 @@ const Card = memo(props => {
     cardDetails,
     disableCardActions = false,
     hideCardBottom = false,
+    disableCardClick = false,
     onCardClick,
   } = props;
 
@@ -121,13 +122,15 @@ const Card = memo(props => {
   );
 
   const handleCardClick = useCallback(() => {
+    if (disableCardClick) return;
+
     if (onCardClick) {
       onCardClick(data);
       return;
     }
 
     doNavigate();
-  }, [data, doNavigate, onCardClick]);
+  }, [data, disableCardClick, doNavigate, onCardClick]);
 
   // Monitor MCP token changes for both remote and pre-built MCP toolkits
   // For remote MCPs, use serverUrl; for pre-built MCPs, use toolkitType
@@ -145,8 +148,9 @@ const Card = memo(props => {
 
   const hasCardDetails = Boolean(cardDetails);
   const showCardBottom = !hideCardBottom;
-  const isWholeCardClickable = hasCardDetails && Boolean(onCardClick);
-  const styles = cardStyles(hasCardDetails, showCardBottom, isWholeCardClickable);
+  const isWholeCardClickable = hasCardDetails && Boolean(onCardClick) && !disableCardClick;
+  const isClickable = !disableCardClick;
+  const styles = cardStyles(hasCardDetails, showCardBottom, isWholeCardClickable, isClickable);
 
   return (
     <Box
@@ -163,7 +167,7 @@ const Card = memo(props => {
         <CardContent sx={styles.cardContent}>
           <Box
             sx={styles.cardTopSection}
-            onClick={isWholeCardClickable ? undefined : handleCardClick}
+            onClick={isWholeCardClickable || disableCardClick ? undefined : handleCardClick}
           >
             <EntityIcon
               icon={data.icon_meta}
@@ -333,7 +337,7 @@ const lineClamp = lines => ({
 });
 
 /** @type {MuiSx} */
-const cardStyles = (hasCardDetails, showCardBottom, isWholeCardClickable) => ({
+const cardStyles = (hasCardDetails, showCardBottom, isWholeCardClickable, isClickable) => ({
   wrapper: {
     width: '100%',
     ...(hasCardDetails ? { height: '100%' } : {}),
@@ -364,7 +368,7 @@ const cardStyles = (hasCardDetails, showCardBottom, isWholeCardClickable) => ({
   cardTopSection: {
     maxHeight: hasCardDetails ? '3.75rem' : '4.5rem',
     height: hasCardDetails ? '3.75rem' : '4.5rem',
-    cursor: 'pointer',
+    cursor: isClickable ? 'pointer' : 'default',
     width: '100%',
     padding: hasCardDetails ? '1rem 1.25rem 0.75rem' : '1.25rem',
     boxSizing: 'border-box',


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5027

## Summary

| Where | What | Why |
|-------|------|-----|
| Card.jsx:37 | Added `disableCardClick` prop (default false) | **Main fix:** Allow disabling card click behavior |
| Card.jsx:124-132 | Added early return in `handleCardClick` when disabled | Additional fix: prevent navigation/callback |
| Card.jsx:151-152 | Added `isClickable` variable, passed to cardStyles | Additional fix: control cursor style |
| Card.jsx:170 | Skip onClick on cardTopSection when disabled | Additional fix: prevent click on top section |
| Card.jsx:340 | Added `isClickable` param to cardStyles function | Additional fix: receive clickable state |
| Card.jsx:371 | Changed cursor to conditional based on isClickable | Additional fix: show default cursor when disabled |
| ApplicationCatalog.jsx:83 | Added `disableCardClick` prop to EntityCard | Additional fix: disable clicks in catalog |

**Root cause:** ApplicationCatalog cards should not navigate on click — they have explicit action buttons (Configure, Request Access). Added `disableCardClick` prop to EntityCard that prevents both navigation and pointer cursor.

**BEFORE**
These areas were clickable
<img width="1305" height="467" alt="image" src="https://github.com/user-attachments/assets/63b6c12b-48a9-4f60-8878-5796d2c0b61d" />

**AFTER**
It is disabled
<img width="587" height="192" alt="image" src="https://github.com/user-attachments/assets/95e1ab7a-1e44-4866-a4fa-cf55c7bc0bd7" />
