### PR TITLE
Feat [EL-5119] notifications mark as read

### DIFF
--- a/src/[fsd]/entities/notifications/lib/helpers/getIcon.helpers.jsx
+++ b/src/[fsd]/entities/notifications/lib/helpers/getIcon.helpers.jsx
@@ -1,0 +1,104 @@
+import { NotificationType } from '@/common/constants';
+import AttentionIcon from '@/components/Icons/AttentionIcon';
+import CommentIcon from '@/components/Icons/CommentIcon';
+import ErrorIcon from '@/components/Icons/ErrorIcon';
+import HeartIcon from '@/components/Icons/HeartIcon';
+import MedalIcon from '@/components/Icons/MedalIcon';
+import RemoveIcon from '@/components/Icons/RemoveIcon';
+import SuccessIcon from '@/components/Icons/SuccessIcon';
+import TrophyOutlinedIcon from '@/components/Icons/TrophyOutlinedIcon';
+
+export const getIcon = (type, theme, notification) => {
+  switch (type) {
+    case NotificationType.PromptModeratorApproval:
+    case NotificationType.AuthorApproval:
+    case NotificationType.ModeratorApprovalOfVersion:
+    case NotificationType.PromptOfSomeProjectWasPublished:
+    case NotificationType.NewPromptVersionOfSomeProjectWasPublished:
+    case NotificationType.ChatUserAdded:
+    case NotificationType.ChatUserMentioned:
+    case NotificationType.PrivateProjectCreated:
+    case NotificationType.ModerationApproved:
+      return <SuccessIcon fill={theme.palette.status.published} />;
+
+    case NotificationType.IndexDataChanged:
+      return notification?.meta?.error && notification.meta.error.trim() ? (
+        <ErrorIcon
+          fill={theme.palette.status.rejected}
+          size={16}
+        />
+      ) : (
+        <SuccessIcon fill={theme.palette.status.published} />
+      );
+
+    case NotificationType.PromptHasAddedToSomeProject:
+    case NotificationType.NewPromptVersionOfSomeProjectWasCreated:
+    case NotificationType.UserWasAddedToSomeProjectAsTeammate:
+      return <SuccessIcon fill={theme.palette.icon.fill.tips} />;
+
+    case NotificationType.PromptModeratorReject:
+    case NotificationType.ModeratorUnpublish:
+    case NotificationType.AgentUnpublished:
+    case NotificationType.AuthorReject:
+    case NotificationType.ModeratorRejectOfVersion:
+    case NotificationType.PromptOfSomeProjectWasRejected:
+    case NotificationType.NewPromptVersionOfSomeProjectWasRejected:
+    case NotificationType.ModerationRejected:
+      return <RemoveIcon fill={theme.palette.status.rejected} />;
+
+    case NotificationType.TokenIsExpired:
+    case NotificationType.SpendingLimitIsExpired:
+      return (
+        <ErrorIcon
+          fill={theme.palette.status.rejected}
+          size={16}
+        />
+      );
+
+    case NotificationType.TokenExpiring:
+    case NotificationType.SpendingLimitExpiring:
+    case NotificationType.BucketExpirationWarning:
+    case NotificationType.PersonalAccessTokenExpiring:
+      return (
+        <AttentionIcon
+          fill={theme.palette.status.onModeration}
+          size={16}
+        />
+      );
+
+    case NotificationType.Rates:
+      return (
+        <HeartIcon
+          fill={theme.palette.icon.fill.tips}
+          size={16}
+        />
+      );
+
+    case NotificationType.Comments:
+      return (
+        <CommentIcon
+          fill={theme.palette.icon.fill.tips}
+          size={16}
+        />
+      );
+
+    case NotificationType.RewardNewLevel:
+      return (
+        <MedalIcon
+          fill={theme.palette.status.published}
+          size={16}
+        />
+      );
+
+    case NotificationType.RewardBadgeToPrompt:
+      return (
+        <TrophyOutlinedIcon
+          fill={theme.palette.status.published}
+          size={16}
+        />
+      );
+
+    default:
+      return null;
+  }
+};

--- a/src/[fsd]/entities/notifications/lib/helpers/index.js
+++ b/src/[fsd]/entities/notifications/lib/helpers/index.js
@@ -1,3 +1,4 @@
 export * from './notification.helpers.js';
+export * from './getIcon.helpers.jsx';
 // Legacy: remove once all environments have run the backfill migration
 export * from './notificationLegacy.helpers.js';

--- a/src/[fsd]/entities/notifications/ui/NotificationListItem.jsx
+++ b/src/[fsd]/entities/notifications/ui/NotificationListItem.jsx
@@ -5,121 +5,17 @@ import { formatDistanceToNow } from 'date-fns';
 import { Box, Typography, useTheme } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
-import { NotificationListItemMessage } from '@/[fsd]/entities/notifications/ui';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { useNotificationBulkMarkSeenMutation } from '@/api/notifications';
 import MarkReadIcon from '@/assets/icons/mark-read-icon.svg?react';
 import MarkUnreadIcon from '@/assets/icons/mark-unread-icon.svg?react';
-import { NotificationType } from '@/common/constants';
 import { convertTime } from '@/common/convertChatConversationMessages';
 import { buildErrorMessage } from '@/common/utils';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 
-import AttentionIcon from './Icons/AttentionIcon';
-import CommentIcon from './Icons/CommentIcon';
-import ErrorIcon from './Icons/ErrorIcon';
-import HeartIcon from './Icons/HeartIcon';
-import MedalIcon from './Icons/MedalIcon';
-import RemoveIcon from './Icons/RemoveIcon';
-import SuccessIcon from './Icons/SuccessIcon';
-import TrophyOutlinedIcon from './Icons/TrophyOutlinedIcon';
-
-export const getIcon = (type, theme, notification) => {
-  switch (type) {
-    case NotificationType.PromptModeratorApproval:
-    case NotificationType.AuthorApproval:
-    case NotificationType.ModeratorApprovalOfVersion:
-    case NotificationType.PromptOfSomeProjectWasPublished:
-    case NotificationType.NewPromptVersionOfSomeProjectWasPublished:
-    case NotificationType.ChatUserAdded:
-    case NotificationType.ChatUserMentioned:
-    case NotificationType.PrivateProjectCreated:
-    case NotificationType.ModerationApproved:
-      return <SuccessIcon fill={theme.palette.status.published} />;
-
-    case NotificationType.IndexDataChanged:
-      // Show error icon if index operation failed
-      return notification?.meta?.error && notification.meta.error.trim() ? (
-        <ErrorIcon
-          fill={theme.palette.status.rejected}
-          size={16}
-        />
-      ) : (
-        <SuccessIcon fill={theme.palette.status.published} />
-      );
-
-    case NotificationType.PromptHasAddedToSomeProject:
-    case NotificationType.NewPromptVersionOfSomeProjectWasCreated:
-    case NotificationType.UserWasAddedToSomeProjectAsTeammate:
-      return <SuccessIcon fill={theme.palette.icon.fill.tips} />;
-
-    case NotificationType.PromptModeratorReject:
-    case NotificationType.ModeratorUnpublish:
-    case NotificationType.AgentUnpublished:
-    case NotificationType.AuthorReject:
-    case NotificationType.ModeratorRejectOfVersion:
-    case NotificationType.PromptOfSomeProjectWasRejected:
-    case NotificationType.NewPromptVersionOfSomeProjectWasRejected:
-    case NotificationType.ModerationRejected:
-      return <RemoveIcon fill={theme.palette.status.rejected} />;
-
-    case NotificationType.TokenIsExpired:
-    case NotificationType.SpendingLimitIsExpired:
-      return (
-        <ErrorIcon
-          fill={theme.palette.status.rejected}
-          size={16}
-        />
-      );
-
-    case NotificationType.TokenExpiring:
-    case NotificationType.SpendingLimitExpiring:
-    case NotificationType.BucketExpirationWarning:
-    case NotificationType.PersonalAccessTokenExpiring:
-      return (
-        <AttentionIcon
-          fill={theme.palette.status.onModeration}
-          size={16}
-        />
-      );
-
-    case NotificationType.Rates:
-      return (
-        <HeartIcon
-          fill={theme.palette.icon.fill.tips}
-          size={16}
-        />
-      );
-
-    case NotificationType.Comments:
-      return (
-        <CommentIcon
-          fill={theme.palette.icon.fill.tips}
-          size={16}
-        />
-      );
-
-    case NotificationType.RewardNewLevel:
-      return (
-        <MedalIcon
-          fill={theme.palette.status.published}
-          size={16}
-        />
-      );
-
-    case NotificationType.RewardBadgeToPrompt:
-      return (
-        <TrophyOutlinedIcon
-          fill={theme.palette.status.published}
-          size={16}
-        />
-      );
-
-    default:
-      return null;
-  }
-};
+import { getIcon } from '../lib/helpers';
+import NotificationListItemMessage from './NotificationListItemMessage';
 
 const NOTIFICATION_CONTEXT_STYLES = {
   list: {
@@ -145,7 +41,7 @@ const NotificationListItem = memo(props => {
   const theme = useTheme();
   const { event_type } = notification;
   const { textVariant } = NOTIFICATION_CONTEXT_STYLES[context] ?? NOTIFICATION_CONTEXT_STYLES.list;
-  const styles = notificationListItemStyles(clampLines, context === 'list', notification.is_seen);
+  const styles = notificationListItemStyles(clampLines, context === 'list');
 
   const [isHovered, setIsHovered] = useState(false);
   const projectId = useSelectedProjectId();
@@ -232,7 +128,7 @@ const NotificationListItem = memo(props => {
 NotificationListItem.displayName = 'NotificationListItem';
 
 /** @type {MuiSx} */
-const notificationListItemStyles = (clampLines, isContextList, isSeen) => ({
+const notificationListItemStyles = (clampLines, isContextList) => ({
   container: ({ palette }) => ({
     display: 'flex',
     padding: '0.5rem 0.75rem',
@@ -243,7 +139,7 @@ const notificationListItemStyles = (clampLines, isContextList, isSeen) => ({
     boxSizing: 'border-box',
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
     '&:hover': {
-      backgroundColor: isContextList && isSeen ? palette.background.tabButton.default : undefined,
+      backgroundColor: isContextList ? palette.background.tabButton.default : undefined,
     },
   }),
   markButton: {

--- a/src/[fsd]/entities/notifications/ui/NotificationListItemMessage.jsx
+++ b/src/[fsd]/entities/notifications/ui/NotificationListItemMessage.jsx
@@ -12,6 +12,7 @@ const NotificationListItemMessage = memo(props => {
   const message = notification.meta?.message;
   const segments = useMemo(() => parseMessage(message), [message]);
   const resolvedHref = resolveHref(notification.event_type, notification.meta, notification.project_id);
+  const styles = notificationListItemMessageStyles(notification.is_seen);
 
   if (message) {
     return (
@@ -24,7 +25,7 @@ const NotificationListItemMessage = memo(props => {
             <Link
               key={index}
               variant={textVariant}
-              sx={{ textDecoration: 'underline', cursor: 'pointer' }}
+              sx={styles.link}
               href={resolvedHref}
               target="_blank"
               rel="noopener noreferrer"
@@ -50,5 +51,14 @@ const NotificationListItemMessage = memo(props => {
 });
 
 NotificationListItemMessage.displayName = 'NotificationListItemMessage';
+
+/** @type {MuiSx} */
+const notificationListItemMessageStyles = isSeen => ({
+  link: ({ palette }) => ({
+    textDecoration: 'underline',
+    cursor: 'pointer',
+    color: isSeen ? palette.text.linkSeen : palette.text.link,
+  }),
+});
 
 export default NotificationListItemMessage;

--- a/src/[fsd]/entities/notifications/ui/index.js
+++ b/src/[fsd]/entities/notifications/ui/index.js
@@ -1,2 +1,3 @@
 export { default as LegacyNotificationMessage } from './LegacyNotificationMessage.jsx';
 export { default as NotificationListItemMessage } from './NotificationListItemMessage.jsx';
+export { default as NotificationListItem } from './NotificationListItem.jsx';

--- a/src/[fsd]/shared/ui/scrollable-container/ScrollableContainer.jsx
+++ b/src/[fsd]/shared/ui/scrollable-container/ScrollableContainer.jsx
@@ -6,6 +6,7 @@ import 'simplebar-react/dist/simplebar.min.css';
 import { Box } from '@mui/material';
 
 const SIMPLEBAR_FILL_STYLE = { height: '100%', width: '100%' };
+const SIMPLEBAR_FIT_CONTENT_STYLE = { height: 'auto', maxHeight: 'inherit', width: '100%' };
 
 /**
  * A scrollable container backed by SimpleBar.
@@ -13,10 +14,16 @@ const SIMPLEBAR_FILL_STYLE = { height: '100%', width: '100%' };
  * The `ref` is forwarded to the underlying SimpleBar instance so consumers
  * can call SimpleBar methods (e.g. `ref.current.getScrollElement()`).
  *
+ * `fillContainer` defaults to `true` and makes the SimpleBar instance fill
+ * the outer container height. When `fillContainer={false}`, the scroll area
+ * sizes to its content instead. In that mode, provide a height constraint
+ * such as `maxHeight` via `sx` on the outer container when scrolling should
+ * activate after the content grows past a limit.
+ *
  * Use the `sx` prop to extend or override the outer container layout.
  */
 const ScrollableContainer = forwardRef((props, ref) => {
-  const { children, sx } = props;
+  const { children, fillContainer = true, sx } = props;
 
   let resolvedSx;
 
@@ -33,7 +40,7 @@ const ScrollableContainer = forwardRef((props, ref) => {
       <SimpleBar
         ref={ref}
         autoHide={false}
-        style={SIMPLEBAR_FILL_STYLE}
+        style={fillContainer ? SIMPLEBAR_FILL_STYLE : SIMPLEBAR_FIT_CONTENT_STYLE}
       >
         {children}
       </SimpleBar>

--- a/src/[fsd]/widgets/Notifications/index.js
+++ b/src/[fsd]/widgets/Notifications/index.js
@@ -1,0 +1,1 @@
+export { default as NotificationList } from './ui';

--- a/src/[fsd]/widgets/Notifications/lib/hooks/index.js
+++ b/src/[fsd]/widgets/Notifications/lib/hooks/index.js
@@ -1,0 +1,1 @@
+export { useNotificationPopoverPosition } from './useNotificationPopoverPosition.hooks';

--- a/src/[fsd]/widgets/Notifications/lib/hooks/useNotificationPopoverPosition.hooks.js
+++ b/src/[fsd]/widgets/Notifications/lib/hooks/useNotificationPopoverPosition.hooks.js
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+const DEFAULT_POPOVER_POSITION = {
+  anchorReference: 'anchorEl',
+  anchorOrigin: {
+    vertical: 'top',
+    horizontal: 'right',
+  },
+  transformOrigin: {
+    vertical: 'bottom',
+    horizontal: 'left',
+  },
+  anchorPosition: null,
+};
+
+const POPOVER_VERTICAL_OFFSET = 120;
+const POPOVER_VIEWPORT_MARGIN = 16;
+
+export const useNotificationPopoverPosition = anchorEl => {
+  const popoverPaperRef = useRef(null);
+  const [popoverPosition, setPopoverPosition] = useState(DEFAULT_POPOVER_POSITION);
+
+  const updatePopoverPosition = useCallback(() => {
+    if (!anchorEl) return;
+
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const paperHeight = popoverPaperRef.current?.offsetHeight ?? 0;
+    const desiredHeight = paperHeight || Math.max(window.innerHeight - POPOVER_VERTICAL_OFFSET, 0);
+    const spaceAbove = anchorRect.top - POPOVER_VIEWPORT_MARGIN;
+    const spaceBelow = window.innerHeight - anchorRect.bottom - POPOVER_VIEWPORT_MARGIN;
+    const isShortPopover = paperHeight > 0 && paperHeight <= window.innerHeight / 2;
+
+    if (isShortPopover) {
+      if (spaceBelow >= paperHeight || spaceBelow > spaceAbove) {
+        setPopoverPosition({
+          anchorReference: 'anchorEl',
+          anchorOrigin: {
+            vertical: 'bottom',
+            horizontal: 'right',
+          },
+          transformOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+          anchorPosition: null,
+        });
+        return;
+      }
+
+      setPopoverPosition(DEFAULT_POPOVER_POSITION);
+      return;
+    }
+
+    if (spaceBelow >= desiredHeight) {
+      setPopoverPosition({
+        anchorReference: 'anchorEl',
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'right',
+        },
+        transformOrigin: {
+          vertical: 'top',
+          horizontal: 'left',
+        },
+        anchorPosition: null,
+      });
+      return;
+    }
+
+    if (spaceAbove >= desiredHeight) {
+      setPopoverPosition(DEFAULT_POPOVER_POSITION);
+      return;
+    }
+
+    const viewportCenterTop = Math.round(window.innerHeight / 2);
+    const minCenterTop = Math.round(desiredHeight / 2) + POPOVER_VIEWPORT_MARGIN;
+    const maxCenterTop = Math.round(window.innerHeight - desiredHeight / 2) - POPOVER_VIEWPORT_MARGIN;
+    const clampedTop = Math.min(
+      Math.max(viewportCenterTop, minCenterTop),
+      Math.max(minCenterTop, maxCenterTop),
+    );
+
+    setPopoverPosition({
+      anchorReference: 'anchorPosition',
+      anchorOrigin: {
+        vertical: 'center',
+        horizontal: 'right',
+      },
+      anchorPosition: {
+        top: clampedTop,
+        left: Math.round(anchorRect.right),
+      },
+      transformOrigin: {
+        vertical: 'center',
+        horizontal: 'left',
+      },
+    });
+  }, [anchorEl]);
+
+  useEffect(() => {
+    if (!anchorEl) {
+      setPopoverPosition(DEFAULT_POPOVER_POSITION);
+      return;
+    }
+
+    updatePopoverPosition();
+    window.addEventListener('resize', updatePopoverPosition);
+
+    return () => {
+      window.removeEventListener('resize', updatePopoverPosition);
+    };
+  }, [anchorEl, updatePopoverPosition]);
+
+  useLayoutEffect(() => {
+    if (!anchorEl) return undefined;
+
+    updatePopoverPosition();
+
+    const frameId = window.requestAnimationFrame(() => {
+      updatePopoverPosition();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [anchorEl, updatePopoverPosition]);
+
+  return {
+    popoverPaperRef,
+    popoverPosition,
+  };
+};

--- a/src/[fsd]/widgets/Notifications/lib/hooks/useNotificationPopoverPosition.hooks.js
+++ b/src/[fsd]/widgets/Notifications/lib/hooks/useNotificationPopoverPosition.hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 
 const DEFAULT_POPOVER_POSITION = {
   anchorReference: 'anchorEl',
@@ -13,45 +13,27 @@ const DEFAULT_POPOVER_POSITION = {
   anchorPosition: null,
 };
 
-const POPOVER_VERTICAL_OFFSET = 120;
 const POPOVER_VIEWPORT_MARGIN = 16;
 
 export const useNotificationPopoverPosition = anchorEl => {
-  const popoverPaperRef = useRef(null);
+  const [paperEl, setPaperEl] = useState(null);
   const [popoverPosition, setPopoverPosition] = useState(DEFAULT_POPOVER_POSITION);
 
+  const popoverPaperRef = useCallback(el => setPaperEl(el), []);
+
   const updatePopoverPosition = useCallback(() => {
-    if (!anchorEl) return;
+    if (!anchorEl || !paperEl) return;
 
     const anchorRect = anchorEl.getBoundingClientRect();
-    const paperHeight = popoverPaperRef.current?.offsetHeight ?? 0;
-    const desiredHeight = paperHeight || Math.max(window.innerHeight - POPOVER_VERTICAL_OFFSET, 0);
+    const paperHeight = paperEl.offsetHeight;
+    if (!paperHeight) return;
+
     const spaceAbove = anchorRect.top - POPOVER_VIEWPORT_MARGIN;
     const spaceBelow = window.innerHeight - anchorRect.bottom - POPOVER_VIEWPORT_MARGIN;
-    const isShortPopover = paperHeight > 0 && paperHeight <= window.innerHeight / 2;
+    const fitsBelow = spaceBelow >= paperHeight;
+    const fitsAbove = spaceAbove >= paperHeight;
 
-    if (isShortPopover) {
-      if (spaceBelow >= paperHeight || spaceBelow > spaceAbove) {
-        setPopoverPosition({
-          anchorReference: 'anchorEl',
-          anchorOrigin: {
-            vertical: 'bottom',
-            horizontal: 'right',
-          },
-          transformOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          anchorPosition: null,
-        });
-        return;
-      }
-
-      setPopoverPosition(DEFAULT_POPOVER_POSITION);
-      return;
-    }
-
-    if (spaceBelow >= desiredHeight) {
+    if (fitsBelow) {
       setPopoverPosition({
         anchorReference: 'anchorEl',
         anchorOrigin: {
@@ -67,52 +49,38 @@ export const useNotificationPopoverPosition = anchorEl => {
       return;
     }
 
-    if (spaceAbove >= desiredHeight) {
+    if (fitsAbove) {
       setPopoverPosition(DEFAULT_POPOVER_POSITION);
       return;
     }
 
-    const viewportCenterTop = Math.round(window.innerHeight / 2);
-    const minCenterTop = Math.round(desiredHeight / 2) + POPOVER_VIEWPORT_MARGIN;
-    const maxCenterTop = Math.round(window.innerHeight - desiredHeight / 2) - POPOVER_VIEWPORT_MARGIN;
-    const clampedTop = Math.min(
-      Math.max(viewportCenterTop, minCenterTop),
-      Math.max(minCenterTop, maxCenterTop),
-    );
+    const paperTop = Math.round(Math.max(POPOVER_VIEWPORT_MARGIN, (window.innerHeight - paperHeight) / 2));
 
     setPopoverPosition({
       anchorReference: 'anchorPosition',
       anchorOrigin: {
-        vertical: 'center',
+        vertical: 'top',
         horizontal: 'right',
       },
       anchorPosition: {
-        top: clampedTop,
+        top: paperTop,
         left: Math.round(anchorRect.right),
       },
       transformOrigin: {
-        vertical: 'center',
+        vertical: 'top',
         horizontal: 'left',
       },
     });
-  }, [anchorEl]);
+  }, [anchorEl, paperEl]);
 
   useEffect(() => {
     if (!anchorEl) {
       setPopoverPosition(DEFAULT_POPOVER_POSITION);
-      return;
     }
-
-    updatePopoverPosition();
-    window.addEventListener('resize', updatePopoverPosition);
-
-    return () => {
-      window.removeEventListener('resize', updatePopoverPosition);
-    };
-  }, [anchorEl, updatePopoverPosition]);
+  }, [anchorEl]);
 
   useLayoutEffect(() => {
-    if (!anchorEl) return undefined;
+    if (!anchorEl || !paperEl) return undefined;
 
     updatePopoverPosition();
 
@@ -123,7 +91,22 @@ export const useNotificationPopoverPosition = anchorEl => {
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [anchorEl, updatePopoverPosition]);
+  }, [anchorEl, paperEl, updatePopoverPosition]);
+
+  useEffect(() => {
+    if (!anchorEl || !paperEl) return undefined;
+
+    updatePopoverPosition();
+    window.addEventListener('resize', updatePopoverPosition);
+
+    const observer = new ResizeObserver(updatePopoverPosition);
+    observer.observe(paperEl);
+
+    return () => {
+      window.removeEventListener('resize', updatePopoverPosition);
+      observer.disconnect();
+    };
+  }, [anchorEl, paperEl, updatePopoverPosition]);
 
   return {
     popoverPaperRef,

--- a/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
+++ b/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { Box, CircularProgress, Popover, Skeleton, Typography } from '@mui/material';
 
 import { NotificationListItem } from '@/[fsd]/entities/notifications/ui';
+import { ScrollableContainer } from '@/[fsd]/shared/ui';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { useNotificationPopoverPosition } from '@/[fsd]/widgets/Notifications/lib/hooks';
 import {
@@ -123,7 +124,7 @@ const NotificationList = memo(props => {
   const hasMore = data && allNotifications.length < data.total;
 
   const handleScroll = useCallback(() => {
-    const listDom = listRef.current;
+    const listDom = listRef.current?.getScrollElement();
     if (!listDom || isFetching) return;
 
     const { clientHeight, scrollHeight, scrollTop } = listDom;
@@ -136,7 +137,7 @@ const NotificationList = memo(props => {
   const debouncedScroll = useMemo(() => debounce(handleScroll, 300), [handleScroll]);
 
   useEffect(() => {
-    const listDom = listRef.current;
+    const listDom = listRef.current?.getScrollElement();
     if (!listDom) return;
 
     listDom.addEventListener('scroll', debouncedScroll);
@@ -189,8 +190,9 @@ const NotificationList = memo(props => {
             aria-label="Close notifications"
           />
         </Box>
-        <Box
+        <ScrollableContainer
           ref={listRef}
+          fillContainer={false}
           sx={styles.listContainer}
         >
           {allNotifications.map(notification => (
@@ -219,7 +221,7 @@ const NotificationList = memo(props => {
               <Typography variant="bodySmall">No new notifications right now</Typography>
             </Box>
           )}
-        </Box>
+        </ScrollableContainer>
         {isFetching && page > 0 && (
           <Box sx={styles.loadMoreSpinner}>
             <CircularProgress
@@ -278,6 +280,7 @@ const notificationListStyles = () => ({
     display: 'flex',
     flexDirection: 'column',
     maxHeight: 'calc(100vh - 7.5rem)',
+    overflow: 'hidden',
   }),
   header: ({ palette }) => ({
     display: 'flex',
@@ -289,10 +292,8 @@ const notificationListStyles = () => ({
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
   }),
   listContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    maxHeight: 'calc(100vh - 12.125rem)',
-    overflowY: 'scroll',
+    flex: 'none',
+    maxHeight: 'calc(100vh - 16.5rem)',
   },
   skeletonItem: ({ palette }) => ({
     '&:not(:last-of-type)': {

--- a/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
+++ b/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
@@ -169,6 +169,7 @@ const NotificationList = memo(props => {
       slotProps={{
         paper: {
           ref: popoverPaperRef,
+          sx: styles.popoverPaper,
         },
       }}
       sx={styles.popover}
@@ -267,6 +268,9 @@ const notificationListStyles = () => ({
     background: 'transparent',
     marginLeft: '1.875rem',
   },
+  popoverPaper: {
+    borderRadius: '0.5rem',
+  },
   container: ({ palette }) => ({
     background: palette.background.notificationList,
     borderRadius: '0.5rem',
@@ -315,6 +319,8 @@ const notificationListStyles = () => ({
   }),
   markAllButton: ({ palette }) => ({
     height: '3rem',
+    borderTop: `0.0625rem solid ${palette.border.notificationItem}`,
+    borderRadius: 0,
     '&:disabled': {
       '& > span': {
         color: palette.text.disabled,
@@ -322,7 +328,7 @@ const notificationListStyles = () => ({
     },
     '&:hover': {
       backgroundColor: palette.background.tabButton.default,
-      borderRadius: '0px',
+      borderRadius: 0,
     },
   }),
   markAllButtonText: ({ palette }) => ({

--- a/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
+++ b/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
@@ -1,12 +1,14 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { debounce } from 'lodash';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { Box, CircularProgress, Popover, Skeleton, Typography } from '@mui/material';
 
+import { NotificationListItem } from '@/[fsd]/entities/notifications/ui';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
+import { useNotificationPopoverPosition } from '@/[fsd]/widgets/Notifications/lib/hooks';
 import {
   TAG_NOTIFICATIONS,
   notificationsApi,
@@ -15,11 +17,10 @@ import {
 } from '@/api/notifications';
 import { PAGE_SIZE } from '@/common/constants';
 import { buildErrorMessage } from '@/common/utils';
+import CloseIcon from '@/components/Icons/CloseIcon';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 import RouteDefinitions, { PathSessionMap } from '@/routes';
-
-import CloseIcon from './Icons/CloseIcon';
-import NotificationListItem from './NotificationListItem';
 
 const NotificationList = memo(props => {
   const { notificationListAnchorEl, onCloseNotificationList } = props;
@@ -30,29 +31,31 @@ const NotificationList = memo(props => {
   const { toastError } = useToast();
   const [bulkMarkSeenNotifications] = useNotificationBulkMarkSeenMutation();
   const styles = notificationListStyles();
-  const { personal_project_id } = useSelector(state => state.user);
+  const projectId = useSelectedProjectId();
+
   const [page, setPage] = useState(0);
   const [allNotifications, setAllNotifications] = useState([]);
+  const { popoverPaperRef, popoverPosition } = useNotificationPopoverPosition(notificationListAnchorEl);
 
   const { data, isFetching, isError, error, refetch } = useNotificationListQuery(
     {
-      projectId: personal_project_id,
+      projectId,
       page,
       pageSize: PAGE_SIZE,
       params: {
         only_new: true,
       },
     },
-    { refetchOnFocus: !!personal_project_id, skip: !personal_project_id },
+    { refetchOnFocus: !!projectId, skip: !projectId },
   );
 
   const onMarkAllAsRead = useCallback(async () => {
-    if (!personal_project_id || !allNotifications.length) return;
+    if (!projectId || !allNotifications.length) return;
     const unreadIds = allNotifications.filter(n => !n.is_seen).map(n => n.id);
     if (!unreadIds.length) return;
     try {
       await bulkMarkSeenNotifications({
-        projectId: personal_project_id,
+        projectId,
         ids: unreadIds,
         isSeen: true,
       }).unwrap();
@@ -65,7 +68,7 @@ const NotificationList = memo(props => {
     } catch (err) {
       toastError(buildErrorMessage(err));
     }
-  }, [personal_project_id, allNotifications, bulkMarkSeenNotifications, toastError]);
+  }, [projectId, allNotifications, bulkMarkSeenNotifications, toastError]);
 
   const handleNotificationSeenChange = useCallback((notificationId, isSeen) => {
     setAllNotifications(prev =>
@@ -154,107 +157,105 @@ const NotificationList = memo(props => {
   }, [refetch]);
 
   return (
-    <>
-      <Popover
-        id="notificationList"
-        open={Boolean(notificationListAnchorEl)}
-        anchorEl={notificationListAnchorEl}
-        anchorReference="anchorEl"
-        onClose={onCloseNotificationList}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'right',
-        }}
-        transformOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        sx={styles.popover}
-      >
-        <Box sx={styles.container}>
-          <Box sx={styles.header}>
-            <Typography
-              variant="labelMedium"
-              color="text.secondary"
-            >
-              Notifications
-            </Typography>
-            <BaseBtn
-              variant={BUTTON_VARIANTS.tertiary}
-              startIcon={<CloseIcon />}
-              onClick={onCloseNotificationList}
-              aria-label="Close notifications"
-            />
-          </Box>
-          <Box
-            ref={listRef}
-            sx={styles.listContainer}
+    <Popover
+      id="notificationList"
+      open={Boolean(notificationListAnchorEl)}
+      anchorEl={popoverPosition.anchorReference === 'anchorEl' ? notificationListAnchorEl : null}
+      anchorReference={popoverPosition.anchorReference}
+      anchorPosition={popoverPosition.anchorPosition}
+      onClose={onCloseNotificationList}
+      anchorOrigin={popoverPosition.anchorOrigin}
+      transformOrigin={popoverPosition.transformOrigin}
+      slotProps={{
+        paper: {
+          ref: popoverPaperRef,
+        },
+      }}
+      sx={styles.popover}
+    >
+      <Box sx={styles.container}>
+        <Box sx={styles.header}>
+          <Typography
+            variant="labelMedium"
+            color="text.secondary"
           >
-            {allNotifications.map(notification => (
-              <NotificationListItem
-                key={notification.id}
-                notification={notification}
-                onNotificationSeenChange={handleNotificationSeenChange}
-                onCloseNotificationList={onCloseNotificationList}
-              />
-            ))}
-            {isFetching && !allNotifications.length && (
-              <>
-                {[...Array(8)].map((_, index) => (
-                  <Skeleton
-                    key={`skeleton-${index}`}
-                    sx={styles.skeletonItem}
-                    variant="rectangular"
-                    width="100%"
-                    height="2.5rem"
-                  />
-                ))}
-              </>
-            )}
-            {!allNotifications.length && !isFetching && (
-              <Box sx={styles.emptyState}>
-                <Typography variant="bodySmall">No new notifications right now</Typography>
-              </Box>
-            )}
-          </Box>
-          {isFetching && page > 0 && (
-            <Box sx={styles.loadMoreSpinner}>
-              <CircularProgress
-                size="1.25rem"
-                thickness={4}
-              />
+            Notifications
+          </Typography>
+          <BaseBtn
+            variant={BUTTON_VARIANTS.tertiary}
+            startIcon={<CloseIcon />}
+            onClick={onCloseNotificationList}
+            aria-label="Close notifications"
+          />
+        </Box>
+        <Box
+          ref={listRef}
+          sx={styles.listContainer}
+        >
+          {allNotifications.map(notification => (
+            <NotificationListItem
+              key={notification.id}
+              notification={notification}
+              onNotificationSeenChange={handleNotificationSeenChange}
+              onCloseNotificationList={onCloseNotificationList}
+            />
+          ))}
+          {isFetching && !allNotifications.length && (
+            <>
+              {[...Array(8)].map((_, index) => (
+                <Skeleton
+                  key={`skeleton-${index}`}
+                  sx={styles.skeletonItem}
+                  variant="rectangular"
+                  width="100%"
+                  height="2.5rem"
+                />
+              ))}
+            </>
+          )}
+          {!allNotifications.length && !isFetching && (
+            <Box sx={styles.emptyState}>
+              <Typography variant="bodySmall">No new notifications right now</Typography>
             </Box>
           )}
-          {allNotifications.length > 0 && (
-            <BaseBtn
-              variant={BUTTON_VARIANTS.auxiliary}
-              onClick={onMarkAllAsRead}
-              sx={styles.markAllButton}
-              disabled={!allNotifications.some(n => !n.is_seen)}
-            >
-              <Typography
-                variant="labelMedium"
-                sx={styles.markAllButtonText}
-              >
-                Mark all as read
-              </Typography>
-            </BaseBtn>
-          )}
+        </Box>
+        {isFetching && page > 0 && (
+          <Box sx={styles.loadMoreSpinner}>
+            <CircularProgress
+              size="1.25rem"
+              thickness={4}
+            />
+          </Box>
+        )}
+        {allNotifications.length > 0 && (
           <BaseBtn
             variant={BUTTON_VARIANTS.auxiliary}
-            onClick={onViewAll}
-            sx={styles.viewAllButton}
+            onClick={onMarkAllAsRead}
+            sx={styles.markAllButton}
+            disabled={!allNotifications.some(n => !n.is_seen)}
           >
             <Typography
               variant="labelMedium"
-              sx={styles.viewAllButtonText}
+              sx={styles.markAllButtonText}
             >
-              View all
+              Mark all as read
             </Typography>
           </BaseBtn>
-        </Box>
-      </Popover>
-    </>
+        )}
+        <BaseBtn
+          variant={BUTTON_VARIANTS.auxiliary}
+          onClick={onViewAll}
+          sx={styles.viewAllButton}
+        >
+          <Typography
+            variant="labelMedium"
+            sx={styles.viewAllButtonText}
+          >
+            View all
+          </Typography>
+        </BaseBtn>
+      </Box>
+    </Popover>
   );
 });
 

--- a/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
+++ b/src/[fsd]/widgets/Notifications/ui/NotificationList.jsx
@@ -1,10 +1,9 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { debounce } from 'lodash';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { Box, CircularProgress, Popover, Skeleton, Typography } from '@mui/material';
+import { Box, CircularProgress, Popover, Skeleton, Typography, debounce } from '@mui/material';
 
 import { NotificationListItem } from '@/[fsd]/entities/notifications/ui';
 import { ScrollableContainer } from '@/[fsd]/shared/ui';
@@ -143,7 +142,7 @@ const NotificationList = memo(props => {
     listDom.addEventListener('scroll', debouncedScroll);
     return () => {
       listDom.removeEventListener('scroll', debouncedScroll);
-      debouncedScroll.cancel();
+      debouncedScroll.clear();
     };
   }, [debouncedScroll]);
 

--- a/src/[fsd]/widgets/Notifications/ui/index.js
+++ b/src/[fsd]/widgets/Notifications/ui/index.js
@@ -1,0 +1,1 @@
+export { default } from './NotificationList';

--- a/src/[fsd]/widgets/sidebar-root/ui/button/NotificationButton.jsx
+++ b/src/[fsd]/widgets/sidebar-root/ui/button/NotificationButton.jsx
@@ -4,10 +4,10 @@ import { useSelector } from 'react-redux';
 import { useMatch, useNavigate } from 'react-router-dom';
 
 import { SIDEBAR_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
+import NotificationList from '@/[fsd]/widgets/Notifications/ui';
 import { useNotificationListQuery } from '@/api/notifications';
 import { sioEvents } from '@/common/constants';
 import BellIcon from '@/components/Icons/BellIcon';
-import NotificationList from '@/components/NotificationList';
 import useSocket from '@/hooks/useSocket';
 import RouteDefinitions from '@/routes';
 import { useTheme } from '@emotion/react';
@@ -54,7 +54,7 @@ const NotificationButton = memo(() => {
       if (!personal_project_id) {
         navigate(RouteDefinitions.Chat);
       } else {
-        setNotificationListAnchorEl(event.target);
+        setNotificationListAnchorEl(event.currentTarget);
       }
     },
     [navigate, personal_project_id],

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -56,10 +56,24 @@ const NotificationList = memo(props => {
         ids: unreadIds,
         isSeen: true,
       }).unwrap();
+      const unreadIdsSet = new Set(unreadIds);
+      setAllNotifications(prev =>
+        prev.map(notification =>
+          unreadIdsSet.has(notification.id) ? { ...notification, is_seen: true } : notification,
+        ),
+      );
     } catch (err) {
       toastError(buildErrorMessage(err));
     }
   }, [personal_project_id, allNotifications, bulkMarkSeenNotifications, toastError]);
+
+  const handleNotificationSeenChange = useCallback((notificationId, isSeen) => {
+    setAllNotifications(prev =>
+      prev.map(notification =>
+        notification.id === notificationId ? { ...notification, is_seen: isSeen } : notification,
+      ),
+    );
+  }, []);
 
   const onViewAll = useCallback(() => {
     dispatch(notificationsApi.util.invalidateTags([TAG_NOTIFICATIONS]));
@@ -85,6 +99,7 @@ const NotificationList = memo(props => {
     if (!data?.rows) return;
     if (isFetching) return;
     if (page === 0) {
+      if (lastAppliedPageRef.current === 0 && allNotifications.length) return;
       lastAppliedPageRef.current = 0;
       setAllNotifications(data.rows);
       return;
@@ -92,7 +107,7 @@ const NotificationList = memo(props => {
     if (lastAppliedPageRef.current === page) return;
     lastAppliedPageRef.current = page;
     setAllNotifications(prev => [...prev, ...data.rows]);
-  }, [data?.rows, notificationListAnchorEl, page, isFetching]);
+  }, [allNotifications.length, data?.rows, notificationListAnchorEl, page, isFetching]);
 
   useEffect(() => {
     if (!notificationListAnchorEl) {
@@ -179,6 +194,7 @@ const NotificationList = memo(props => {
               <NotificationListItem
                 key={notification.id}
                 notification={notification}
+                onNotificationSeenChange={handleNotificationSeenChange}
                 onCloseNotificationList={onCloseNotificationList}
               />
             ))}
@@ -197,7 +213,7 @@ const NotificationList = memo(props => {
             )}
             {!allNotifications.length && !isFetching && (
               <Box sx={styles.emptyState}>
-                <Typography variant="bodySmall">No notifications right now</Typography>
+                <Typography variant="bodySmall">No new notifications right now</Typography>
               </Box>
             )}
           </Box>
@@ -211,9 +227,10 @@ const NotificationList = memo(props => {
           )}
           {allNotifications.length > 0 && (
             <BaseBtn
-              variant={BUTTON_VARIANTS.tertiary}
+              variant={BUTTON_VARIANTS.auxiliary}
               onClick={onMarkAllAsRead}
               sx={styles.markAllButton}
+              disabled={!allNotifications.some(n => !n.is_seen)}
             >
               <Typography
                 variant="labelMedium"
@@ -224,7 +241,7 @@ const NotificationList = memo(props => {
             </BaseBtn>
           )}
           <BaseBtn
-            variant={BUTTON_VARIANTS.tertiary}
+            variant={BUTTON_VARIANTS.auxiliary}
             onClick={onViewAll}
             sx={styles.viewAllButton}
           >
@@ -296,16 +313,14 @@ const notificationListStyles = () => ({
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
   }),
   markAllButton: ({ palette }) => ({
-    width: '100%',
-    padding: '0.75rem 1.25rem',
     height: '3rem',
-    boxSizing: 'border-box',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderTop: `0.0625rem solid ${palette.border.notificationItem}`,
-    borderRadius: '0px',
+    '&:disabled': {
+      '& > span': {
+        color: palette.text.disabled,
+      },
+    },
     '&:hover': {
+      backgroundColor: palette.background.tabButton.default,
       borderRadius: '0px',
     },
   }),
@@ -313,16 +328,11 @@ const notificationListStyles = () => ({
     color: palette.text.button.showMore,
   }),
   viewAllButton: ({ palette }) => ({
-    width: '100%',
-    padding: '0.75rem 1.25rem',
     height: '3rem',
-    boxSizing: 'border-box',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
     borderTop: `0.0625rem solid ${palette.border.notificationItem}`,
     borderRadius: '0px',
     '&:hover': {
+      backgroundColor: palette.background.tabButton.default,
       borderRadius: '0px',
     },
   }),

--- a/src/components/NotificationList.jsx
+++ b/src/components/NotificationList.jsx
@@ -7,7 +7,12 @@ import { useNavigate } from 'react-router-dom';
 import { Box, CircularProgress, Popover, Skeleton, Typography } from '@mui/material';
 
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
-import { TAG_NOTIFICATIONS, notificationsApi, useNotificationListQuery } from '@/api/notifications';
+import {
+  TAG_NOTIFICATIONS,
+  notificationsApi,
+  useNotificationBulkMarkSeenMutation,
+  useNotificationListQuery,
+} from '@/api/notifications';
 import { PAGE_SIZE } from '@/common/constants';
 import { buildErrorMessage } from '@/common/utils';
 import useToast from '@/hooks/useToast';
@@ -23,6 +28,7 @@ const NotificationList = memo(props => {
   const listRef = useRef();
   const lastAppliedPageRef = useRef(-1);
   const { toastError } = useToast();
+  const [bulkMarkSeenNotifications] = useNotificationBulkMarkSeenMutation();
   const styles = notificationListStyles();
   const { personal_project_id } = useSelector(state => state.user);
   const [page, setPage] = useState(0);
@@ -39,6 +45,21 @@ const NotificationList = memo(props => {
     },
     { refetchOnFocus: !!personal_project_id, skip: !personal_project_id },
   );
+
+  const onMarkAllAsRead = useCallback(async () => {
+    if (!personal_project_id || !allNotifications.length) return;
+    const unreadIds = allNotifications.filter(n => !n.is_seen).map(n => n.id);
+    if (!unreadIds.length) return;
+    try {
+      await bulkMarkSeenNotifications({
+        projectId: personal_project_id,
+        ids: unreadIds,
+        isSeen: true,
+      }).unwrap();
+    } catch (err) {
+      toastError(buildErrorMessage(err));
+    }
+  }, [personal_project_id, allNotifications, bulkMarkSeenNotifications, toastError]);
 
   const onViewAll = useCallback(() => {
     dispatch(notificationsApi.util.invalidateTags([TAG_NOTIFICATIONS]));
@@ -188,6 +209,20 @@ const NotificationList = memo(props => {
               />
             </Box>
           )}
+          {allNotifications.length > 0 && (
+            <BaseBtn
+              variant={BUTTON_VARIANTS.tertiary}
+              onClick={onMarkAllAsRead}
+              sx={styles.markAllButton}
+            >
+              <Typography
+                variant="labelMedium"
+                sx={styles.markAllButtonText}
+              >
+                Mark all as read
+              </Typography>
+            </BaseBtn>
+          )}
           <BaseBtn
             variant={BUTTON_VARIANTS.tertiary}
             onClick={onViewAll}
@@ -259,6 +294,23 @@ const notificationListStyles = () => ({
     gap: '1rem',
     boxSizing: 'border-box',
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
+  }),
+  markAllButton: ({ palette }) => ({
+    width: '100%',
+    padding: '0.75rem 1.25rem',
+    height: '3rem',
+    boxSizing: 'border-box',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderTop: `0.0625rem solid ${palette.border.notificationItem}`,
+    borderRadius: '0px',
+    '&:hover': {
+      borderRadius: '0px',
+    },
+  }),
+  markAllButtonText: ({ palette }) => ({
+    color: palette.text.button.showMore,
   }),
   viewAllButton: ({ palette }) => ({
     width: '100%',

--- a/src/components/NotificationListItem.jsx
+++ b/src/components/NotificationListItem.jsx
@@ -138,13 +138,14 @@ const NotificationListItem = memo(props => {
     showIcon = true,
     sx = {},
     contentSX = {},
+    onNotificationSeenChange,
     onCloseNotificationList,
     context = 'list',
   } = props;
   const theme = useTheme();
   const { event_type } = notification;
   const { textVariant } = NOTIFICATION_CONTEXT_STYLES[context] ?? NOTIFICATION_CONTEXT_STYLES.list;
-  const styles = notificationListItemStyles(clampLines, context === 'list');
+  const styles = notificationListItemStyles(clampLines, context === 'list', notification.is_seen);
 
   const [isHovered, setIsHovered] = useState(false);
   const projectId = useSelectedProjectId();
@@ -154,6 +155,14 @@ const NotificationListItem = memo(props => {
   const shouldMarkAsRead = !notification.is_seen;
   const markToggleLabel = shouldMarkAsRead ? 'Mark as read' : 'Mark as unread';
   const MarkIcon = shouldMarkAsRead ? MarkReadIcon : MarkUnreadIcon;
+
+  const handleMouseEnter = useCallback(() => {
+    setIsHovered(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsHovered(false);
+  }, []);
 
   const handleMarkToggle = useCallback(
     async e => {
@@ -165,18 +174,26 @@ const NotificationListItem = memo(props => {
           ids: [notification.id],
           isSeen: shouldMarkAsRead,
         }).unwrap();
+        onNotificationSeenChange?.(notification.id, shouldMarkAsRead);
       } catch (err) {
         toastError(buildErrorMessage(err));
       }
     },
-    [projectId, notification.id, shouldMarkAsRead, bulkMarkSeenNotifications, toastError],
+    [
+      projectId,
+      notification.id,
+      shouldMarkAsRead,
+      bulkMarkSeenNotifications,
+      onNotificationSeenChange,
+      toastError,
+    ],
   );
 
   return (
     <Box
       sx={[styles.container, sx]}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       {showIcon && <Box sx={styles.iconContainer}>{getIcon(event_type, theme, notification)}</Box>}
       <Box sx={[styles.content, contentSX]}>
@@ -215,7 +232,7 @@ const NotificationListItem = memo(props => {
 NotificationListItem.displayName = 'NotificationListItem';
 
 /** @type {MuiSx} */
-const notificationListItemStyles = (clampLines, isContextList) => ({
+const notificationListItemStyles = (clampLines, isContextList, isSeen) => ({
   container: ({ palette }) => ({
     display: 'flex',
     padding: '0.5rem 0.75rem',
@@ -225,6 +242,9 @@ const notificationListItemStyles = (clampLines, isContextList) => ({
     gap: '0.7rem',
     boxSizing: 'border-box',
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
+    '&:hover': {
+      backgroundColor: isContextList && isSeen ? palette.background.tabButton.default : undefined,
+    },
   }),
   markButton: {
     flexShrink: 0,

--- a/src/components/NotificationListItem.jsx
+++ b/src/components/NotificationListItem.jsx
@@ -1,12 +1,20 @@
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 
 import { formatDistanceToNow } from 'date-fns';
 
 import { Box, Typography, useTheme } from '@mui/material';
 
+import Tooltip from '@/ComponentsLib/Tooltip';
 import { NotificationListItemMessage } from '@/[fsd]/entities/notifications/ui';
+import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
+import { useNotificationBulkMarkSeenMutation } from '@/api/notifications';
+import MarkReadIcon from '@/assets/icons/mark-read-icon.svg?react';
+import MarkUnreadIcon from '@/assets/icons/mark-unread-icon.svg?react';
 import { NotificationType } from '@/common/constants';
 import { convertTime } from '@/common/convertChatConversationMessages';
+import { buildErrorMessage } from '@/common/utils';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+import useToast from '@/hooks/useToast';
 
 import AttentionIcon from './Icons/AttentionIcon';
 import CommentIcon from './Icons/CommentIcon';
@@ -136,10 +144,40 @@ const NotificationListItem = memo(props => {
   const theme = useTheme();
   const { event_type } = notification;
   const { textVariant } = NOTIFICATION_CONTEXT_STYLES[context] ?? NOTIFICATION_CONTEXT_STYLES.list;
-  const styles = notificationListItemStyles(clampLines);
+  const styles = notificationListItemStyles(clampLines, context === 'list');
+
+  const [isHovered, setIsHovered] = useState(false);
+  const projectId = useSelectedProjectId();
+  const [bulkMarkSeenNotifications] = useNotificationBulkMarkSeenMutation();
+  const { toastError } = useToast();
+
+  const shouldMarkAsRead = !notification.is_seen;
+  const markToggleLabel = shouldMarkAsRead ? 'Mark as read' : 'Mark as unread';
+  const MarkIcon = shouldMarkAsRead ? MarkReadIcon : MarkUnreadIcon;
+
+  const handleMarkToggle = useCallback(
+    async e => {
+      e.stopPropagation();
+      if (!projectId) return;
+      try {
+        await bulkMarkSeenNotifications({
+          projectId,
+          ids: [notification.id],
+          isSeen: shouldMarkAsRead,
+        }).unwrap();
+      } catch (err) {
+        toastError(buildErrorMessage(err));
+      }
+    },
+    [projectId, notification.id, shouldMarkAsRead, bulkMarkSeenNotifications, toastError],
+  );
 
   return (
-    <Box sx={[styles.container, sx]}>
+    <Box
+      sx={[styles.container, sx]}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       {showIcon && <Box sx={styles.iconContainer}>{getIcon(event_type, theme, notification)}</Box>}
       <Box sx={[styles.content, contentSX]}>
         <Box sx={styles.message}>
@@ -155,6 +193,21 @@ const NotificationListItem = memo(props => {
           </Typography>
         )}
       </Box>
+      {context === 'list' && isHovered && (
+        <Tooltip
+          title={markToggleLabel}
+          enterDelay={1200}
+          placement="top"
+        >
+          <BaseBtn
+            variant={BUTTON_VARIANTS.secondary}
+            startIcon={<MarkIcon />}
+            aria-label={markToggleLabel}
+            onClick={handleMarkToggle}
+            sx={styles.markButton}
+          />
+        </Tooltip>
+      )}
     </Box>
   );
 });
@@ -162,7 +215,7 @@ const NotificationListItem = memo(props => {
 NotificationListItem.displayName = 'NotificationListItem';
 
 /** @type {MuiSx} */
-const notificationListItemStyles = clampLines => ({
+const notificationListItemStyles = (clampLines, isContextList) => ({
   container: ({ palette }) => ({
     display: 'flex',
     padding: '0.5rem 0.75rem',
@@ -173,14 +226,19 @@ const notificationListItemStyles = clampLines => ({
     boxSizing: 'border-box',
     borderBottom: `0.0625rem solid ${palette.border.notificationItem}`,
   }),
+  markButton: {
+    flexShrink: 0,
+    alignSelf: 'center',
+  },
   iconContainer: {
-    width: '1rem',
+    width: '2rem',
     minWidth: '1rem',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
     paddingTop: '0.0625rem',
+    alignSelf: isContextList ? 'center' : 'flex-start',
     '& > svg': {
       width: '1.125rem',
       height: '1.125rem',

--- a/src/darkPalette.js
+++ b/src/darkPalette.js
@@ -34,6 +34,7 @@ const blue20 = 'rgba(106, 232, 250, 0.20)';
 const blue24 = 'rgba(106, 232, 250, 0.24)';
 const blue30 = 'rgba(106, 232, 250, 0.30)';
 const blue40 = 'rgba(41, 184, 245, 0.40)';
+const blue70 = 'rgba(41, 184, 245, 0.70)';
 const skyBlue20 = 'rgba(41, 184, 245, 0.20)';
 export const darkBlue = '#006DD1';
 const darkBlueLowOpacity = 'rgba(0, 109, 209, 0.4)';
@@ -460,6 +461,7 @@ const darkPalette = {
       logout: lightOrange,
     },
     link: blue,
+    linkSeen: blue70,
     highlighted: white,
   },
   icon: {

--- a/src/lightPalette.js
+++ b/src/lightPalette.js
@@ -66,7 +66,10 @@ const lightGrey = 'rgba(217, 217, 217, 1)';
 export const blue01 = 'rgba(248, 252, 255, 1)';
 const blue02 = 'rgba(110, 177, 255, 1)';
 const blue03 = 'rgba(99, 144, 254, 1)';
+
 const blue = 'rgba(41, 184, 245, 1)';
+const blue70 = 'rgba(41, 184, 245, 0.70)';
+
 const darkBlue = '#006DD1';
 const darkBlueLowOpacity = 'rgba(0, 109, 209, 0.4)';
 const completedBlue = '#036ED033';
@@ -459,6 +462,7 @@ const lightPalette = {
       logout: orange,
     },
     link: blue,
+    linkSeen: blue70,
     highlighted: gray60, //magenta,
   },
   icon: {

--- a/src/lightPalette.js
+++ b/src/lightPalette.js
@@ -68,10 +68,10 @@ const blue02 = 'rgba(110, 177, 255, 1)';
 const blue03 = 'rgba(99, 144, 254, 1)';
 
 const blue = 'rgba(41, 184, 245, 1)';
-const blue70 = 'rgba(41, 184, 245, 0.70)';
 
 const darkBlue = '#006DD1';
 const darkBlueLowOpacity = 'rgba(0, 109, 209, 0.4)';
+const darkBlue70 = 'rgba(0, 109, 209, 0.7)';
 const completedBlue = '#036ED033';
 const hoverBlue = '#2783D8';
 const almostWhite = '#FAFAFA';
@@ -462,7 +462,7 @@ const lightPalette = {
       logout: orange,
     },
     link: blue,
-    linkSeen: blue70,
+    linkSeen: darkBlue70,
     highlighted: gray60, //magenta,
   },
   icon: {

--- a/src/lightPalette.js
+++ b/src/lightPalette.js
@@ -461,7 +461,7 @@ const lightPalette = {
       loginSuccess: green,
       logout: orange,
     },
-    link: blue,
+    link: darkBlue,
     linkSeen: darkBlue70,
     highlighted: gray60, //magenta,
   },

--- a/src/pages/NotificationCenter/NotificationTable.jsx
+++ b/src/pages/NotificationCenter/NotificationTable.jsx
@@ -13,10 +13,11 @@ import {
   GridTablePagination,
   GridTableRow,
 } from '@/[fsd]/entities/grid-table/ui';
+import { getIcon } from '@/[fsd]/entities/notifications/lib/helpers';
+import { NotificationListItem } from '@/[fsd]/entities/notifications/ui';
 import { useNotificationBulkDeleteMutation, useNotificationBulkMarkSeenMutation } from '@/api/notifications';
 import { SortOrderOptions } from '@/common/constants';
 import { buildErrorMessage } from '@/common/utils';
-import NotificationListItem, { getIcon } from '@/components/NotificationListItem';
 import useToast from '@/hooks/useToast';
 import { useTheme } from '@emotion/react';
 


### PR DESCRIPTION
Added scrollbar

<img width="1217" height="769" alt="image" src="https://github.com/user-attachments/assets/bacb895b-b6cf-4fe2-80ce-994d49ec0ba3" />

<img width="1251" height="775" alt="image" src="https://github.com/user-attachments/assets/016d08dc-229b-45e1-bab0-383e9fbe69ef" />




<img width="795" height="1053" alt="image" src="https://github.com/user-attachments/assets/3348bfe6-e657-42fe-9f27-2fcefd152917" />
<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/4e7c7c78-fe87-4985-b469-82662cc75be3" />
<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/421d032e-132c-4699-88a9-2fa0e052db74" />
<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/ca21b5a3-d45f-44e1-901d-859119611862" />

<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/4193d3cd-e6aa-443a-941c-d729db401191" />

<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/89a1fe30-ee7f-4022-9d86-41f22d910f45" />


## Summary

- **Mark as read / Mark all as read**: individual notifications can be toggled read/unread inline; a "Mark all as read" bulk action is added to the notification popover. Notification items remain visible in the list after being marked read rather than disappearing.
- **Read-state link styling**: links inside notification messages render in a dimmed `linkSeen` colour (new palette token, both light and dark) when the notification is already read.
- **FSD migration**: `NotificationList` and `NotificationListItem` moved from `src/components/` into FSD layers (`widgets/Notifications` and `entities/notifications/ui`); `getIcon` extracted to `entities/notifications/lib/helpers`. `NotificationTable` updated to import from the new locations.
- **Smart popover positioning**: new `useNotificationPopoverPosition` hook positions the notification popover below the anchor when space allows, above it as a fallback, and centered in the viewport when it fits neither. A `ResizeObserver` (via callback ref) re-runs positioning as the popover fills with content, and a `window resize` listener keeps it correct on viewport changes.

- **Scrollable notifications list**: the notification popover now uses a custom scrollable container with a persistent scrollbar. The popover grows naturally for small notification counts and becomes scrollable once it reaches its maximum viewport-constrained height.

## Test plan

- [ ] Open the notification bell — popover appears below / above / centered depending on available viewport space
- [ ] Resize the browser window — popover repositions correctly
- [ ] Mark a single notification as read/unread — item stays visible, icon toggles
- [ ] Click "Mark all as read" — all items update to read state, button disables
- [ ] Verify read notifications render links in the dimmed colour (light and dark theme)
- [ ] Open Notification Center page — `NotificationListItem` renders correctly from its new FSD location