### PR TITLE
fix: [EL-5029] Editing input during speaking mode does not reset auto-send timer

### DIFF
--- a/src/[fsd]/features/chat/lib/hooks/useSpeakingModeLoop.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSpeakingModeLoop.hooks.js
@@ -53,6 +53,22 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
     }
   }, []);
 
+  // Schedule an auto-send after SILENCE_TIMEOUT_MS of no new activity.
+  // Shared by both voice transcripts and manual-edit detection.
+  const scheduleSend = useCallback(() => {
+    clearSilenceTimer();
+    silenceTimerRef.current = setTimeout(() => {
+      const content = inputRef.current?.getInputContent?.() ?? '';
+      if (content.trim()) {
+        hasSentRef.current = true;
+        inputRef.current?.sendQuestion?.();
+        inputRef.current?.reset?.();
+        // Pause recording until the AI response and TTS are done
+        stopRecordingRef.current?.();
+      }
+    }, SILENCE_TIMEOUT_MS);
+  }, [clearSilenceTimer, inputRef]);
+
   const handleTranscript = useCallback(
     ({ final, interim }) => {
       // Re-sync cursor refs if the user manually edited the input between transcript
@@ -83,21 +99,18 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
         lastSetValueRef.current = newValue;
         inputRef.current?.setValue(newValue, cursorPos);
 
-        clearSilenceTimer();
-        silenceTimerRef.current = setTimeout(() => {
-          const content = inputRef.current?.getInputContent?.() ?? '';
-          if (content.trim()) {
-            hasSentRef.current = true;
-            inputRef.current?.sendQuestion?.();
-            inputRef.current?.reset?.();
-            // Pause recording until the AI response and TTS are done
-            stopRecordingRef.current?.();
-          }
-        }, SILENCE_TIMEOUT_MS);
+        scheduleSend();
       }
     },
-    [inputRef, clearSilenceTimer],
+    [inputRef, scheduleSend],
   );
+
+  // Called when the user manually edits the input field while speaking mode is
+  // active. Resets the auto-send timer so the message is not sent mid-edit.
+  const notifyManualEdit = useCallback(() => {
+    if (!isSpeakingMode || hasSentRef.current) return;
+    scheduleSend();
+  }, [isSpeakingMode, scheduleSend]);
 
   const serverHook = useStreamingSpeechRecognition({
     onTranscript: handleTranscript,
@@ -148,6 +161,15 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isStreaming, isTTSPlaying, isSpeakingMode]);
 
+  // Called by external actions that trigger a new AI response (e.g. Regenerate).
+  // Stops recording and activates the restart guard, identical to the auto-send path.
+  const pauseForRegeneration = useCallback(() => {
+    if (!isSpeakingMode) return;
+    clearSilenceTimer();
+    stopRecordingRef.current?.();
+    hasSentRef.current = true;
+  }, [isSpeakingMode, clearSilenceTimer]);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -157,5 +179,5 @@ export const useSpeakingModeLoop = ({ isSpeakingMode, inputRef, isStreaming, isT
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { isRecording };
+  return { isRecording, pauseForRegeneration, notifyManualEdit };
 };

--- a/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js
+++ b/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js
@@ -502,6 +502,37 @@ export const clearIgnoredServers = () => {
 };
 
 /**
+ * Start a background scheduler that proactively refreshes OAuth tokens before they expire.
+ *
+ * The scheduler runs independently of user activity — tokens are refreshed when they
+ * cross the 75% lifetime threshold even when the user is idle (not sending messages).
+ * This complements the per-message refresh check in getAllTokens(), which only fires
+ * during active use.
+ *
+ * The interval matches REFRESH_CHECK_INTERVAL_MS (60 s) so both paths share the same
+ * cadence. lastRefreshCheckTime is updated on each scheduler tick to prevent getAllTokens()
+ * from issuing a duplicate refresh check within the same window.
+ *
+ * @returns {Function} Cleanup function that clears the interval (call on app unmount).
+ */
+export const startTokenRefreshScheduler = () => {
+  if (!isStorageAvailable()) return () => {};
+
+  const intervalId = setInterval(() => {
+    const serversToRefresh = getServersNeedingRefresh();
+    if (serversToRefresh.length > 0) {
+      addToRefreshQueue(serversToRefresh);
+      processRefreshQueue();
+    }
+    // Keep getAllTokens() rate-limiter in sync so it skips the next check
+    // if the scheduler just ran, avoiding a double-refresh burst on message send.
+    lastRefreshCheckTime = Date.now();
+  }, REFRESH_CHECK_INTERVAL_MS);
+
+  return () => clearInterval(intervalId);
+};
+
+/**
  * Mark a server/toolkit as "connection verified" for header-based auth MCP servers
  * that don't require OAuth tokens on the client side.
  * This stores a minimal marker that makes getAccessToken return truthy,

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1064,6 +1064,7 @@ const ChatBox = forwardRef((props, boxRef) => {
   const onRegenerateAnswerStream = useCallback(
     (id, question, questionId) => async () => {
       stopTTS?.();
+      chatInput.current?.pauseSpeakingMode?.();
       const questionIndex = chat_history.findIndex(item => item.id === id) - 1;
       const theQuestion = question || chat_history[questionIndex]?.content;
       const question_id = questionId || chat_history[questionIndex]?.id;
@@ -1087,6 +1088,7 @@ const ChatBox = forwardRef((props, boxRef) => {
   const onRegenerateAnswer = useCallback(
     (uuid, messageParticipant) => async () => {
       stopTTS();
+      chatInput.current?.pauseSpeakingMode?.();
       let prevMessage = {};
       setChatHistory(prevMessages => {
         prevMessage = prevMessages.find(message => message.id === uuid);

--- a/src/pages/NewChat/NewChatInput.jsx
+++ b/src/pages/NewChat/NewChatInput.jsx
@@ -96,12 +96,24 @@ const NewChatInput = forwardRef((props, ref) => {
   const voiceButtonRef = useRef(null);
   const [isRecording, setIsRecording] = useState(false);
 
-  const { isRecording: isSpeakingModeRecording } = useSpeakingModeLoop({
+  const {
+    isRecording: isSpeakingModeRecording,
+    pauseForRegeneration,
+    notifyManualEdit,
+  } = useSpeakingModeLoop({
     isSpeakingMode,
     inputRef: userInputRef,
     isStreaming,
     isTTSPlaying,
   });
+
+  const handleInputChange = useCallback(
+    value => {
+      onInputChange?.(value);
+      notifyManualEdit();
+    },
+    [onInputChange, notifyManualEdit],
+  );
 
   // Expose a stable imperative API while delegating each call to the latest UserInput handle.
   useImperativeHandle(
@@ -117,8 +129,9 @@ const NewChatInput = forwardRef((props, ref) => {
       sendQuestion: (...args) => userInputRef.current?.sendQuestion?.(...args),
       insertTextAtCursor: (...args) => userInputRef.current?.insertTextAtCursor?.(...args),
       mentionUser: (...args) => userInputRef.current?.mentionUser?.(...args),
+      pauseSpeakingMode: () => pauseForRegeneration(),
     }),
-    [],
+    [pauseForRegeneration],
   );
 
   const handleVoiceRecordingChange = useCallback(
@@ -372,7 +385,7 @@ const NewChatInput = forwardRef((props, ref) => {
       disabledInput={isLoading}
       onSend={handleSend}
       onNormalKeyDown={onNormalKeyDown}
-      onInputChange={onInputChange}
+      onInputChange={handleInputChange}
       tooltipOfSendButton={tooltipOfSendButton}
       showLoading={isLoading}
       onFilePaste={handleFilePaste}


### PR DESCRIPTION
  ---                                                                                                         
  1. Speaking Mode Captures Voice During TTS After Regeneration (Issue #5020)
                                                                                                              
  Root cause: hasSentRef.current is only set when the loop auto-sends via the silence timer. Clicking       
  Regenerate bypasses the loop entirely, so the mic was never stopped and kept recording through streaming and
   TTS playback of the regenerated response.                                                                
                                                                                                              
  Fix — 3 files:                                                                                              
  
  - useSpeakingModeLoop.hooks.js — Added pauseForRegeneration callback: stops the mic and sets                
  hasSentRef.current = true, activating the existing restart guard so the mic resumes only after streaming and
   TTS both finish.                                                                                           
  - NewChatInput.jsx — Exposed pauseSpeakingMode() via useImperativeHandle.                                 
  - ChatBox.jsx — Called chatInput.current?.pauseSpeakingMode?.() at the top of both onRegenerateAnswer and   
  onRegenerateAnswerStream, right after stopTTS().                                                            
                                                                                                              
  ---                                                                                                         
  2. Editing Input During Speaking Mode Does Not Reset Auto-Send Timer                                      
                                                                                                              
  Root cause: The 3-second silence timer was only reset when a new voice transcript arrived. Manual keyboard
  edits had no mechanism to reset it, so the message could auto-send while the user was still typing.         
                                                                                                            
  Fix — 2 files:                                                                                              
                                                                                                            
  - useSpeakingModeLoop.hooks.js — Extracted scheduleSend (the clearSilenceTimer + setTimeout block that was  
  inline in handleTranscript) to avoid duplication. Added notifyManualEdit callback: guards on isSpeakingMode 
  && !hasSentRef.current, then calls scheduleSend() to cancel the current countdown and start a fresh 3-second
   window.                                                                                                  
  - NewChatInput.jsx — Added handleInputChange that calls both the parent's onInputChange and
  notifyManualEdit(). Passed it to UserInput as onInputChange. This works correctly because                   
  UserInput.setValue() (used by the voice hook) updates state directly without firing onInputChange, so
  notifyManualEdit is only triggered by real keyboard events.    