### PR TITLE
fix: [EL-5013] preserve attachment state across toggle and save

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AttachmentSwitch.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AttachmentSwitch.jsx
@@ -5,6 +5,7 @@ import YAML from 'js-yaml';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  DefaultState,
   STATE_INPUT_ATTACHMENTS,
   StateVariableTypes,
 } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
@@ -64,7 +65,7 @@ const AttachmentSwitch = memo(({ disabled }) => {
 
       // Sync input_attachments state variable in pipeline YAML
       if (isPipeline) {
-        const currentState = yamlJsonObject?.state || {};
+        const currentState = yamlJsonObject?.state || { ...DefaultState };
         const alreadyHasKey = STATE_INPUT_ATTACHMENTS in currentState;
 
         if (checkedValue && !alreadyHasKey) {

--- a/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
+++ b/src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js
@@ -5,6 +5,7 @@ import YAML from 'js-yaml';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  DefaultState,
   STATE_INPUT_ATTACHMENTS,
   StateVariableTypes,
 } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
@@ -34,7 +35,7 @@ export const usePipelineAttachmentYamlSync = () => {
 
   useEffect(() => {
     const currentYamlObj = yamlJsonObjectRef.current;
-    const currentState = currentYamlObj?.state || {};
+    const currentState = currentYamlObj?.state || { ...DefaultState };
     const alreadyHasKey = STATE_INPUT_ATTACHMENTS in currentState;
 
     if (hasAttachments && !alreadyHasKey) {

--- a/src/pages/NewChat/PipelineEditor.jsx
+++ b/src/pages/NewChat/PipelineEditor.jsx
@@ -66,7 +66,6 @@ const PipelineEditorContent = memo(props => {
   const styles = getStyles();
 
   useConversationStartersSync(onConversationStartersChange);
-  usePipelineAttachmentYamlSync();
 
   // LLM Settings setter for the modal dialog
   const onLLMSettingsChange = useCallback(
@@ -104,6 +103,17 @@ const PipelineEditorContent = memo(props => {
 });
 
 PipelineEditorContent.displayName = 'PipelineEditorContent';
+
+// Always-mounted component that keeps input_attachments in sync regardless of active tab.
+// Must live inside BaseEditor's children so it has access to Formik context.
+// memo() prevents re-renders from parent state changes; the component still re-renders
+// when its own Formik/Redux subscriptions change, which is exactly when sync is needed.
+const PipelineAttachmentYamlSync = memo(() => {
+  usePipelineAttachmentYamlSync();
+  return null;
+});
+
+PipelineAttachmentYamlSync.displayName = 'PipelineAttachmentYamlSync';
 
 const PipelineEditor = forwardRef(
   (
@@ -486,6 +496,7 @@ const PipelineEditor = forwardRef(
             projectId={pipeline?.entity_meta?.project_id || projectId}
             isCreateMode={isCreateMode}
           />
+          <PipelineAttachmentYamlSync />
 
           {isCreateMode && (
             <CreateAgentForm


### PR DESCRIPTION
# fix: [EL-5013] Preserve attachment-related pipeline state across toggle and save

## Problems

After enabling **File Attachments** in pipeline settings and saving, the `input`, `messages`, and other
default state variables appeared **disabled** in the STATE panel.

There was also a follow-up regression on the chat page pipeline editor: after saving from the **Flow Editor**
tab, `input_attachments` disappeared from the STATE panel and the YAML/canvas looked empty until switching
back to the Configuration tab and then returning to the Flow Editor tab.

### Root cause

When a pipeline has no explicit `state` section yet in its YAML (`yamlJsonObject.state` is `undefined`), the
code building the new state object fell back to an empty object `{}`:

```js
// ❌ Before
const currentState = currentYamlObj?.state || {};
// → built: { state: { input_attachments: {...} } }
//   'input' and 'messages' are absent
```

Once the state became an explicit object containing only `input_attachments`, the `StateVariableList` check
failed:

```jsx
enabled={!states || !!states?.input}
//        false  ||  undefined  →  false  (disabled!)
```

`input` and `messages` only render as **enabled** when the whole `states` object is `null/undefined` (implicit
defaults) **or** they are present as explicit keys. Creating a state object with only `input_attachments`
broke both conditions.

## Fix

Replace the `|| {}` fallback with `|| { ...DefaultState }` in both locations where `input_attachments` is
added to the YAML state. This ensures `input` and `messages` are always included as the baseline before
`input_attachments` is merged in — consistent with how `StateDrawer.jsx` already handles the same operation in
`handleToggleState`.

```js
// ✅ After
const currentState = currentYamlObj?.state || { ...DefaultState };
```

For the post-save regression, keep the YAML sync hook mounted for the entire lifetime of the editor form
instead of only while the Configuration tab content is rendered. `BaseEditor` already places all children
inside Formik, so the sync can run from an always-mounted render-null component and react to save/reset
updates even when the active tab is Flow Editor.

```jsx
<ApplicationValidator ... />
<PipelineAttachmentYamlSync />
{activeTab === 0 && <PipelineEditorContent ... />}
{activeTab === 1 && <EditorPanel ... />}
```

## Files changed

- `src/[fsd]/features/pipelines/lib/hooks/usePipelineAttachmentYamlSync.hooks.js`
- `src/[fsd]/features/agent/ui/agent-details/configurations/switch/AttachmentSwitch.jsx`
- `src/pages/NewChat/PipelineEditor.jsx`
