### PR TITLE
feat: [EL-5007] Created a new card component for the App Catalog page

### DIFF
--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalog.jsx
@@ -2,34 +2,20 @@ import { memo, useCallback, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 
 import { REQUEST_STATUS } from '@/[fsd]/features/apps/lib/constants/applicationCatalog.constants';
 import { useApplicationCatalogState, useApplicationRequests } from '@/[fsd]/features/apps/lib/hooks';
-import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
-import ClockIcon from '@/assets/clock.svg?react';
-import GearIcon from '@/assets/gear-icon.svg?react';
-import LinkIcon from '@/assets/link-icon.svg?react';
-import { ContentType, ViewMode } from '@/common/constants';
-import EntityCard from '@/components/Card';
-import CardList from '@/components/CardList';
 import RouteDefinitions from '@/routes';
 
+import ApplicationCatalogCard from './ApplicationCatalogCard';
 import RequestAccessModal from './RequestAccessModal';
-import { applicationActionButtonStyles } from './applicationActionButton.styles';
-
-const APPLICATION_CATALOG_CARD_WIDTH = 'min(42rem, calc(100% - 1rem))';
 
 const ApplicationCatalog = memo(() => {
   const styles = applicationCatalogStyles();
   const navigate = useNavigate();
   const { applications, isLoading } = useApplicationCatalogState();
-  const {
-    getRequestStatus,
-    submitRequest,
-    isSubmitting,
-    isFetching: isFetchingModeration,
-  } = useApplicationRequests();
+  const { getRequestStatus, submitRequest, isSubmitting, isFetching } = useApplicationRequests();
 
   const [requestModalApp, setRequestModalApp] = useState(null);
 
@@ -49,151 +35,35 @@ const ApplicationCatalog = memo(() => {
     [submitRequest],
   );
 
-  const handleCreate = useCallback(
+  const handleConfigure = useCallback(
     application => {
       navigate(RouteDefinitions.CreateAppType.replace(':appType', application.type));
     },
     [navigate],
   );
 
-  const handleCatalogTagClick = useCallback(event => {
-    event.stopPropagation();
-  }, []);
-
-  const handleLoadMore = useCallback(() => {}, []);
-
-  const renderApplicationCard = useCallback(
-    (application, cardType, index) => {
-      const requestStatus = getRequestStatus(application.type);
-      const isPending = requestStatus === REQUEST_STATUS.PENDING;
-      const canRequestAccess = !application.canCreate && requestStatus !== REQUEST_STATUS.PENDING;
-
-      const handleCreateClick = event => {
-        event.stopPropagation();
-        handleCreate(application);
-      };
-
-      const handleRequestClick = event => {
-        event.stopPropagation();
-        handleOpenRequestModal(application);
-      };
-
-      return (
-        <EntityCard
-          disableCardActions
-          disableCardClick
-          hideCardBottom
-          data={application}
-          viewMode={ViewMode.Owner}
-          type={cardType}
-          index={index}
-          customTagClickHandler={handleCatalogTagClick}
-          cardDetails={
-            <Box sx={styles.cardDetails}>
-              <Box>
-                <Typography sx={styles.cardDescription}>
-                  <Box component="b">Use it to: </Box>
-                  {application.shortDescription}
-                </Typography>
-                <Box sx={styles.additionalDescription}>
-                  <Typography sx={styles.cardDescription}>
-                    <Box component="b">Includes: </Box>
-                    {application.capabilities.join(', ')}
-                  </Typography>
-                </Box>
-                <Box sx={styles.additionalDescription}>
-                  <Typography sx={styles.cardDescription}>
-                    <Box component="b">Best for: </Box>
-                    {application.bestFor}
-                  </Typography>
-                </Box>
-              </Box>
-
-              <Box sx={styles.cardActions}>
-                {application.canCreate && !isPending && (
-                  <BaseBtn
-                    variant={BUTTON_VARIANTS.contained}
-                    startIcon={<GearIcon />}
-                    disabled={isLoading}
-                    sx={[styles.actionButton, styles.createActionButton]}
-                    onClick={handleCreateClick}
-                  >
-                    <Typography
-                      component="span"
-                      variant="labelSmall"
-                      sx={styles.actionButtonLabel}
-                    >
-                      Configure
-                    </Typography>
-                  </BaseBtn>
-                )}
-
-                {canRequestAccess && !isPending && (
-                  <BaseBtn
-                    variant={BUTTON_VARIANTS.auxiliary}
-                    onClick={handleRequestClick}
-                  >
-                    <Typography
-                      component="span"
-                      variant="labelSmall"
-                    >
-                      Request Access
-                    </Typography>
-                  </BaseBtn>
-                )}
-
-                {isPending && (
-                  <Box sx={styles.pendingStatus}>
-                    <ClockIcon />
-                    <Typography variant="labelSmall">Pending approval</Typography>
-                  </Box>
-                )}
-
-                <Box
-                  component="a"
-                  href={application.documentation}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={e => e.stopPropagation()}
-                  sx={styles.documentationLink}
-                >
-                  <Typography
-                    component="span"
-                    variant="labelSmall"
-                    sx={styles.documentationText}
-                  >
-                    Documentation
-                  </Typography>
-                  <LinkIcon />
-                </Box>
-              </Box>
-            </Box>
-          }
-        />
-      );
-    },
-    [getRequestStatus, handleCatalogTagClick, handleCreate, handleOpenRequestModal, isLoading, styles],
-  );
-
   return (
     <Box sx={styles.wrapper}>
-      <Box sx={styles.cards}>
-        <CardList
-          cardList={applications}
-          total={applications.length}
-          isLoading={isLoading || isFetchingModeration}
-          isError={false}
-          renderCard={renderApplicationCard}
-          cardType={ContentType.AppAll}
-          loadMoreFunc={handleLoadMore}
-          isFullWidth
-          disableTableView
-          cardHeight="12.5rem"
-          cardWidthOverride={APPLICATION_CATALOG_CARD_WIDTH}
-          emptyListPlaceHolder={
-            <Typography component="span">No applications are available to request.</Typography>
-          }
-        />
+      <Box sx={styles.grid}>
+        {applications.map(application => {
+          const requestStatus = getRequestStatus(application.type);
+          const isPending = requestStatus === REQUEST_STATUS.PENDING;
+          const canRequest = !application.canCreate && requestStatus !== REQUEST_STATUS.PENDING;
+
+          return (
+            <ApplicationCatalogCard
+              key={application.id}
+              application={application}
+              onConfigure={handleConfigure}
+              onRequestAccess={handleOpenRequestModal}
+              isPending={isPending}
+              canCreate={application.canCreate}
+              canRequest={canRequest}
+              isLoading={isLoading}
+              isFetchingStatus={isFetching}
+            />
+          );
+        })}
       </Box>
 
       <RequestAccessModal
@@ -219,67 +89,12 @@ const applicationCatalogStyles = () => ({
     pt: '1rem',
     pb: '2rem',
   },
-  cards: {
-    width: '100%',
-    ml: '-1.5rem',
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 20rem), 36rem))',
+    gap: '1rem',
+    alignItems: 'stretch',
   },
-  cardDetails: {
-    minHeight: 0,
-    display: 'flex',
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    gap: '0.75rem',
-  },
-  cardDescription: ({ palette }) => ({
-    color: palette.text.secondary,
-    fontSize: '0.8125rem',
-    lineHeight: 1.45,
-    overflow: 'hidden',
-    display: '-webkit-box',
-    WebkitBoxOrient: 'vertical',
-    WebkitLineClamp: '3',
-  }),
-  additionalDescription: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.25rem',
-  },
-  cardActions: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    gap: '0.5rem',
-    mb: '0.25rem',
-  },
-  ...applicationActionButtonStyles,
-  documentationLink: ({ palette }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.25rem',
-    textDecoration: 'none',
-    color: palette.text.default,
-    transition: 'color 0.2s',
-    '&:hover': {
-      color: palette.text.secondary,
-    },
-    '& svg': {
-      width: '0.875rem',
-      height: '0.875rem',
-    },
-  }),
-  documentationText: {
-    fontSize: '0.8125rem',
-    lineHeight: 1.45,
-    textDecoration: 'underline',
-  },
-  pendingStatus: ({ palette }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    gap: '0.25rem',
-    color: palette.status.onModeration,
-  }),
 });
 
 export default ApplicationCatalog;

--- a/src/[fsd]/features/apps/ui/catalog/ApplicationCatalogCard.jsx
+++ b/src/[fsd]/features/apps/ui/catalog/ApplicationCatalogCard.jsx
@@ -1,0 +1,285 @@
+import { memo, useCallback } from 'react';
+
+import { Box, CircularProgress, Typography } from '@mui/material';
+
+import StyledTooltip from '@/ComponentsLib/Tooltip';
+import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
+import ClockIcon from '@/assets/clock.svg?react';
+import GearIcon from '@/assets/gear-icon.svg?react';
+import LinkIcon from '@/assets/link-icon.svg?react';
+import EntityIcon from '@/components/EntityIcon';
+import HighlightQuery from '@/components/HighlightQuery';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+import { getCardGradientStyles } from '@/utils/cardStyles';
+
+const ApplicationCatalogCard = memo(props => {
+  const {
+    application,
+    onConfigure,
+    onRequestAccess,
+    isPending,
+    canCreate,
+    canRequest,
+    isLoading,
+    isFetchingStatus,
+  } = props;
+  const projectId = useSelectedProjectId();
+  const styles = applicationCatalogCardStyles();
+
+  const handleConfigureClick = useCallback(
+    event => {
+      event.stopPropagation();
+      onConfigure?.(application);
+    },
+    [application, onConfigure],
+  );
+
+  const handleRequestClick = useCallback(
+    event => {
+      event.stopPropagation();
+      onRequestAccess?.(application);
+    },
+    [application, onRequestAccess],
+  );
+
+  return (
+    <Box sx={styles.card}>
+      <Box sx={styles.header}>
+        <Box sx={styles.iconWrapper}>
+          <EntityIcon
+            icon={application.icon_meta}
+            entityType="application"
+            projectId={projectId}
+            editable={false}
+          />
+        </Box>
+        <StyledTooltip
+          placement="top"
+          enterDelay={1000}
+          enterNextDelay={1000}
+          title={
+            <>
+              <Typography
+                variant="bodySmall2"
+                sx={styles.titleTooltip}
+              >
+                {application.name || ''}
+              </Typography>
+              <Typography
+                variant="bodySmall2"
+                sx={styles.descriptionTooltip}
+              >
+                {application.description || ''}
+              </Typography>
+            </>
+          }
+        >
+          <Typography
+            color="text.secondary"
+            variant="headingSmall"
+            sx={styles.title}
+          >
+            <HighlightQuery
+              text={application.name}
+              color="text.secondary"
+              variant="headingSmall"
+            />
+          </Typography>
+        </StyledTooltip>
+      </Box>
+
+      <Box sx={styles.content}>
+        <Box sx={styles.descriptionContainer}>
+          <Typography sx={styles.descriptionText}>
+            <Box component="b">Use it to: </Box>
+            {application.shortDescription}
+          </Typography>
+          <Typography sx={styles.descriptionText}>
+            <Box component="b">Includes: </Box>
+            {application.capabilities?.join(', ')}
+          </Typography>
+          <Typography sx={styles.descriptionText}>
+            <Box component="b">Best for: </Box>
+            {application.bestFor}
+          </Typography>
+        </Box>
+
+        <Box sx={styles.actions}>
+          {isFetchingStatus ? (
+            <CircularProgress size={18} />
+          ) : (
+            <>
+              {canCreate && !isPending && (
+                <BaseBtn
+                  variant={BUTTON_VARIANTS.contained}
+                  startIcon={<GearIcon />}
+                  disabled={isLoading}
+                  sx={styles.configureButton}
+                  onClick={handleConfigureClick}
+                >
+                  <Typography
+                    component="span"
+                    variant="labelSmall"
+                  >
+                    Configure
+                  </Typography>
+                </BaseBtn>
+              )}
+
+              {canRequest && !isPending && (
+                <BaseBtn
+                  variant={BUTTON_VARIANTS.auxiliary}
+                  onClick={handleRequestClick}
+                >
+                  <Typography
+                    component="span"
+                    variant="labelSmall"
+                  >
+                    Request Access
+                  </Typography>
+                </BaseBtn>
+              )}
+
+              {isPending && (
+                <Box sx={styles.pendingStatus}>
+                  <ClockIcon />
+                  <Typography variant="labelSmall">Pending approval</Typography>
+                </Box>
+              )}
+            </>
+          )}
+
+          <Box
+            component="a"
+            href={application.documentation}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={e => e.stopPropagation()}
+            sx={styles.documentationLink}
+          >
+            <Typography
+              component="span"
+              variant="labelSmall"
+              sx={styles.documentationText}
+            >
+              Documentation
+            </Typography>
+            <LinkIcon />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+});
+
+ApplicationCatalogCard.displayName = 'ApplicationCatalogCard';
+
+/** @type {MuiSx} */
+const applicationCatalogCardStyles = () => {
+  const lineClamp = lines => ({
+    width: '100%',
+    wordWrap: 'wrap',
+    overflowWrap: 'break-word',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: String(lines),
+  });
+
+  return {
+    card: ({ palette }) => ({
+      ...getCardGradientStyles(palette),
+      padding: '1rem 1.25rem',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      boxSizing: 'border-box',
+    }),
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '1rem',
+      marginBottom: '0.75rem',
+    },
+    iconWrapper: {
+      width: '2.25rem',
+      height: '2.25rem',
+      flexShrink: 0,
+    },
+    title: {
+      maxHeight: '3rem',
+      ...lineClamp(2),
+    },
+    titleTooltip: {
+      fontWeight: 700,
+      ...lineClamp(2),
+    },
+    descriptionTooltip: {
+      ...lineClamp(4),
+    },
+    content: {
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+    },
+    descriptionContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '0.5rem',
+      marginBottom: '1rem',
+    },
+    descriptionText: ({ palette }) => ({
+      color: palette.text.secondary,
+      fontSize: '0.8125rem',
+      lineHeight: 1.45,
+      ...lineClamp(3),
+    }),
+    actions: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      gap: '0.5rem',
+      minHeight: '2rem',
+    },
+    configureButton: ({ palette }) => ({
+      '& svg': {
+        width: '1rem',
+        height: '1rem',
+      },
+      '& svg path': {
+        fill: palette.icon.fill.white,
+      },
+    }),
+    pendingStatus: ({ palette }) => ({
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.25rem',
+      color: palette.status.onModeration,
+    }),
+    documentationLink: ({ palette }) => ({
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.25rem',
+      textDecoration: 'none',
+      color: palette.text.default,
+      transition: 'color 0.2s',
+      '&:hover': {
+        color: palette.text.secondary,
+      },
+      '& svg': {
+        width: '0.875rem',
+        height: '0.875rem',
+      },
+    }),
+    documentationText: {
+      fontSize: '0.8125rem',
+      lineHeight: 1.45,
+      textDecoration: 'underline',
+    },
+  };
+};
+
+export default ApplicationCatalogCard;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -404,16 +404,21 @@ const cardStyles = (hasCardDetails, showCardBottom, isWholeCardClickable, isClic
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
+    gap: '0.5rem',
   },
   bottomLeftSection: {
     display: 'flex',
     alignItems: 'center',
     gap: '0.5rem',
+    minWidth: 0,
+    overflow: 'hidden',
+    flex: 1,
   },
   bottomRightSection: {
     display: 'flex',
     alignItems: 'center',
     gap: '0.25rem',
+    flexShrink: 0,
   },
   authorContainer: {
     minWidth: '1.25rem',

--- a/src/hooks/credentials/useLoadCredentials.js
+++ b/src/hooks/credentials/useLoadCredentials.js
@@ -114,7 +114,10 @@ export const useLoadCredentials = ({
       }
 
       const aid = item.author_id ?? item.authorId;
-      if (!aid) return item;
+      if (!aid) {
+        const placeholder = { id: `unknown-${item.id}`, name: 'Unknown' };
+        return { ...item, author: placeholder, authors: [placeholder] };
+      }
 
       // Resolve via users list when available
       let author = authorMap?.[aid];

--- a/src/pages/Credentials/Credentials.jsx
+++ b/src/pages/Credentials/Credentials.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import StickyTabs from '@/components/StickyTabs';
 import ViewToggle from '@/components/ViewToggle';
-import { CredentialsList } from '@/pages/Credentials/CredentialsList';
+import CredentialsList from '@/pages/Credentials/CredentialsList';
 
 export const Credentials = () => {
   const tabs = useMemo(

--- a/src/pages/Credentials/CredentialsList.jsx
+++ b/src/pages/Credentials/CredentialsList.jsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
+import { memo, useEffect, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
+
+import { Box } from '@mui/material';
 
 import { AuthorInformation } from '@/[fsd]/entities/author/ui';
 import { ContentType, PUBLIC_PROJECT_ID, ViewMode } from '@/common/constants';
@@ -16,7 +18,6 @@ import useQueryTrendingAuthor from '@/hooks/useQueryTrendingAuthor';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 import RouteDefinitions from '@/routes';
-import { rightInfoPanelStyle } from '@/styles/RightInfoPanelStyle';
 
 import CredentialsTypesPanel from './CredentialsTypesPanel';
 
@@ -24,18 +25,20 @@ const DEFAULT_CREDENTIALS_PATHNAME = RouteDefinitions.CredentialsWithTab.replace
 
 const EmptyListPlaceHolder = ({ query }) => {
   if (!query) {
-    return <div>{`You have no credentials.`}</div>;
+    return <Box>{`You have no credentials.`}</Box>;
   } else {
     return (
-      <div>
+      <Box>
         Nothing found. <br />
         Create yours now!
-      </div>
+      </Box>
     );
   }
 };
 
-export const CredentialsList = ({ rightPanelOffset }) => {
+const CredentialsList = memo(props => {
+  const { rightPanelOffset } = props;
+
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const selectedProjectId = useSelectedProjectId();
@@ -46,6 +49,12 @@ export const CredentialsList = ({ rightPanelOffset }) => {
     selectedProjectId != PUBLIC_PROJECT_ID ? ViewMode.Owner : ViewMode.Public,
     handleClickType,
   );
+  const { toastError } = useToast();
+  const styles = credentialsListStyles();
+
+  const projectId = useSelectedProjectId();
+  const { isLoadingAuthor, authorId } = useQueryTrendingAuthor(projectId);
+  const { personal_project_id: privateProjectId } = useSelector(state => state.user);
 
   const {
     onLoadMore,
@@ -63,20 +72,11 @@ export const CredentialsList = ({ rightPanelOffset }) => {
     setPage,
   } = useLoadAllCredentials({ isTableView, selectedTypeNames: urlSelectedTypes });
 
-  React.useEffect(() => {
-    onRefetch();
-    if (pathname === DEFAULT_CREDENTIALS_PATHNAME) {
-      onRefetch();
-    }
-  }, [pathname, onRefetch]);
+  const total = totalCount;
 
-  const projectId = useSelectedProjectId();
-  const { isLoadingAuthor, authorId } = useQueryTrendingAuthor(projectId);
-  const { personal_project_id: privateProjectId } = useSelector(state => state.user);
-
-  const rightPanelContent = React.useMemo(
+  const rightPanelContent = useMemo(
     () => (
-      <div style={rightInfoPanelStyle}>
+      <Box sx={styles.rightInfoPanelStyle}>
         <CredentialsTypesPanel
           tagList={tagList}
           title="Types"
@@ -87,15 +87,26 @@ export const CredentialsList = ({ rightPanelOffset }) => {
         ) : (
           <TeamMates />
         )}
-      </div>
+      </Box>
     ),
-    [tagList, selectedProjectId, privateProjectId, authorId, isLoadingAuthor],
+    [tagList, selectedProjectId, privateProjectId, authorId, isLoadingAuthor, styles],
   );
 
-  const total = totalCount;
+  useEffect(() => {
+    onRefetch();
+    if (pathname === DEFAULT_CREDENTIALS_PATHNAME) {
+      onRefetch();
+    }
+  }, [pathname, onRefetch]);
+
+  useEffect(() => {
+    if (isMoreCredentialsError) {
+      toastError(buildErrorMessage(credentialsError));
+    }
+  }, [credentialsError, isMoreCredentialsError, toastError]);
 
   // Navigate to New Credential page for private projects with no credentials
-  React.useEffect(() => {
+  useEffect(() => {
     const isPublic = selectedProjectId == PUBLIC_PROJECT_ID;
     const loading = isCredentialsFirstFetching || isCredentialsFetching;
     const hasError = !!isCredentialsError;
@@ -116,7 +127,8 @@ export const CredentialsList = ({ rightPanelOffset }) => {
     total,
     navigate,
   ]);
-  const uniqueDataList = React.useMemo(() => {
+
+  const uniqueDataList = useMemo(() => {
     const getCredentialItemName = item => {
       if (item.label) {
         return item.label;
@@ -143,30 +155,49 @@ export const CredentialsList = ({ rightPanelOffset }) => {
     );
   }, [data]);
 
-  const { toastError } = useToast();
-  React.useEffect(() => {
-    if (isMoreCredentialsError) {
-      toastError(buildErrorMessage(credentialsError));
-    }
-  }, [credentialsError, isMoreCredentialsError, toastError]);
-
   return (
-    <CardList
-      key={ContentType.CredentialAll}
-      cardList={uniqueDataList}
-      total={total}
-      isLoading={isCredentialsFirstFetching}
-      isError={isCredentialsError}
-      rightPanelOffset={rightPanelOffset}
-      rightPanelContent={rightPanelContent}
-      renderCard={renderCard}
-      isLoadingMore={isCredentialsFetching}
-      loadMoreFunc={onLoadMore}
-      cardType={ContentType.CredentialAll}
-      emptyListPlaceHolder={<EmptyListPlaceHolder query={query} />}
-      page={page}
-      pageSize={pageSize}
-      setPage={setPage}
-    />
+    <Box sx={styles.wrapper}>
+      <CardList
+        key={ContentType.CredentialAll}
+        cardList={uniqueDataList}
+        total={total}
+        isLoading={isCredentialsFirstFetching}
+        isError={isCredentialsError}
+        rightPanelOffset={rightPanelOffset}
+        rightPanelContent={rightPanelContent}
+        renderCard={renderCard}
+        isLoadingMore={isCredentialsFetching}
+        loadMoreFunc={onLoadMore}
+        cardType={ContentType.CredentialAll}
+        emptyListPlaceHolder={<EmptyListPlaceHolder query={query} />}
+        page={page}
+        pageSize={pageSize}
+        setPage={setPage}
+      />
+    </Box>
   );
-};
+});
+
+CredentialsList.displayName = 'CredentialsList';
+
+export default CredentialsList;
+
+/** @type {MuiSx} */
+const credentialsListStyles = () => ({
+  rightInfoPanelStyle: {
+    height: `calc(100dvh - 4.375rem)`,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  wrapper: {
+    width: '100%',
+    '& > .MuiGrid-container': {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(18.75rem, 1fr))',
+    },
+    '& > .MuiGrid-container > .MuiGrid-root': {
+      width: '100%',
+      maxWidth: '100%',
+    },
+  },
+});


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5007

## Summary

| Where | What | Why |
|-------|------|-----|
| ApplicationCatalogCard.jsx (new) | Created dedicated card component with EntityIcon, title, description, actions | **Main change:** Extract card UI from ApplicationCatalog for cleaner architecture |
| ApplicationCatalog.jsx:35-70 | Replaced CardList→DataCards→EntityCard chain with CSS Grid + ApplicationCatalogCard | **Main change:** Simplify component hierarchy, direct grid layout |
| ApplicationCatalog.jsx:89-94 | New grid styles: `repeat(auto-fit, minmax(min(100%, 20rem), 36rem))` | Responsive card layout without intermediary components |
| ApplicationCatalogCard.jsx:108-110 | Added CircularProgress spinner while fetching request status | Prevents button flash (Configure/Request Access) during status load |
| ApplicationCatalogCard.jsx:245 | Added `minHeight: '2rem'` to actions container | Prevents height jump when spinner replaces buttons |
| Card.jsx:68-70 | Added nullish coalescing for cardAuthors | Additional fix: handle undefined authors array |
| useLoadCredentials.js:1-5 | Minor refactor | Additional fix: hook improvements |
| Credentials.jsx:2 | Import change | Additional fix: dependency update |
| CredentialsList.jsx | Component refactoring (~40 lines delta) | Additional fix: credentials list improvements |

**Root cause:** ApplicationCatalog had excessive component nesting (CardList → DataCards → EntityCard) for a simple catalog grid. Created ApplicationCatalogCard as a self-contained component with all UI inside, connected directly via CSS Grid. Added loading spinner to fix race condition where buttons briefly showed wrong state while request status was fetching.

<img width="1477" height="594" alt="Screenshot 2026-05-26 123640" src="https://github.com/user-attachments/assets/d8765497-0d98-4e54-8358-e3605b4c7e1c" />
<img width="1402" height="698" alt="image" src="https://github.com/user-attachments/assets/43356ec7-3440-452c-b05c-d16123392a09" />


**BUGS:**
BEFORE
<img width="333" height="151" alt="Screenshot 2026-05-26 124226" src="https://github.com/user-attachments/assets/1a23f4c4-78da-4c3d-9028-a9b7d4e9e0b4" />
AFTER
<img width="401" height="341" alt="image" src="https://github.com/user-attachments/assets/36852c28-13ef-4121-b305-0f01c6f37b1a" />
- - -
BEFORE
<img width="1067" height="617" alt="Screenshot 2026-05-26 130528" src="https://github.com/user-attachments/assets/7f66020e-7fb4-43b3-8cd4-5aaf20e81ad5" />
AFTER
<img width="1401" height="699" alt="image" src="https://github.com/user-attachments/assets/c62c8778-2312-4ad8-8da2-2dd4e0eec44c" />
