### PR TITLE
fix: [EL-5014] refactor pipeline trigger fetching logic in useSaveNew…

### DIFF
--- a/src/hooks/application/useSaveNewVersion.js
+++ b/src/hooks/application/useSaveNewVersion.js
@@ -7,7 +7,7 @@ import {
   LAYOUT_VERSION,
   ORIENTATION,
 } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
-import { useLazyGetPipelineTriggerQuery, useSaveApplicationNewVersionMutation } from '@/api/applications';
+import { useSaveApplicationNewVersionMutation } from '@/api/applications';
 import { buildErrorMessage, replaceVersionInPath } from '@/common/utils';
 import { useNameFromUrl, useViewModeFromUrl } from '@/hooks/useSearchParamValue';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
@@ -47,8 +47,6 @@ const useSaveNewVersion = ({
       reset,
     },
   ] = useSaveApplicationNewVersionMutation();
-
-  const [fetchPipelineTrigger] = useLazyGetPipelineTriggerQuery();
 
   const onSuccessHandler = useCallback(
     newVersionData => {
@@ -116,27 +114,8 @@ const useSaveNewVersion = ({
         ? calculateNodesAndEdges(yamlCode, ORIENTATION.vertical, flowNodes)
         : {};
 
-      // Fetch current trigger configuration for pipelines
-      // (trigger is cached separately from version details, so we need to fetch it fresh)
-      // Note: versionDetails.id is undefined (cleared by SaveNewVersionButton), so use currentVersionId from URL
-      let triggerConfig = null;
-      if (isFromPipeline && selectedProjectId && currentVersionId) {
-        try {
-          const triggerResult = await fetchPipelineTrigger({
-            projectId: selectedProjectId,
-            versionId: currentVersionId,
-          }).unwrap();
-          if (triggerResult) {
-            triggerConfig = {
-              type: triggerResult.type,
-              cron: triggerResult.cron,
-              timezone: triggerResult.timezone,
-            };
-          }
-        } catch {
-          // Ignore errors - will default to chat_message trigger
-        }
-      }
+      // Reset trigger to default 'chat_message' for new versions
+      const triggerConfig = isFromPipeline ? { type: 'chat_message' } : null;
 
       const result = await saveNewVersion({
         ...(versionDetails || {}),
@@ -177,8 +156,6 @@ const useSaveNewVersion = ({
       applicationId,
       onSuccessHandler,
       flowNodes,
-      fetchPipelineTrigger,
-      currentVersionId,
     ],
   );
 


### PR DESCRIPTION
reset trigger to Chat Message on Save Version As

  Previously, saving a pipeline as a new version copied the source
  version's trigger (schedule/webhook). New versions now always start
  with the default 'chat_message' trigger to avoid unintended automated
  executions.

Fixes: EliteaAI/elitea_issues#5014