### PR TITLE
fix: [EL-5058] LLM model change not applied when chatting with published agent (pre-conversation)

### DIFF
--- a/src/hooks/chat/useAddNewParticipants.js
+++ b/src/hooks/chat/useAddNewParticipants.js
@@ -11,7 +11,7 @@ import {
   useListModelsQuery,
   useUpdateApplicationVersionMutation,
 } from '@/api';
-import { ChatParticipantType } from '@/common/constants';
+import { ChatParticipantType, PUBLIC_PROJECT_ID } from '@/common/constants';
 import { buildErrorMessage, getChatParticipantUniqueId } from '@/common/utils';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
@@ -74,6 +74,14 @@ export const transformParticipant = (participantType, participant, variables) =>
           ...(participantType === ChatParticipantType.Applications &&
             participant.version_details?.id &&
             !participant.entity_settings?.version_id && { version_id: participant.version_details.id }),
+          // Include llm_settings override for published agents/pipelines from public project
+          ...((participantType === ChatParticipantType.Applications ||
+            participantType === ChatParticipantType.Pipelines) &&
+            participant.entity_meta?.project_id === PUBLIC_PROJECT_ID &&
+            (participant.entity_settings?.llm_settings || participant.version_details?.llm_settings) && {
+              llm_settings:
+                participant.entity_settings?.llm_settings || participant.version_details?.llm_settings,
+            }),
         },
         meta: {
           mcp: participant.meta?.mcp || undefined,

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -523,6 +523,17 @@ const ChatBox = forwardRef((props, boxRef) => {
 
   const getPayload = useCallback(
     ({ question, question_id, participant, conversationUuid, attachmentList }) => {
+      // For published agent/pipeline participants on the Chat page, use their entity_settings.llm_settings
+      // as fallback so the predict payload carries the correct model override
+      const isPublishedAgentParticipant =
+        !isAgentsPage &&
+        activeParticipant?.entity_meta?.project_id === PUBLIC_PROJECT_ID &&
+        (activeParticipant?.entity_name === ChatParticipantType.Applications ||
+          activeParticipant?.entity_name === ChatParticipantType.Pipelines);
+      const participantLlmSettings = isPublishedAgentParticipant
+        ? activeParticipant?.entity_settings?.llm_settings
+        : undefined;
+
       return generateMessagePayload({
         attachmentList,
         question,
@@ -544,9 +555,9 @@ const ChatBox = forwardRef((props, boxRef) => {
               )
               .map(it => it.id) || []
           : selectedUsers.map(user => user.user.id),
-        unsavedLLMSettings,
+        unsavedLLMSettings: unsavedLLMSettings || participantLlmSettings,
         participants: activeConversation?.participants || [],
-        allowLLMSettingsOverride: isAgentsPage,
+        allowLLMSettingsOverride: isAgentsPage || !!participantLlmSettings,
         conversationMeta: activeConversation?.meta,
       });
     },

--- a/src/pages/NewChat/NewConversationView.jsx
+++ b/src/pages/NewChat/NewConversationView.jsx
@@ -623,9 +623,25 @@ const NewConversationView = forwardRef(
             }
             if (selectedParticipant) {
               setTimeout(async () => {
-                const selectedParticipantFiltered = selectedParticipants.filter(
-                  p => !p.meta.added_from_agent,
-                );
+                const selectedParticipantFiltered = selectedParticipants
+                  .filter(p => !p.meta.added_from_agent)
+                  .map(sp => {
+                    if (
+                      sp.entity_meta?.project_id === PUBLIC_PROJECT_ID &&
+                      activeParticipant?.entity_settings?.llm_settings &&
+                      sp.entity_meta?.id === activeParticipant.entity_meta?.id &&
+                      sp.entity_name === activeParticipant.entity_name
+                    ) {
+                      return {
+                        ...sp,
+                        entity_settings: {
+                          ...sp.entity_settings,
+                          ...activeParticipant.entity_settings,
+                        },
+                      };
+                    }
+                    return sp;
+                  });
 
                 await addNewParticipants(selectedParticipantFiltered, createdConversation, participants => {
                   onComplete?.([
@@ -654,9 +670,25 @@ const NewConversationView = forwardRef(
             } else {
               if (selectedParticipants.length) {
                 setTimeout(async () => {
-                  const selectedParticipantFiltered = selectedParticipants.filter(
-                    p => !p.meta.added_from_agent,
-                  );
+                  const selectedParticipantFiltered = selectedParticipants
+                    .filter(p => !p.meta.added_from_agent)
+                    .map(sp => {
+                      if (
+                        sp.entity_meta?.project_id === PUBLIC_PROJECT_ID &&
+                        activeParticipant?.entity_settings?.llm_settings &&
+                        sp.entity_meta?.id === activeParticipant.entity_meta?.id &&
+                        sp.entity_name === activeParticipant.entity_name
+                      ) {
+                        return {
+                          ...sp,
+                          entity_settings: {
+                            ...sp.entity_settings,
+                            ...activeParticipant.entity_settings,
+                          },
+                        };
+                      }
+                      return sp;
+                    });
 
                   await addNewParticipants(
                     selectedParticipantFiltered,


### PR DESCRIPTION
When a user changes the LLM model for a published (public-project) agent on the Chat page, the selected model was not used — the agent executed with its default model instead.

Root cause: three separate code paths all ignored the locally-changed model:
1. transformParticipant (useAddNewParticipants) did not include llm_settings in the POST body when creating the conversation participant, so the DB always stored the default.
2. getPayload (ChatBox) did not pass the participant's entity_settings.llm_settings as unsavedLLMSettings fallback, so each predict WS message omitted the override.
3. selectedParticipantFiltered (NewConversationView, two locations) read from the stale selectedParticipants state, which is never synced when the model changes via onChangeParticipantSettings — only activeConversation.participants is updated.

Fix: guard all three code paths on entity_meta.project_id === PUBLIC_PROJECT_ID so the llm_settings override flows through only for published agents from the public project, leaving all other agent types completely unaffected.

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/5058