### PR TITLE
fix: [EL-5104] Fixed behavior of a truncated text in the Code Mirror Editor

### DIFF
--- a/src/[fsd]/shared/lib/hooks/useCodeMirror.hooks.js
+++ b/src/[fsd]/shared/lib/hooks/useCodeMirror.hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { CodeMirrorEditorHelpers } from '@/[fsd]/shared/lib/helpers';
 import useEliteATheme from '@/hooks/useEliteATheme';
@@ -11,10 +11,14 @@ export const useCodeMirror = props => {
 
   const [code, setCode] = useState(value);
   const [debounceTimeout, setDebounceTimeout] = useState(null);
+  const lastNotifiedValueRef = useRef(value);
   const { isDarkMode } = useEliteATheme();
 
   useEffect(() => {
-    setCode(value);
+    if (value !== lastNotifiedValueRef.current) {
+      setCode(value);
+      lastNotifiedValueRef.current = value;
+    }
   }, [value]);
 
   const basicExtensions = useMemo(
@@ -42,6 +46,7 @@ export const useCodeMirror = props => {
       }
       // Set a new timeout to update Formik's state after a delay
       const timeout = setTimeout(() => {
+        lastNotifiedValueRef.current = newValue;
         notifyChange?.(newValue);
       }, 30);
 

--- a/src/[fsd]/shared/ui/field/CodeMirrorEditor.jsx
+++ b/src/[fsd]/shared/ui/field/CodeMirrorEditor.jsx
@@ -16,10 +16,20 @@ const createMaxLengthExtension = maxLength => {
   }
 
   return EditorState.transactionFilter.of(tr => {
-    if (tr.newDoc.length > maxLength) {
-      return [];
-    }
-    return tr;
+    if (!tr.docChanged) return tr;
+    if (tr.newDoc.length <= maxLength) return tr;
+
+    const truncatedText = tr.newDoc.sliceString(0, maxLength);
+    const cursorPos = Math.min(tr.selection.main.head, truncatedText.length);
+
+    return tr.startState.update({
+      changes: {
+        from: 0,
+        to: tr.startState.doc.length,
+        insert: truncatedText,
+      },
+      selection: { anchor: cursorPos },
+    });
   });
 };
 


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5104

## Summary

| Where | What | Why |
|-------|------|-----|
| CodeMirrorEditor.jsx:18-31 | Replaced transaction blocking with truncation logic | **Main fix:** Paste exceeding limit was fully blocked instead of truncated |
| CodeMirrorEditor.jsx:23 | Added cursor position preservation after truncation | Additional fix: cursor jumped to position 0 after paste |
| useCodeMirror.hooks.js:14 | Added `lastNotifiedValueRef` to track sent values | Additional fix: race condition caused text disappearing after pause |
| useCodeMirror.hooks.js:17-22 | Modified useEffect to ignore "echo" updates | Additional fix: prevents rollback when debounced value returns from parent |
| useCodeMirror.hooks.js:51 | Update ref before notifyChange | Additional fix: marks value as "ours" before sending to parent |

**Root cause:** Two separate issues in CodeMirror integration:
1. `transactionFilter` returned empty array `[]` when exceeding maxLength (blocked entirely) instead of creating a new transaction with truncated text
2. Bidirectional sync between CodeMirror and Formik had race condition — debounced value returned from parent triggered useEffect which overwrote current editor state


<img width="1555" height="648" alt="Screenshot 2026-06-02 133749" src="https://github.com/user-attachments/assets/568d84bd-095a-4157-88a0-e780d827102f" />
