### PR TITLE
feat: [EL-5116] Add “Create New Secret” Shortcut in Credential Secret Dropdown

### DIFF
--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx
@@ -12,6 +12,7 @@ import { CodeMirrorLinterHelpers } from '@/[fsd]/shared/lib/helpers';
 import { useFieldFocus } from '@/[fsd]/shared/lib/hooks';
 import { Checkbox, Field, Input } from '@/[fsd]/shared/ui';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
+import { SecretManagementInput } from '@/[fsd]/shared/ui/secret-field';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
 import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { MAX_NAME_LENGTH } from '@/common/constants';
@@ -21,7 +22,6 @@ import EmbeddingModelSelect from '@/components/EmbeddingModelSelect';
 import FormInput from '@/components/FormInput.jsx';
 import ImageGenerationModelSelect from '@/components/ImageGenerationModelSelect';
 import LlmModelSelect from '@/components/LlmModelSelect';
-import SecretManagementInput from '@/components/SecretManagementInput.jsx';
 import ToolkitSelect from '@/components/ToolkitSelect';
 
 const ToolBaseProperty = memo(props => {

--- a/src/[fsd]/shared/ui/field/SecretInputField.jsx
+++ b/src/[fsd]/shared/ui/field/SecretInputField.jsx
@@ -3,8 +3,8 @@ import { memo, useCallback, useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 
 import { includeFieldWrapperOverlapStyles } from '@/[fsd]/shared/ui/field/styles';
+import { SecretManagementInput } from '@/[fsd]/shared/ui/secret-field';
 import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
-import SecretManagementInput from '@/components/SecretManagementInput.jsx';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
 const SecretInputFieldField = memo(props => {
@@ -38,7 +38,12 @@ const SecretInputFieldField = memo(props => {
     >
       <Box sx={styles.header}>
         <Typography variant="bodyMedium">{`${label}${isRequired ? ' *' : ''}`}</Typography>
-        {tooltipHint && <InfoTooltip infoTooltip={tooltipHint} sx={styles.infoIconWrapper} />}
+        {tooltipHint && (
+          <InfoTooltip
+            infoTooltip={tooltipHint}
+            sx={styles.infoIconWrapper}
+          />
+        )}
       </Box>
       <SecretManagementInput
         sx={{ marginTop: '0rem' }}

--- a/src/[fsd]/shared/ui/index.js
+++ b/src/[fsd]/shared/ui/index.js
@@ -19,3 +19,4 @@ export { default as ScrollableContainer } from './scrollable-container';
 export * as Icon from './icon';
 export { default as Markdown } from './markdown';
 export * as Mention from './mention';
+export * as SecretField from './secret-field';

--- a/src/[fsd]/shared/ui/secret-field/SecretField.jsx
+++ b/src/[fsd]/shared/ui/secret-field/SecretField.jsx
@@ -1,14 +1,21 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useSelector } from 'react-redux';
 
 import { Visibility, VisibilityOff } from '@mui/icons-material';
-import { Box, InputAdornment, TextField } from '@mui/material';
-import IconButton from '@mui/material/IconButton';
+import { Box, InputAdornment, TextField, Tooltip } from '@mui/material';
 
+import { BaseBtn } from '@/[fsd]/shared/ui/button';
+import { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
 import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import { useSecretsListQuery } from '@/api/secrets.js';
+import RefreshIcon from '@/assets/refresh-icon.svg?react';
+import { PERMISSIONS } from '@/common/constants';
 import Toggle from '@/components/Toggle.jsx';
+import useCheckPermission from '@/hooks/useCheckPermission';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+import RouteDefinitions, { getBasename } from '@/routes';
 
 export const secretRegex = /^{{secret\.([A-Za-z0-9_]+)}}$/;
 
@@ -35,7 +42,7 @@ const updateRawPassword = ({ value, isUserInputRef, setRawPasswordInput, isLoade
   }
 };
 
-export const SecretField = memo(props => {
+const SecretField = memo(props => {
   const {
     value,
     onChange = () => {},
@@ -85,9 +92,17 @@ export const SecretField = memo(props => {
     [selectedProjectId, specifiedProjectId],
   );
 
+  const { personal_project_id } = useSelector(state => state.user);
+  const { checkPermission } = useCheckPermission();
+  const canCreateSecret = checkPermission(PERMISSIONS.secrets.create);
+
   const skip = !projectId || (!isSecret && activeTab === toggleOptions[1].value);
 
-  const { data = [], isError } = useSecretsListQuery(projectId, {
+  const {
+    data = [],
+    isError,
+    refetch,
+  } = useSecretsListQuery(projectId, {
     skip,
   });
 
@@ -103,13 +118,78 @@ export const SecretField = memo(props => {
     handleSwitchToSecretTab();
   }, [handleSwitchToSecretTab]);
 
-  const secretsOptions = useMemo(() => {
-    return isError
-      ? []
-      : data
-          ?.map(item => ({ label: item.name, value: item.secret_name }))
-          .sort((a, b) => a.label.localeCompare(b.label)) || [];
+  const savedSecretsOptions = useMemo(() => {
+    if (isError) return [];
+    return (data || [])
+      .map(item => ({ label: item.name, value: item.secret_name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, [data, isError]);
+
+  const createSecretsOptions = useMemo(() => {
+    if (!canCreateSecret) return [];
+    const secretsPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'secrets');
+    const baseUrl = `${window.location.protocol}//${window.location.host}`;
+    const basename = getBasename();
+    const buildUrl = targetProjectId =>
+      `${baseUrl}${basename}/${targetProjectId}${secretsPath}?createSecret=1`;
+
+    const options = [
+      {
+        value: '__create_private_secret__',
+        label: 'New Private Secret',
+        variant: 'action',
+        onActivate: () => window.open(buildUrl(personal_project_id), '_blank', 'noopener,noreferrer'),
+      },
+    ];
+
+    if (selectedProjectId !== personal_project_id) {
+      options.push({
+        value: '__create_project_secret__',
+        label: 'New Project Secret',
+        variant: 'action',
+        onActivate: () => window.open(buildUrl(selectedProjectId), '_blank', 'noopener,noreferrer'),
+      });
+    }
+
+    return options;
+  }, [canCreateSecret, selectedProjectId, personal_project_id]);
+
+  const refreshButton = useMemo(
+    () => (
+      <Tooltip
+        title="Refresh secrets"
+        placement="top"
+      >
+        <BaseBtn
+          variant={BUTTON_VARIANTS.tertiary}
+          size="small"
+          onClick={refetch}
+          sx={styles.refreshIcon}
+        >
+          <RefreshIcon />
+        </BaseBtn>
+      </Tooltip>
+    ),
+    [refetch, styles.refreshIcon],
+  );
+
+  const secretOptionGroups = useMemo(() => {
+    const groups = [];
+    if (createSecretsOptions.length > 0) {
+      groups.push({
+        key: 'Create',
+        title: 'Create',
+        options: createSecretsOptions,
+      });
+    }
+    groups.push({
+      key: 'Saved Secrets',
+      title: 'Saved Secrets',
+      headerEnd: refreshButton,
+      options: savedSecretsOptions,
+    });
+    return groups;
+  }, [createSecretsOptions, savedSecretsOptions, refreshButton]);
 
   const handlePasswordInputChange = useCallback(
     (e, rawNewValue) => {
@@ -174,12 +254,12 @@ export const SecretField = memo(props => {
           value={value}
           label={label}
           onChange={handleChangeValue}
-          options={secretsOptions}
+          optionGroups={secretOptionGroups}
+          options={[]}
           disabled={disabled}
           required={required}
           error={error}
           helperText={helperText}
-          // customSelectedFontSize={'0.875rem'}
           sx={styles.select}
           {...inputProps}
           {...selectProps}
@@ -218,23 +298,28 @@ export const SecretField = memo(props => {
                     sx: styles.inputLabel,
                     shrink: true,
                   },
-            }}
-            InputProps={{
-              endAdornment: passwordVisibilityToggle && (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    color="secondary"
-                    aria-label="toggle password visibility"
-                    edge="end"
-                    onClick={() => {
-                      setShowPassword(prevState => !prevState);
-                    }}
-                  >
-                    {showPassword ? <VisibilityOff /> : <Visibility />}
-                  </IconButton>
-                </InputAdornment>
-              ),
+              input: {
+                endAdornment: passwordVisibilityToggle && (
+                  <InputAdornment position="end">
+                    <BaseBtn
+                      variant={BUTTON_VARIANTS.secondary}
+                      size="small"
+                      aria-label="toggle password visibility"
+                      edge="end"
+                      onClick={() => {
+                        setShowPassword(prevState => !prevState);
+                      }}
+                      sx={styles.passwordVisibilityToggle}
+                    >
+                      {showPassword ? (
+                        <VisibilityOff sx={styles.visibilityToggleIcon} />
+                      ) : (
+                        <Visibility sx={styles.visibilityToggleIcon} />
+                      )}
+                    </BaseBtn>
+                  </InputAdornment>
+                ),
+              },
             }}
             {...inputProps}
             {...textFieldProps}
@@ -295,96 +380,42 @@ const secretFieldStyles = error => ({
       display: 'none',
     },
   },
+  refreshIcon: ({ palette }) => ({
+    color: palette.text.default,
+    padding: 0,
+    position: 'relative',
+    backgroundColor: 'transparent',
+    '&:hover, &:active, &.Mui-focusVisible': {
+      backgroundColor: 'transparent',
+    },
+    '&:hover': {
+      color: palette.text.secondary,
+    },
+    '&:hover::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '1.625rem',
+      height: '1.625rem',
+      transform: 'translate(-21%, -18%)',
+      borderRadius: '50%',
+      backgroundColor: palette.background.userInputBackgroundActive,
+    },
+  }),
+  passwordVisibilityToggle: {
+    minWidth: '1.5rem !important',
+    maxWidth: '1.5rem !important',
+    maxHeight: '1.5rem !important',
+    minHeight: '1.5rem !important',
+    padding: 0,
+  },
+  visibilityToggleIcon: {
+    width: '0.875rem',
+    height: '0.875rem',
+  },
 });
 
 SecretField.displayName = 'SecretField';
 
-const SecretManagementInput = memo(props => {
-  const {
-    sx = {},
-    authType,
-    authTypes,
-    fieldPath,
-    editField,
-    onInputBlur = () => {},
-    inputValue,
-    error,
-    helperText,
-    required = true,
-    disabled = false,
-    passwordVisibilityToggle = false,
-    disableSecret = false,
-    id,
-    name,
-    specifiedProjectId,
-    description,
-  } = props;
-
-  const [inputLabel, setInputLabel] = useState('API Key');
-
-  const handleChangeToggleValue = useCallback(() => {
-    if (disableSecret) return null;
-    editField(fieldPath, '');
-  }, [disableSecret, fieldPath, editField]);
-
-  const authenticationType = useMemo(() => {
-    if (!authTypes || typeof authTypes !== 'object') {
-      return {
-        label: inputLabel,
-      };
-    }
-
-    const authenticationTypes = Object.values(authTypes) || [];
-
-    return authenticationTypes.find(authTypeItem => authTypeItem.value === authType);
-  }, [inputLabel, authType, authTypes]);
-
-  useEffect(() => {
-    setInputLabel(authenticationType.label);
-  }, [authType, authenticationType.label]);
-
-  const handleInputChange = useCallback(
-    field => (e, value) => {
-      editField(field, value);
-    },
-    [editField],
-  );
-
-  return (
-    <SecretField
-      containerProps={{
-        sx: [secretManagementInputStyles.container, sx],
-      }}
-      inputProps={{ name: name || 'api_key' }}
-      label={inputLabel}
-      value={inputValue}
-      onChange={handleInputChange(fieldPath)}
-      onChangeToggle={handleChangeToggleValue}
-      textFieldProps={{ onBlur: onInputBlur }}
-      error={error}
-      helperText={helperText}
-      disabled={disabled}
-      required={required}
-      passwordVisibilityToggle={passwordVisibilityToggle}
-      disableSecret={disableSecret}
-      id={id}
-      specifiedProjectId={specifiedProjectId}
-      tooltipDescription={description}
-    />
-  );
-});
-
-/** @type {MuiSx} */
-const secretManagementInputStyles = {
-  container: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-end',
-  },
-};
-
-SecretManagementInput.displayName = 'SecretManagementInput';
-
-export default SecretManagementInput;
+export default SecretField;

--- a/src/[fsd]/shared/ui/secret-field/SecretManagementInput.jsx
+++ b/src/[fsd]/shared/ui/secret-field/SecretManagementInput.jsx
@@ -1,0 +1,93 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import SecretField from './SecretField';
+
+const SecretManagementInput = memo(props => {
+  const {
+    sx = {},
+    authType,
+    authTypes,
+    fieldPath,
+    editField,
+    onInputBlur = () => {},
+    inputValue,
+    error,
+    helperText,
+    required = true,
+    disabled = false,
+    passwordVisibilityToggle = false,
+    disableSecret = false,
+    id,
+    name,
+    specifiedProjectId,
+    description,
+  } = props;
+
+  const [inputLabel, setInputLabel] = useState('API Key');
+
+  const handleChangeToggleValue = useCallback(() => {
+    if (disableSecret) return null;
+    editField(fieldPath, '');
+  }, [disableSecret, fieldPath, editField]);
+
+  const authenticationType = useMemo(() => {
+    if (!authTypes || typeof authTypes !== 'object') {
+      return {
+        label: inputLabel,
+      };
+    }
+
+    const authenticationTypes = Object.values(authTypes) || [];
+
+    return authenticationTypes.find(authTypeItem => authTypeItem.value === authType);
+  }, [inputLabel, authType, authTypes]);
+
+  useEffect(() => {
+    setInputLabel(authenticationType.label);
+  }, [authType, authenticationType.label]);
+
+  const handleInputChange = useCallback(
+    field => (e, value) => {
+      editField(field, value);
+    },
+    [editField],
+  );
+
+  return (
+    <SecretField
+      containerProps={{
+        sx: [secretManagementInputStyles.container, sx],
+      }}
+      inputProps={{ name: name || 'api_key' }}
+      label={inputLabel}
+      value={inputValue}
+      onChange={handleInputChange(fieldPath)}
+      onChangeToggle={handleChangeToggleValue}
+      textFieldProps={{ onBlur: onInputBlur }}
+      error={error}
+      helperText={helperText}
+      disabled={disabled}
+      required={required}
+      passwordVisibilityToggle={passwordVisibilityToggle}
+      disableSecret={disableSecret}
+      id={id}
+      specifiedProjectId={specifiedProjectId}
+      tooltipDescription={description}
+    />
+  );
+});
+
+/** @type {MuiSx} */
+const secretManagementInputStyles = {
+  container: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+  },
+};
+
+SecretManagementInput.displayName = 'SecretManagementInput';
+
+export default SecretManagementInput;

--- a/src/[fsd]/shared/ui/secret-field/index.js
+++ b/src/[fsd]/shared/ui/secret-field/index.js
@@ -1,0 +1,2 @@
+export { default as SecretField, secretRegex } from './SecretField';
+export { default as SecretManagementInput } from './SecretManagementInput';

--- a/src/[fsd]/widgets/llm-model-selector/ui/LLMSettings.jsx
+++ b/src/[fsd]/widgets/llm-model-selector/ui/LLMSettings.jsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_STEPS_LIMIT,
   DEFAULT_TEMPERATURE,
 } from '@/[fsd]/shared/lib/constants/llmSettings.constants';
+import { SecretField } from '@/[fsd]/shared/ui/secret-field';
 import {
   VALIDATION_RULE,
   getMaxTokensHelperText,
@@ -23,7 +24,6 @@ import {
 } from '@/[fsd]/widgets/llm-model-selector/ui/settings';
 import { PROMPT_PAYLOAD_KEY } from '@/common/constants';
 import { isNullOrUndefined, parseValueToIntNumber } from '@/common/utils';
-import { SecretField } from '@/components/SecretManagementInput';
 
 const LLMSettings = memo(props => {
   const {


### PR DESCRIPTION
# Solution: Add "Create New Secret" Shortcut in Credential Secret Dropdown

**Issue:** EliteaAI/elitea_issues#5116  
**Milestone:** R-2.0.4  

---

## Problem

When a user is in **Secret mode** inside a credential field, the dropdown only shows a flat list of existing secrets. If the secret they need does not exist yet, they must navigate away to **Settings → Secrets**, create it, and come back. This is especially painful mid-flow.

The **Toolkit credential select** (CredentialsSelect) already has a `CREATE` group with "New Private" and "New Project" shortcuts and a refresh icon. The Secret dropdown should match this UX.

---

## Changes Made

### 1. FSD Migration

The original `src/components/SecretManagementInput.jsx` was split into two single-component files and moved to the FSD `shared` layer:

```
src/[fsd]/shared/ui/secret-field/
├── SecretField.jsx            ← core component (was inline in SecretManagementInput.jsx)
├── SecretManagementInput.jsx  ← thin wrapper (unchanged logic)
└── index.js                   ← barrel exports
```

**Why `shared/`:** `SecretManagementInput` is consumed from `shared/ui/field/SecretInputField.jsx`. Since `shared` cannot import from `features`, the components must live in `shared`.

---

### 2. Enhancement: Create New Secret + Refresh in Secret Dropdown

All logic is inside `SecretField.jsx`. No backend changes.

#### New imports

```jsx
import { useSelector } from 'react-redux';
import { Tooltip } from '@mui/material';
import { BaseBtn } from '@/[fsd]/shared/ui/button';
import { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
import { PERMISSIONS } from '@/common/constants';
import useCheckPermission from '@/hooks/useCheckPermission';
import RefreshIcon from '@/assets/refresh-icon.svg?react';
import RouteDefinitions, { getBasename } from '@/routes';
```

#### New hooks inside `SecretField`

```jsx
const { personal_project_id } = useSelector(state => state.user);
const { checkPermission } = useCheckPermission();
const canCreateSecret = checkPermission(PERMISSIONS.secrets.create);
```

#### `refetch` added to query destructure

```jsx
const { data = [], isError, refetch } = useSecretsListQuery(projectId, { skip });
```

#### `createSecretsOptions` — opens Secrets page in new tab with project ID

```jsx
const createSecretsOptions = useMemo(() => {
  if (!canCreateSecret) return [];
  const secretsPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'secrets');
  const baseUrl = `${window.location.protocol}//${window.location.host}`;
  const basename = getBasename();
  const buildUrl = targetProjectId =>
    `${baseUrl}${basename}/${targetProjectId}${secretsPath}?createSecret=1`;

  const options = [
    {
      value: '__create_private_secret__',
      label: 'New Private Secret',
      variant: 'action',
      onActivate: () => window.open(buildUrl(personal_project_id), '_blank', 'noopener,noreferrer'),
    },
  ];

  if (selectedProjectId !== personal_project_id) {
    options.push({
      value: '__create_project_secret__',
      label: 'New Project Secret',
      variant: 'action',
      onActivate: () => window.open(buildUrl(selectedProjectId), '_blank', 'noopener,noreferrer'),
    });
  }

  return options;
}, [canCreateSecret, selectedProjectId, personal_project_id]);
```

> **URL includes project ID:** "New Private Secret" uses `personal_project_id`; "New Project Secret" uses `selectedProjectId`. This matches the `CredentialsSelect` pattern exactly.

#### Refresh button + `optionGroups`

```jsx
const refreshButton = useMemo(() => (
  <Tooltip title="Refresh secrets" placement="top">
    <BaseBtn variant={BUTTON_VARIANTS.tertiary} size="small" onClick={refetch} sx={styles.refreshIcon}>
      <RefreshIcon />
    </BaseBtn>
  </Tooltip>
), [refetch]);

const secretOptionGroups = useMemo(() => {
  const groups = [];
  if (createSecretsOptions.length > 0) {
    groups.push({ key: 'Create', title: 'Create', options: createSecretsOptions });
  }
  groups.push({
    key: 'Saved Secrets',
    title: 'Saved Secrets',
    headerEnd: refreshButton,
    options: savedSecretsOptions,
  });
  return groups;
}, [createSecretsOptions, savedSecretsOptions, refreshButton]);
```

#### `SingleSelect` updated to use `optionGroups`

```jsx
<SingleSelect
  showBorder
  id={id}
  value={value}
  label={label}
  onChange={handleChangeValue}
  optionGroups={secretOptionGroups}
  options={[]}
  ...
/>
```

#### `refreshIcon` style added to `secretFieldStyles`

```jsx
refreshIcon: ({ palette }) => ({
  color: palette.text.default,
  padding: 0,
  position: 'relative',
  backgroundColor: 'transparent',
  '&:hover, &:active, &.Mui-focusVisible': { backgroundColor: 'transparent' },
  '&:hover': { color: palette.text.secondary },
  '&:hover::before': {
    content: '""',
    position: 'absolute',
    top: 0,
    left: 0,
    width: '1.625rem',
    height: '1.625rem',
    transform: 'translate(-21%, -18%)',
    borderRadius: '50%',
    backgroundColor: palette.background.userInputBackgroundActive,
  },
}),
```

---

## Files Changed

| File | Change |
|---|---|
| `src/[fsd]/shared/ui/secret-field/SecretField.jsx` | **NEW** — core component with create/refresh enhancement |
| `src/[fsd]/shared/ui/secret-field/SecretManagementInput.jsx` | **NEW** — thin wrapper (split from original) |
| `src/[fsd]/shared/ui/secret-field/index.js` | **NEW** — barrel: `SecretField`, `secretRegex`, `SecretManagementInput` |
| `src/[fsd]/shared/ui/index.js` | Added `export * as SecretField from './secret-field'` |
| `src/[fsd]/shared/ui/field/SecretInputField.jsx` | Import updated to `@/[fsd]/shared/ui/secret-field` |
| `src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBaseProperty.jsx` | Import updated to `@/[fsd]/shared/ui/secret-field` |
| `src/[fsd]/widgets/LLMModelSelector/ui/LLMSettings.jsx` | Import updated to `@/[fsd]/shared/ui/secret-field` |
| `src/components/SecretManagementInput.jsx` | **DELETED** |

---

## Behavior After Change

| Scenario | Behavior |
|---|---|
| User has `secrets.create` permission | CREATE section shown with "New Private Secret" (always) + "New Project Secret" (team project only) |
| User lacks `secrets.create` permission | CREATE section hidden; only SAVED SECRETS shown |
| User clicks "New Private Secret" | Opens `/{personal_project_id}/settings/secrets?createSecret=1` in new tab |
| User clicks "New Project Secret" | Opens `/{selectedProjectId}/settings/secrets?createSecret=1` in new tab |
| User clicks refresh icon in "SAVED SECRETS" header | `refetch()` called; list updates |
| Existing consumers (SecretInputField, ToolBaseProperty, LLMSettings) | No regression — imports updated to new FSD path |

---

## Acceptance Criteria

- [x] Secret dropdown shows CREATE and SAVED SECRETS sections when Secret mode is enabled
- [x] Create actions only shown when user has `PERMISSIONS.secrets.create`
- [x] Clicking a create action opens Secrets page in a new tab with correct project ID in URL
- [x] Refresh icon in SAVED SECRETS header reloads the secrets list via `refetch()`
- [x] Newly created secrets appear after clicking refresh
- [x] Users without `secrets.list` permission: dropdown not shown (existing skip logic unchanged)
- [x] Components migrated to FSD `shared/ui/secret-field/` — one component per file
- [x] All three consumers updated; old `src/components/SecretManagementInput.jsx` deleted
