### PR TITLE
Hotfix [EL-5063] interactive sidebar tour fix order

### DIFF
--- a/src/[fsd]/features/interactive-tours/lib/constants/sidebarTour.constants.js
+++ b/src/[fsd]/features/interactive-tours/lib/constants/sidebarTour.constants.js
@@ -16,9 +16,9 @@ export const sidebarTourSteps = [
     target: SIDEBAR_TOUR_TARGETS.logo,
     placement: 'right',
     title: 'ELITEA Logo',
-    content: `The **ELITEA Logo** 
-    
-Green mark points that server is working
+    content: `The **ELITEA Logo** in the sidebar shows the server status.
+
+Green mark points that server is working.
 Red mark points that server is updating.`,
     skip: false,
   },
@@ -60,9 +60,9 @@ The button detects your current page and adjusts its action accordingly:
 - **Chat** — starts a new conversation
 - **Agents** — opens the new agent creation form
 - **Pipelines** — opens the new pipeline creation form
+- **Credentials** — opens the new credential creation form
 - **Toolkits** — opens the new toolkit creation form
 - **MCPs** — opens the new MCP creation form
-- **Credentials** — opens the new credential creation form
 - **Artifacts** — opens the new bucket creation form
 - **Settings → AI Configuration** — opens the new model integration creation form
 - **Settings → Personal Tokens** — opens the new personal token creation form
@@ -125,10 +125,7 @@ Once configured, a toolkit can be attached to any agent or pipeline and used dir
     target: SIDEBAR_TOUR_TARGETS.navApplications,
     placement: 'right',
     title: 'Applications',
-    content: `## What is Applications?
-
-The Applications menu is where you discover, request, and manage purpose-built AI applications that extend ELITEA beyond agents and pipelines. Each application provides a dedicated interface and a ready-to-use set of tools that can also be referenced in agents and pipelines.`,
-    skip: false,
+    content: `**ELITEA Applications** are purpose-built AI applications that extend ELITEA beyond agents and pipelines. Each application provides a dedicated interface and a ready-to-use set of tools that can also be referenced in agents and pipelines.`,
   },
   {
     id: 'mcps',

--- a/src/[fsd]/widgets/Sidebar/ui/button/CreateEntityButton.jsx
+++ b/src/[fsd]/widgets/Sidebar/ui/button/CreateEntityButton.jsx
@@ -42,6 +42,7 @@ const CreateEntityButton = memo(props => {
   );
   const isSystemPromptsPage = useMemo(() => pathname.includes('/settings/prompts'), [pathname]);
   const isSettingsUsersPage = useMemo(() => pathname.includes('/settings/users'), [pathname]);
+  const isAgentStudioPage = useMemo(() => pathname.startsWith(RouteDefinitions.AgentStudio), [pathname]);
   const shouldDisableCreatingChat = useMemo(
     () => selectedOption === CreateEntityConstants.OptionsMap.Chat && isCreatingNewConversation,
     [selectedOption, isCreatingNewConversation],
@@ -199,6 +200,7 @@ const CreateEntityButton = memo(props => {
       shouldDisablePersonalSpace ||
       !hasPermissionForSelectedOption ||
       isSystemPromptsPage ||
+      isAgentStudioPage ||
       shouldDisableInviteUser ||
       shouldDisableCreatingChat ||
       shouldDisableOwnLLMs ||
@@ -207,6 +209,7 @@ const CreateEntityButton = memo(props => {
       shouldDisablePersonalSpace,
       hasPermissionForSelectedOption,
       isSystemPromptsPage,
+      isAgentStudioPage,
       shouldDisableInviteUser,
       shouldDisableCreatingChat,
       shouldDisableOwnLLMs,


### PR DESCRIPTION
- fixed order for interactive card for "+ Create" button - to not confuse users
- disabled Create Button on Agents Studio page - as that page is collection of published agents

<img width="694" height="858" alt="image" src="https://github.com/user-attachments/assets/0118090d-6336-457d-be3a-815245ab20d8" />

<img width="1310" height="728" alt="image" src="https://github.com/user-attachments/assets/a102b6b0-3d05-4a79-8a6b-a503925935b9" />
