### PR TITLE
fix: [EL-5079] sync input_attachments YAML state when toggling Attachments on chat page

### DIFF
--- a/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
+++ b/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
@@ -33,8 +33,6 @@ export const usePipelineAttachmentYamlSync = () => {
   yamlJsonObjectRef.current = yamlJsonObject;
 
   useEffect(() => {
-    if (!yamlCode) return;
-
     const currentYamlObj = yamlJsonObjectRef.current;
     const currentState = currentYamlObj?.state || {};
     const alreadyHasKey = STATE_INPUT_ATTACHMENTS in currentState;

--- a/src/pages/NewChat/PipelineEditor.jsx
+++ b/src/pages/NewChat/PipelineEditor.jsx
@@ -22,6 +22,7 @@ import { useConversationStartersSync } from '@/[fsd]/features/chat/lib/hooks';
 import useRefetchAgentVersionDetailsOnClose from '@/[fsd]/features/chat/lib/hooks/useRefetchAgentVersionDetailsOnClose';
 import { FlowEditorConstants } from '@/[fsd]/features/pipelines/flow-editor/lib/constants';
 import { LayoutHelpers, ParsePipelineHelpers } from '@/[fsd]/features/pipelines/flow-editor/lib/helpers';
+import { usePipelineAttachmentYamlSync } from '@/[fsd]/features/pipelines/lib/hooks';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
 import { DEFAULT_REASONING_EFFORT } from '@/[fsd]/shared/lib/constants/llmSettings.constants';
 import { useGetApplicationVersionDetailQuery, usePublicApplicationDetailsQuery } from '@/api/applications';
@@ -65,6 +66,7 @@ const PipelineEditorContent = memo(props => {
   const styles = getStyles();
 
   useConversationStartersSync(onConversationStartersChange);
+  usePipelineAttachmentYamlSync();
 
   // LLM Settings setter for the modal dialog
   const onLLMSettingsChange = useCallback(


### PR DESCRIPTION

## Problem

Enabling or disabling the **Attachments** toggle in the pipeline editor on the **Chat page** did not
add/remove the `input_attachments` variable from the pipeline's YAML state, even though the same
toggle worked correctly on the **Pipelines page**.

A secondary issue: even after the chat-page fix, pipelines with **no nodes** (empty YAML/instructions)
also did not get `input_attachments` added, on either page.

## Root Cause

1. **Chat page missing hook call.** `ConfigurationTab` (Pipelines page) already called
   `usePipelineAttachmentYamlSync()`, which reactively syncs `input_attachments` in the YAML whenever
   `version_details.meta.internal_tools` changes in Formik. The equivalent component on the Chat page,
   `PipelineEditorContent` in `PipelineEditor.jsx`, never called this hook.

2. **Empty-YAML early return.** `usePipelineAttachmentYamlSync` contained an `if (!yamlCode) return`
   guard that silently skipped all sync logic for pipelines whose `instructions` field is empty (no
   nodes added yet).

## Changes

### `src/pages/NewChat/PipelineEditor.jsx`

- Imported `usePipelineAttachmentYamlSync` from `@/[fsd]/features/pipelines/lib/hooks`.
- Called `usePipelineAttachmentYamlSync()` inside `PipelineEditorContent`, directly after the existing
  `useConversationStartersSync` call — mirroring the pattern in `ConfigurationTab`.

### `src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js`

- Removed the `if (!yamlCode) return` early-return guard.
- The hook now handles empty YAML correctly: when `hasAttachments` is `true` it spreads `input_attachments`
  into whatever state is present (which may be `{}`), producing only the variables that belong there.

## Testing

1. Open a chat that has a pipeline participant with at least one node.
   - Toggle **Attachments ON** → `input_attachments` appears in the YAML `state` block.
   - Toggle **Attachments OFF** → `input_attachments` is removed from the YAML `state` block.
2. Repeat with a pipeline that has **no nodes** (empty instructions).
   - Toggle **Attachments ON** → YAML is created with only `input_attachments` in state.
   - Toggle **Attachments OFF** → `input_attachments` is removed (YAML state becomes empty).
3. Verify the same behaviour still works on the **Pipelines page** (regression check).
