### PR TITLE
fix: [EL-5030] use entity ids for chat attachment refresh

### DIFF
--- a/src/[fsd]/features/chat/lib/hooks/useAttachmentToolChange.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useAttachmentToolChange.hooks.js
@@ -7,15 +7,17 @@ import { useCallback } from 'react';
 export const useAttachmentToolChange = ({ activeParticipant, refetchParticipantDetails }) => {
   const handleAttachmentToolChange = useCallback(
     async participantId => {
-      // Only refetch if the changed participant is the currently active one
-      if (!activeParticipant?.id || activeParticipant?.id !== participantId) {
+      // The chat editor callback for the pipeline path passes the entity id,
+      // which corresponds to activeParticipant.entity_meta.id — NOT activeParticipant.id
+      // (the latter is the conversation participant row id and never matches).
+      const activeEntityId = activeParticipant?.entity_meta?.id;
+      if (!activeEntityId || activeEntityId !== participantId) {
         return;
       }
 
-      // Refetch participant details to get updated attachment settings
       await refetchParticipantDetails?.();
     },
-    [activeParticipant?.id, refetchParticipantDetails],
+    [activeParticipant?.entity_meta?.id, refetchParticipantDetails],
   );
 
   return { handleAttachmentToolChange };

--- a/src/pages/NewChat/PipelineEditor.jsx
+++ b/src/pages/NewChat/PipelineEditor.jsx
@@ -394,8 +394,7 @@ const PipelineEditor = forwardRef(
       savedFormData => {
         setIsDirty(false);
         setIsYamlDirty(false);
-
-        onAttachmentToolChange?.(pipeline?.id);
+        onAttachmentToolChange?.(pipeline?.entity_meta?.id);
 
         // Notify parent component if needed
         if (onPipelineSaved && savedFormData) {
@@ -409,16 +408,16 @@ const PipelineEditor = forwardRef(
           onPipelineSaved(savedFormData);
         }
       },
-      [onAttachmentToolChange, onPipelineSaved, pipeline?.id, pipelineId, trackEvent],
+      [onAttachmentToolChange, onPipelineSaved, pipeline?.entity_meta?.id, pipelineId, trackEvent],
     );
 
     const handleAttachmentToolChange = useCallback(() => {
-      onAttachmentToolChange?.(pipeline?.id);
+      onAttachmentToolChange?.(pipeline?.entity_meta?.id);
       // Refetch agent details to get updated attachment/tool configuration
       if (refetchVersionDetails && !isCreateMode) {
         refetchVersionDetails();
       }
-    }, [isCreateMode, onAttachmentToolChange, pipeline?.id, refetchVersionDetails]);
+    }, [isCreateMode, onAttachmentToolChange, pipeline?.entity_meta?.id, refetchVersionDetails]);
     // Early return null when pipeline is null and not in create mode
     if (!pipeline && !isCreateMode) {
       return null;


### PR DESCRIPTION

https://github.com/user-attachments/assets/8145b306-9efd-4c73-947b-315f67781a98

<img width="1310" height="889" alt="2026-05-27_09h19_17" src="https://github.com/user-attachments/assets/1201a7bd-36c1-40b1-a267-2b10f2d8b555" />

# Fix EL-5030: Paperclip Icon Not Updated When Allow Attachments Toggle Changes (Scenario 2)

## Issue

[EL-5030](https://github.com/EliteaAI/elitea_issues/issues/5030)

1. **Scenario 1 (NEW chat)** — fixed by prior commit https://github.com/EliteaAI/EliteaUI/pull/236.
2. **Scenario 2 (EXISTING chat with 1+ messages)** — fixed by this change.

- Open existing chat → toggle Allow Attachments in the pipeline editor → save.
- Before fix: paperclip icon does not update until a hard reload.
- After fix: paperclip icon reflects the new value immediately.

## Root cause

After saving the toggle change, the chat side has to refetch the active participant's `version_details` so
that `getAttachmentDisabledStatus(activeParticipant, activeParticipantDetails)` sees the updated
`internal_tools` array. That refetch is supposed to be triggered by
`src/[fsd]/features/chat/lib/hooks/useAttachmentToolChange.hooks.js`, but the id passed from the chat editor
did not match what the refetch hook was checking.

The verified log output in the broken flow looked like this:

```text
PipelineEditor handleSaveSuccess -> pipelineParticipantId: 192, pipelineEntityId: 200
useAttachmentToolChange handler invoked -> participantId: 192, activeEntityId: 200, match: false
useAttachmentToolChange BAILED — id mismatch, no refetch
```

The mismatch happened because the pipeline chat editor was sending the **conversation participant row id**:

```js
// BEFORE (buggy)
onAttachmentToolChange?.(pipeline?.id);
```

But `useAttachmentToolChange` identifies the active chat participant by the **entity id** at
`activeParticipant.entity_meta.id`:

```js
const activeEntityId = activeParticipant?.entity_meta?.id;
if (!activeEntityId || activeEntityId !== participantId) {
  return;
}
await refetchParticipantDetails?.();
```

Because `participant.id` and `participant.entity_meta.id` are different values in existing chats, the guard
returned early and `refetchParticipantDetails` never ran. `activeParticipantDetails` stayed stale until a hard
reload, so the paperclip state did not refresh immediately.

## Fix

Keep the chat-side comparison on `activeParticipant.entity_meta.id`, and change the pipeline editor to send
the same kind of id:

```js
// AFTER (fixed)
onAttachmentToolChange?.(pipeline?.entity_meta?.id);
```

The refetch hook remains:

```js
export const useAttachmentToolChange = ({ activeParticipant, refetchParticipantDetails }) => {
  const handleAttachmentToolChange = useCallback(
    async participantId => {
      // The pipeline chat editor passes the entity id, which corresponds to
      // activeParticipant.entity_meta.id — NOT activeParticipant.id
      // (the latter is the conversation participant row id and never matches).
      const activeEntityId = activeParticipant?.entity_meta?.id;
      if (!activeEntityId || activeEntityId !== participantId) {
        return;
      }
      await refetchParticipantDetails?.();
    },
    [activeParticipant?.entity_meta?.id, refetchParticipantDetails],
  );

  return { handleAttachmentToolChange };
};
```

With the id type aligned across the pipeline flow, the refetch fires after save, `activeParticipantDetails`
updates with the new `internal_tools` array, and `useAttachments` recomputes `disableAttachments` so the
paperclip icon updates immediately.

## Files changed

- `src/[fsd]/features/chat/lib/hooks/useAttachmentToolChange.hooks.js`
- `src/pages/NewChat/PipelineEditor.jsx`

## Manual test

1. Open a chat that already has 1+ messages with a pipeline participant.
2. Open the pipeline editor, flip Allow Attachments, save.
3. Paperclip icon in the chat input updates immediately (enabled → disabled, or vice versa) without a reload.
4. Repeat in the opposite direction.

