### PR TITLE
fix: [EL-5077] Speech-to-text highlight text invisible in light mode due to white color scheme

### DIFF
--- a/src/[fsd]/shared/ui/markdown/Token.jsx
+++ b/src/[fsd]/shared/ui/markdown/Token.jsx
@@ -33,7 +33,7 @@ const Token = memo(props => {
   } = props;
 
   const theme = useTheme();
-  const styles = getStyles();
+  const styles = getStyles(theme);
 
   const overrides = useCallback(
     rawData => ({
@@ -358,14 +358,14 @@ const Token = memo(props => {
 Token.displayName = 'Token';
 
 /**@type {MuiSx} */
-const getStyles = () => ({
+const getStyles = ({ palette }) => ({
   text: { whiteSpace: 'pre-wrap' },
   paragraph: {
     marginBlockStart: '0rem',
     marginBottom: '0.8em',
     whiteSpace: 'pre-wrap',
   },
-  mark: { background: 'transparent', color: 'white', fontWeight: 500 },
+  mark: { background: 'transparent', color: palette.text.highlighted, fontWeight: 500 },
   inline: { display: 'inline' },
 });
 

--- a/src/darkPalette.js
+++ b/src/darkPalette.js
@@ -460,6 +460,7 @@ const darkPalette = {
       logout: lightOrange,
     },
     link: blue,
+    highlighted: white,
   },
   icon: {
     main: gray10,

--- a/src/lightPalette.js
+++ b/src/lightPalette.js
@@ -459,6 +459,7 @@ const lightPalette = {
       logout: orange,
     },
     link: blue,
+    highlighted: gray60, //magenta,
   },
   icon: {
     main: light10,


### PR DESCRIPTION
- Change highlight color for light theme