### PR TITLE
fix: [EL-5078] remove chat_history from agent node

### DIFF
--- a/src/[fsd]/features/pipelines/flow-editor/lib/helpers/flowEditor.helpers.js
+++ b/src/[fsd]/features/pipelines/flow-editor/lib/helpers/flowEditor.helpers.js
@@ -113,7 +113,6 @@ const createApplicationMapping = (existingMapping, selectedToolkit) => {
   return {
     mapping: {
       task: { ...(existingMapping?.task || { type: 'fstring', value: '' }) },
-      chat_history: { ...(existingMapping?.chat_history || { type: 'fixed', value: [], dataType: 'array' }) },
       ...(selectedToolkit?.variables?.reduce((result, variable) => {
         return {
           [variable.name]: {
@@ -131,13 +130,6 @@ const createApplicationMapping = (existingMapping, selectedToolkit) => {
         value: '',
         data_type: 'string',
       },
-      chat_history: {
-        tooltip:
-          "Chat History relevant for agent. Array of messages, each with 'content' and 'type' fields. Example: [{'content': 'Hello', 'type': 'human'}, {'content': 'Hi there!', 'type': 'ai'}]",
-        type: 'fixed',
-        value: Object.keys(existingMapping || {}).includes('chat_history') ? [] : '', // if chat_history already exists in mapping, default to empty array, otherwise default to empty string in order not to confuse the user that chat_history is in the mapping when it's not
-        data_type: 'array',
-      },
       ...(selectedToolkit?.variables?.reduce((result, variable) => {
         return {
           [variable.name]: {
@@ -151,7 +143,6 @@ const createApplicationMapping = (existingMapping, selectedToolkit) => {
     },
     defaultValues: {
       task: '',
-      chat_history: [],
     },
   };
 };
@@ -355,7 +346,6 @@ export const getDefaultInputMappingOfTool = (
 const createApplicationTooltips = selectedToolkit => {
   const tooltips = {
     task: 'Provides the main instruction or task for the agent being called.',
-    chat_history: 'Defines how chat history is passed to the agent being called',
   };
   selectedToolkit?.settings?.variables?.forEach(variable => {
     tooltips[variable.name] = 'This is a variable from the agent';

--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/InputMappingItem.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/InputMappingItem.jsx
@@ -147,13 +147,7 @@ const InputMappingItem = memo(props => {
   } = props;
   const inputOptions = useInputOptions();
   const isStringType = type === 'string' || type === 'fstring' || type === 'fixed';
-  const typeOptions = useMemo(
-    () =>
-      FlowEditorConstants.agentTaskTypeOptions.filter(
-        option => option.value !== 'fstring' || variable !== 'chat_history',
-      ),
-    [variable],
-  );
+  const typeOptions = useMemo(() => FlowEditorConstants.agentTaskTypeOptions, []);
   const onChangeType = useCallback(
     newType => {
       // Preserve value when switching between 'fstring' and 'fixed'

--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/SimpleLLMInputItem.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/SimpleLLMInputItem.jsx
@@ -121,13 +121,7 @@ const SimpleLLMInputItem = memo(props => {
     modelConfig = null,
   } = props;
 
-  const typeOptions = useMemo(
-    () =>
-      FlowEditorConstants.agentTaskTypeOptions.filter(
-        option => option.value !== 'fstring' || variable !== 'chat_history',
-      ),
-    [variable],
-  );
+  const typeOptions = useMemo(() => FlowEditorConstants.agentTaskTypeOptions, []);
   const stateVariableOptions = useInputOptions();
   const language =
     (type === 'fstring' || type === 'fixed') && variableName.toLowerCase() === 'code' ? 'python' : undefined;


### PR DESCRIPTION
# RCA: Remove `chat_history` Field from Agent Node

**Issue:** [EliteaAI/elitea_issues#5078](https://github.com/EliteaAI/elitea_issues/issues/5078)  
**Parent Issue:** [EliteaAI/elitea_issues#4790](https://github.com/EliteaAI/elitea_issues/issues/4790)  
**Milestone:** R-2.0.3  
**Date:** 2026-05-28

---

## Summary

The `chat_history` field still appears as a configurable input in the Agent node's UI (pipeline flow editor), even though it has been deprecated and is no longer consumed by sub-agents/sub-pipelines. The field became obsolete after the architectural change in issue #4790, which established `task` as the sole input contract for sub-agent invocation. The backend already marks the field as deprecated and ignores it. The fix is purely frontend.

---

## Background

Issue #4790 introduced an enhancement to **exclude `chat_history` from sub-agent payloads** and use `task` as the single source of truth for sub-agent input. The stated rationale was:

- Make sub-agent execution deterministic and reliable
- Pass all required context through the `task` field only
- Avoid cases where sub-agents ignored required context from chat history
- Establish a clean parent → sub-agent communication contract

The SDK was updated to implement this, but the UI was never cleaned up, leaving `chat_history` visible and configurable in the Agent node even though it has no effect.

---

## Root Cause

The change in #4790 deprecated `chat_history` in the SDK layer but **did not remove the field from the UI layer**. This created an inconsistency:

- **SDK ignores `chat_history` when invoking sub-agents** (`formulate_query` excludes it, the variable merge loop skips it, and the schema marks it as "Deprecated and ignored").
- **UI still renders it as a valid configurable field** in the Agent node input mapping.

The backend (`applicationToolSchema`) is not consumed by the frontend — it is used internally by the SDK for LLM tool-calling. Therefore, no backend changes are required.

---

## Component Architecture: Why Only the Frontend Needs Changing

The pipeline flow editor has two separate rendering paths for node inputs:

| Component | Used by | Handles `chat_history`? |
|-----------|---------|------------------------|
| `SimpleLLMInputs` → `SimpleLLMInputItem` | LLMNode, CodeNode, PrinterNode | Yes — `chat_history` is a real, active input for LLM prompt nodes |
| `InputMapping` → `InputMappingItem` | AgentNode, BaseToolNode, DefaultNode | Only had `chat_history` because `createApplicationMapping()` injected it |

The `fstring` type restriction for `chat_history` in `InputMappingItem` was only relevant because Agent nodes included `chat_history` in their mapping. Once removed from `createApplicationMapping()`, that filter becomes dead code.

The equivalent restriction in `SimpleLLMInputItem` must **not** be removed — LLM nodes still use `chat_history` as a real field.

---

## Affected Files and Code Locations

### Frontend — Source of the Bug

**`EliteaUI/src/[fsd]/features/pipelines/flow-editor/lib/helpers/flowEditor.helpers.js`**

`createApplicationMapping()` injected `chat_history` into the Agent node default mapping:

```js
// mapping object
chat_history: { ...(existingMapping?.chat_history || { type: 'fixed', value: [], dataType: 'array' }) },

// mappingInfo object
chat_history: {
  tooltip: "Chat History relevant for agent. ...",
  type: 'fixed',
  value: Object.keys(existingMapping || {}).includes('chat_history') ? [] : '',
  data_type: 'array',
},

// defaultValues object
chat_history: [],
```

`createApplicationTooltips()` also defined a tooltip for it:

```js
chat_history: 'Defines how chat history is passed to the agent being called',
```

**`EliteaUI/src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/InputMappingItem.jsx`**

Dead code — a `fstring` type restriction that existed only because Agent nodes had `chat_history`:

```jsx
option => option.value !== 'fstring' || variable !== 'chat_history',
```

---

### Backend — No Changes Required

The SDK already handles `chat_history` correctly:

- `applicationToolSchema` — field present but marked "Deprecated and ignored"; accepts it for backward compat with stored pipeline configs
- `formulate_query()` — `chat_history` in `excluded_keys`, never forwarded to sub-agents
- Variable merge loop — explicitly skips `chat_history`
- Top-level agent execution (`indexer_agent.py`, `pipeline_run.py`) — `chat_history` used for the parent agent's own conversation context; this is intentional and must not change

---

## Impact Analysis

| Layer | Impact | Severity |
|-------|--------|----------|
| UI — Agent node input mapping | Field shows as configurable, creates confusion | Medium |
| UI — `InputMappingItem` dead filter | Dead `fstring` guard for `chat_history` | Low |
| Existing saved pipeline configs | May have `chat_history` in stored `variables_mapping` | None — SDK already ignores it silently |
| LLM node / top-level execution | No impact — different code paths, untouched | None |

### Regression Risk

**None.** The SDK already ignores `chat_history` when invoking sub-agents. Removing it from the Agent node UI means new pipelines won't include it. Old pipelines that have it stored in their configuration will load fine — the backend accepts and silently discards it. No data migration is required.

---

## Fix Applied

### `flowEditor.helpers.js` — `createApplicationMapping()`

Removed `chat_history` from all three returned sub-objects: `mapping`, `mappingInfo`, and `defaultValues`.

### `flowEditor.helpers.js` — `createApplicationTooltips()`

Removed the `chat_history` entry from the tooltips object.

### `InputMappingItem.jsx`

Removed the dead `fstring` type filter that was specific to `chat_history`.

---

## Files Changed

| File | Repository | Change |
|------|-----------|--------|
| `src/[fsd]/features/pipelines/flow-editor/lib/helpers/flowEditor.helpers.js` | `EliteaUI` | Remove `chat_history` from `createApplicationMapping()` and `createApplicationTooltips()` |
| `src/[fsd]/features/pipelines/flow-editor/ui/settings/InputMappings/InputMappingItem.jsx` | `EliteaUI` | Remove dead `fstring` filter for `chat_history` |
