### PR TITLE
feat(chat): [EL-4942] Edit and re-submit last user message

### DIFF
--- a/src/components/Chat/ChatMessageList.jsx
+++ b/src/components/Chat/ChatMessageList.jsx
@@ -13,8 +13,6 @@ import UserMessage from '@/components/Chat/UserMessage';
 import { isParticipantStillActive } from '@/hooks/chat/useParticipantName';
 import { actions as chatActions, selectMessageIdToView } from '@/slices/chat';
 
-const isEditAPIReady = true;
-
 const ChatMessageList = memo(props => {
   const {
     sx,
@@ -58,14 +56,25 @@ const ChatMessageList = memo(props => {
   // Simplified autoscroll: scroll new message to top of viewport
   const [bottomSpacer, setBottomSpacer] = useState(0);
   const { id: userId } = useSelector(state => state.user);
+
   const canDeleteAllMessage = useMemo(
     () => activeConversation?.author_id === userId,
     [activeConversation?.author_id, userId],
   );
+
   const lastUserMessageIndex = useMemo(
     () => chat_history.reduce((last, msg, i) => (msg.role === ROLES.User ? i : last), -1),
     [chat_history],
   );
+
+  const getOnSubmit = useCallback(
+    (message, index) =>
+      userId === message.user_id && index === lastUserMessageIndex && !isLoading && !isStreaming
+        ? onSubmitEditedMessage
+        : undefined,
+    [userId, lastUserMessageIndex, isLoading, isStreaming, onSubmitEditedMessage],
+  );
+
   const onClickSentTo = useCallback(
     participant => () => {
       if (participant && onSelectParticipant) {
@@ -232,15 +241,7 @@ const ChatMessageList = memo(props => {
                   ? onDeleteAnswer(message.id)
                   : undefined
               }
-              onSubmit={
-                isEditAPIReady &&
-                userId === message.user_id &&
-                index === lastUserMessageIndex &&
-                !isLoading &&
-                !isStreaming
-                  ? onSubmitEditedMessage
-                  : undefined
-              }
+              onSubmit={getOnSubmit(message, index)}
               onRemoveAttachment={onRemoveAttachment}
             />
           ) : (

--- a/src/components/Chat/ChatMessageList.jsx
+++ b/src/components/Chat/ChatMessageList.jsx
@@ -13,7 +13,7 @@ import UserMessage from '@/components/Chat/UserMessage';
 import { isParticipantStillActive } from '@/hooks/chat/useParticipantName';
 import { actions as chatActions, selectMessageIdToView } from '@/slices/chat';
 
-const isEditAPIReady = false;
+const isEditAPIReady = true;
 
 const ChatMessageList = memo(props => {
   const {
@@ -61,6 +61,10 @@ const ChatMessageList = memo(props => {
   const canDeleteAllMessage = useMemo(
     () => activeConversation?.author_id === userId,
     [activeConversation?.author_id, userId],
+  );
+  const lastUserMessageIndex = useMemo(
+    () => chat_history.reduce((last, msg, i) => (msg.role === ROLES.User ? i : last), -1),
+    [chat_history],
   );
   const onClickSentTo = useCallback(
     participant => () => {
@@ -228,7 +232,15 @@ const ChatMessageList = memo(props => {
                   ? onDeleteAnswer(message.id)
                   : undefined
               }
-              onSubmit={isEditAPIReady && userId === message.user_id ? onSubmitEditedMessage : undefined}
+              onSubmit={
+                isEditAPIReady &&
+                userId === message.user_id &&
+                index === lastUserMessageIndex &&
+                !isLoading &&
+                !isStreaming
+                  ? onSubmitEditedMessage
+                  : undefined
+              }
               onRemoveAttachment={onRemoveAttachment}
             />
           ) : (

--- a/src/components/Chat/UserMessage.jsx
+++ b/src/components/Chat/UserMessage.jsx
@@ -70,9 +70,12 @@ const UserMessage = React.forwardRef((props, ref) => {
   }, []);
 
   const onClickSubmit = useCallback(() => {
-    onSubmit(messageId, value);
+    const updatedItems = questionItem
+      ? [{ uuid: questionItem.uuid, content: value, item_type: 'text_message' }]
+      : [];
+    onSubmit(messageId, updatedItems);
     setIsEditing(false);
-  }, [messageId, onSubmit, value]);
+  }, [messageId, onSubmit, questionItem, value]);
 
   const isSentToDummyParticipant =
     sentTo &&
@@ -244,7 +247,7 @@ const UserMessage = React.forwardRef((props, ref) => {
               disabled={value === content}
               onClick={onClickSubmit}
             >
-              Submit
+              Save and apply
             </Button>
             <Button
               variant="elitea"

--- a/src/components/Chat/UserMessage.jsx
+++ b/src/components/Chat/UserMessage.jsx
@@ -57,13 +57,14 @@ const UserMessage = React.forwardRef((props, ref) => {
   );
 
   const onEdit = useCallback(() => {
+    setValue(content || questionItem?.item_details?.content || '');
     setIsEditing(true);
-  }, []);
+  }, [content, questionItem]);
 
   const onCancel = useCallback(() => {
     setIsEditing(false);
-    setValue(content);
-  }, [content]);
+    setValue(content || questionItem?.item_details?.content || '');
+  }, [content, questionItem]);
 
   const onChange = useCallback(event => {
     setValue(event.target.value);
@@ -363,6 +364,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'row-reverse',
     alignItems: 'center',
+    gap: '0.5rem',
     marginTop: '0.5rem',
   },
   submitButton: {

--- a/src/pages/NewChat/ChatBox.jsx
+++ b/src/pages/NewChat/ChatBox.jsx
@@ -1072,32 +1072,8 @@ const ChatBox = forwardRef((props, boxRef) => {
     [chat_history, toastError, toastSuccess],
   );
 
-  const onRegenerateAnswerStream = useCallback(
-    (id, question, questionId) => async () => {
-      stopTTS?.();
-      chatInput.current?.pauseSpeakingMode?.();
-      const questionIndex = chat_history.findIndex(item => item.id === id) - 1;
-      const theQuestion = question || chat_history[questionIndex]?.content;
-      const question_id = questionId || chat_history[questionIndex]?.id;
-      const leftChatHistory = chat_history.slice(0, questionIndex);
-      const { participant_id } = chat_history.find(item => item.question_id === question_id) || {};
-      const participant = getParticipantById(activeConversation, participant_id);
-
-      const payload = getPayload({
-        question: theQuestion,
-        question_id,
-        chatHistory: leftChatHistory,
-        participant,
-        attachmentList: [],
-      });
-      payload.payload.message_id = id;
-      emit(payload);
-    },
-    [chat_history, activeConversation, getPayload, emit, stopTTS],
-  );
-
   const onRegenerateAnswer = useCallback(
-    (uuid, messageParticipant) => async () => {
+    (uuid, messageParticipant, updatedItems) => async () => {
       stopTTS();
       chatInput.current?.pauseSpeakingMode?.();
       let prevMessage = {};
@@ -1142,6 +1118,9 @@ const ChatBox = forwardRef((props, boxRef) => {
       });
       payload.message_id = uuid;
       payload.stream_id = uuid;
+      if (updatedItems?.length) {
+        payload.updated_items = updatedItems;
+      }
       setTimeout(() => {
         setStreamingInfo(question_id);
       }, 20);
@@ -1473,12 +1452,32 @@ const ChatBox = forwardRef((props, boxRef) => {
   );
 
   const onSubmitEditedMessage = useCallback(
-    (id, question) => {
-      const { id: answerId } = chat_history.find(item => item.question_id === id) || {};
-      setChatHistory(prev => prev.map(item => (item.id === id ? { ...item, content: question } : item)));
-      answerId ? onRegenerateAnswerStream(answerId, question)() : onResendQuestionStream(id, question);
+    (id, updatedItems) => {
+      const textUpdate = updatedItems?.find(u => u.item_type === 'text_message');
+      setChatHistory(prev =>
+        prev.map(item => {
+          if (item.id !== id) return item;
+          return {
+            ...item,
+            ...(textUpdate ? { content: textUpdate.content } : {}),
+            message_items: (item.message_items || []).map(mi => {
+              const update = updatedItems?.find(u => u.uuid === mi.uuid);
+              if (!update) return mi;
+              return { ...mi, item_details: { ...mi.item_details, content: update.content } };
+            }),
+          };
+        }),
+      );
+      const { id: answerId, participant_id } = chat_history.find(item => item.question_id === id) || {};
+      const participant = getParticipantById(activeConversation, participant_id);
+      if (answerId) {
+        onRegenerateAnswer(answerId, participant, updatedItems)();
+      } else {
+        const question = textUpdate?.content || '';
+        onResendQuestionStream(id, question);
+      }
     },
-    [chat_history, onRegenerateAnswerStream, onResendQuestionStream, setChatHistory],
+    [chat_history, activeConversation, onRegenerateAnswer, onResendQuestionStream, setChatHistory],
   );
 
   const { onLoadMoreMessages, isLoadingMore } = useLoadMoreMessages({


### PR DESCRIPTION
## Summary

Implements the "Edit and Re-submit Last User Message" feature (issue #4942).

- **Edit icon (pencil)** appears on hover of the last user message only; hidden during loading/streaming and for all older messages
- Clicking Edit opens **inline editing mode** with the original text pre-filled
- **Cancel** restores the original content without any API call
- **Save and apply** persists the edited content to the DB and regenerates the last LLM response — in a single round trip to the existing `/regenerate/` endpoint via a new `updated_items` payload field (requires the paired `elitea_core` backend PR)
- The `onSubmit` callback now passes a structured `[{uuid, content, item_type}]` array instead of a raw string, leaving space to support canvas and other item types in the future
- Removes unused `onRegenerateAnswerStream` (superseded by `onRegenerateAnswer` which already handles the REST regenerate path)
- Button label: **"Save and apply"** (per issue spec)

## Depends on

Backend PR in `elitea_core`: feat/EL-4942/edit-last-user-message

## Files changed

| File | Change |
|------|--------|
| `src/components/Chat/ChatMessageList.jsx` | Enable edit feature; restrict to last user message; add `lastUserMessageIndex` memo |
| `src/components/Chat/UserMessage.jsx` | `onClickSubmit` passes structured items array; rename button |
| `src/pages/NewChat/ChatBox.jsx` | `onRegenerateAnswer` forwards `updated_items`; `onSubmitEditedMessage` uses structured flow; remove unused callback |

## Test plan

- [ ] Hover last user message → pencil icon visible; not visible on older messages
- [ ] Click pencil → inline editor opens with original text
- [ ] Click Cancel → original text restored, no API call
- [ ] Edit text, click "Save and apply" → single `POST /regenerate/` call in network tab; response regenerated with new text
- [ ] Verify DB: `text_item.content` updated in `p_<id>.chat_messages_text`
- [ ] Edit icon disabled while another message is loading/streaming
- [ ] Works in Chat, Agents, Pipelines, Toolkits views

🤖 Generated with [Claude Code](https://claude.com/claude-code)