### PR TITLE
Hotfix: [EL-5030] update paperclip icon when pipeline attachment toggle changes in new chat

### DIFF
--- a/src/hooks/chat/useNewConversationAttachments.js
+++ b/src/hooks/chat/useNewConversationAttachments.js
@@ -9,12 +9,18 @@ import { useAttachmentState } from './useAttachmentState';
  * Simplified version - attachments are now handled via internal tools auto-injection
  * and always use the default attachment bucket.
  */
-export default function useNewConversationAttachments({ selectedParticipant }) {
-  // Use shared utility for determining disabled status
-  const disableAttachments = useMemo(
-    () => getAttachmentDisabledStatus(selectedParticipant, selectedParticipant),
-    [selectedParticipant],
-  );
+export default function useNewConversationAttachments({ selectedParticipant, activeParticipantDetails }) {
+  // Use shared utility for determining disabled status.
+  // Prefer activeParticipantDetails when it has been fetched (has version_details),
+  // because it reflects the latest saved state (e.g. after toggling attachment in the pipeline editor).
+  // Fall back to selectedParticipant (which already carries version_details from the initial load)
+  // until activeParticipantDetails is populated by the API call.
+  const disableAttachments = useMemo(() => {
+    const detailsForCheck = activeParticipantDetails?.version_details
+      ? activeParticipantDetails
+      : selectedParticipant;
+    return getAttachmentDisabledStatus(selectedParticipant, detailsForCheck);
+  }, [selectedParticipant, activeParticipantDetails]);
 
   // Use shared attachment state management
   const { attachments, onAttachFiles, onDeleteAttachment, onClearAttachments } = useAttachmentState();

--- a/src/pages/NewChat/NewChat.jsx
+++ b/src/pages/NewChat/NewChat.jsx
@@ -1446,6 +1446,7 @@ const NewChat = props => {
                 activeConversation={activeConversation}
                 setActiveConversation={setActiveConversation}
                 activeParticipant={activeParticipant}
+                activeParticipantDetails={activeParticipantDetails}
                 setActiveParticipant={setActiveParticipant}
                 setChatHistory={setChatHistory}
                 interaction_uuid={interaction_uuid}

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -54,6 +54,7 @@ const NewConversationView = forwardRef(
       setActiveConversation,
       setActiveParticipant,
       activeParticipant,
+      activeParticipantDetails,
       setChatHistory,
       interaction_uuid,
       onShowAgentEditor,
@@ -95,7 +96,7 @@ const NewConversationView = forwardRef(
     const [updateChatLlmSettings] = useUpdateParticipantLlmSettingsMutation();
     const [conversationEditMeta] = useConversationEditMutation();
     const { attachments, disableAttachments, onAttachFiles, onDeleteAttachment, onClearAttachments } =
-      useNewConversationAttachments({ selectedParticipant });
+      useNewConversationAttachments({ selectedParticipant, activeParticipantDetails });
 
     // Create LLM settings for conversation pages from user settings
     const [llmSettings, setLlmSettings] = useState({


### PR DESCRIPTION

## Bug

In the **new conversation view** (before a conversation is created):
1. Add a pipeline participant that has the attachment toggle **OFF**
2. Open the pipeline editor and switch the attachment toggle to **ON**, save
3. The paperclip button in the chat input stays **disabled** — it should become enabled

## Root cause

`NewConversationView` calls `useNewConversationAttachments({ selectedParticipant })`.

Inside that hook, `disableAttachments` was computed as:

```js
getAttachmentDisabledStatus(selectedParticipant, selectedParticipant)
```

`getAttachmentDisabledStatus` checks **two separate things** from its two arguments:

| Argument | Used for |
|---|---|
| First — `participant` | Entity type check: is this an Application / Pipeline? |
| Second — `participantDetails` | `version_details.meta.internal_tools` — is `"attachments"` in the list? |

Both arguments pointed to the same `selectedParticipant` local state object.
`selectedParticipant` is initialized at component mount from `activeParticipant` and **never updated** when
the pipeline editor saves changes.

Meanwhile, `NewChat.jsx` already had the correct mechanism:
- `useActiveParticipantDetails({ activeParticipant })` fetches participant details from the API
- `refetchParticipantDetails()` re-fetches with `forceRefetch: true` after the attachment toggle is saved
- The result is stored in `activeParticipantDetails` — fresh, up-to-date data

But `activeParticipantDetails` was never passed down to `NewConversationView`, so the hook could not use it.

The **existing conversation** path (`useAttachments`) worked correctly all along because it already received
both `activeParticipant` and `activeParticipantDetails` as separate arguments.

## Fix

**Three files changed:**

### 1. `src/hooks/chat/useNewConversationAttachments.js`

Added `activeParticipantDetails` parameter and use it as the source for `version_details` when it has
already been loaded (i.e. after the initial API call or after a re-fetch triggered by the toggle save).
Fall back to `selectedParticipant` for the initial render — before `activeParticipantDetails` loads from
the API it starts as `{}`, so without the fallback the paperclip would flash disabled on load.

```js
// Before
export default function useNewConversationAttachments({ selectedParticipant }) {
  const disableAttachments = useMemo(
    () => getAttachmentDisabledStatus(selectedParticipant, selectedParticipant),
    [selectedParticipant],
  );

// After
export default function useNewConversationAttachments({ selectedParticipant, activeParticipantDetails }) {
  const disableAttachments = useMemo(() => {
    const detailsForCheck = activeParticipantDetails?.version_details
      ? activeParticipantDetails   // fresh from API — reflects the saved toggle state
      : selectedParticipant;       // fallback: API not yet loaded on initial render
    return getAttachmentDisabledStatus(selectedParticipant, detailsForCheck);
  }, [selectedParticipant, activeParticipantDetails]);
```

### 2. `src/pages/NewChat/NewConversationView.jsx`

- Added `activeParticipantDetails` to the destructured props
- Passed it through to `useNewConversationAttachments`

### 3. `src/pages/NewChat/NewChat.jsx`

Added `activeParticipantDetails={activeParticipantDetails}` to the `<NewConversationView>` JSX so the
already-available (and already-refreshed) details flow down to the view.

## Data flow after fix

```
Pipeline editor saves attachment toggle
  → useAttachmentToolChange.handleAttachmentToolChange(pipelineId)
    → refetchParticipantDetails()                          (NewChat.jsx)
      → fetchDetails({ forceRefetch: true })
        → fresh API call
          → setActiveParticipantDetails({ ...details })
            → activeParticipantDetails prop updated        (NewChat.jsx)
              → passed to NewConversationView              (NEW)
                → passed to useNewConversationAttachments  (NEW)
                  → detailsForCheck = activeParticipantDetails
                    → disableAttachments recomputed ✓
                      → paperclip enabled/disabled correctly ✓
```

## Why the fallback to `selectedParticipant` is needed

`useActiveParticipantDetails` initialises its state as `useState({})`.
Until the first API call completes, `activeParticipantDetails` is `{}` with no `version_details`.
Without the fallback:
- `internal_tools` defaults to `[]`
- `!internalTools.includes('attachments')` → `true` → paperclip disabled
- Every pipeline with attachments enabled would flash disabled on initial load

`selectedParticipant` already carries `version_details` from when it was originally fetched and stored,
so it provides a correct starting state while the API call is in flight.
