### PR TITLE
feat: [EL-5135] Transformed from simple IconButton to split-button UI pattern with dropdown menu

### DIFF
--- a/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
+++ b/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
@@ -16,6 +16,50 @@ export const OptionsMap = {
   MCP: 'MCP', // For MCPs
 };
 
+export const RouteToLabelMap = [
+  { route: RouteDefinitions.AgentStudio, label: null },
+  { route: RouteDefinitions.CreateIntegration, label: 'Integration' },
+  { route: 'settings/model-configuration', label: 'Integration' },
+  { route: RouteDefinitions.CreatePersonalToken, label: 'Token' },
+  { route: 'settings/tokens', label: 'Token' },
+  { route: 'settings/secrets', label: 'Secret' },
+  { route: 'settings/users', label: 'Invite User' },
+  { route: RouteDefinitions.AppsApplications, label: 'Application' },
+  { route: RouteDefinitions.AppsCatalog, label: 'Application' },
+  { route: RouteDefinitions.Chat, label: 'Conversation' },
+  { route: RouteDefinitions.Applications, label: 'Agent' },
+  { route: RouteDefinitions.Pipelines, label: 'Pipeline' },
+  { route: RouteDefinitions.Credentials, label: 'Credential' },
+  { route: RouteDefinitions.Toolkits, label: 'Toolkit' },
+  { route: RouteDefinitions.MCPs, label: 'MCP' },
+  { route: RouteDefinitions.Artifacts, label: 'Artifact Bucket' },
+];
+
+export const DropdownItems = [
+  { label: 'Conversation', route: RouteDefinitions.Chat, option: 'Conversation' },
+  { label: 'Agent', route: RouteDefinitions.Applications, option: 'Agent' },
+  { label: 'Pipeline', route: RouteDefinitions.Pipelines, option: 'Pipeline' },
+  { label: 'Credential', route: RouteDefinitions.Credentials, option: 'Credential' },
+  { label: 'Toolkit', route: RouteDefinitions.Toolkits, option: 'Toolkit' },
+  { label: 'Application', route: RouteDefinitions.AppsApplications, option: 'Application' },
+  { label: 'MCP', route: RouteDefinitions.MCPs, option: 'MCP' },
+  { label: 'Artifact Bucket', route: RouteDefinitions.Artifacts, option: 'Bucket' },
+  { label: 'Integration', route: 'settings/model-configuration', option: 'Integration' },
+  { label: 'Token', route: 'settings/tokens', option: 'Personal Token' },
+  { label: 'Secret', route: 'settings/secrets', option: 'Secret' },
+  { label: 'Invite User', route: 'settings/users', option: 'User' },
+];
+
+export const SimpleCreateRoutes = [
+  'settings/analytics',
+  'settings/prompts',
+  'settings/environment',
+  RouteDefinitions.AgentStudio,
+  RouteDefinitions.Resources,
+  RouteDefinitions.NotificationCenter,
+  RouteDefinitions.AppsCatalog,
+];
+
 export const CreationPermissions = {
   Chat: [PERMISSIONS.chat.folders.create, PERMISSIONS.chat.create],
   Conversation: [PERMISSIONS.chat.folders.create, PERMISSIONS.chat.create],
@@ -25,10 +69,11 @@ export const CreationPermissions = {
   App: [PERMISSIONS.toolkits.create],
   MCP: [PERMISSIONS.toolkits.create],
   Credential: undefined, // No specific permission needed for credentials
-  Bucket: [PERMISSIONS.artifacts.buckets.create],
+  Bucket: [PERMISSIONS.artifacts.buckets.create, PERMISSIONS.artifacts.create],
   Model: undefined, // No specific permission needed for model credentials
   'Personal Token': undefined, // Personal tokens creation allowed from settings
   Secret: [PERMISSIONS.secrets.list], // Allow if user can access secrets page
+  User: [PERMISSIONS.users.create],
 };
 
 export const CommandPathMap = {
@@ -83,7 +128,9 @@ export const PrevUrlPathMap = {
 };
 
 export const PathToOptionMap = [
+  { path: RouteDefinitions.CreateIntegration, option: 'Integration' },
   { path: 'settings/model-configuration', option: 'Integration' },
+  { path: RouteDefinitions.CreatePersonalToken, option: 'Personal Token' },
   { path: 'settings/tokens', option: 'Personal Token' },
   { path: 'settings/secrets', option: 'Secret' },
   { path: 'settings/users', option: 'User' },

--- a/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
+++ b/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
@@ -1,11 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, ClickAwayListener, Paper, Popper, useTheme } from '@mui/material';
 
 import StyledTooltip from '@/ComponentsLib/Tooltip';
+import { Button } from '@/[fsd]/shared/ui';
 import { CreateEntityConstants } from '@/[fsd]/widgets/sidebar-root/lib/constants';
 import { useDisablePersonalSpace } from '@/[fsd]/widgets/sidebar-root/lib/hooks';
 import PlusIcon from '@/assets/plus-icon.svg?react';
@@ -16,6 +17,8 @@ import {
   SearchParams,
   ViewMode,
 } from '@/common/constants';
+import ArrowDownIcon from '@/components/Icons/ArrowDownIcon';
+import CheckIcon from '@/components/Icons/CheckIcon';
 import useCheckPermission from '@/hooks/useCheckPermission';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import RouteDefinitions from '@/routes';
@@ -25,14 +28,18 @@ const CreateEntityButton = memo(props => {
   const { tourId } = props;
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const theme = useTheme();
   const { checkPermission } = useCheckPermission();
   const isCreatingNewConversation = useSelector(state => state.chat.isCreatingNewConversation);
 
   const sideBarCollapsed = useSelector(state => state.settings.sideBarCollapsed);
   const [selectedOption, setSelectedOption] = useState('Chat');
+  const [openMenu, setOpenMenu] = useState(false);
   const { pathname, state } = useLocation();
-  const locationState = useMemo(() => state || { from: [], routeStack: [] }, [state]);
+  const locationState = useMemo(() => ({ from: [], routeStack: [], ...state }), [state]);
   const styles = createEntityButtonStyles(sideBarCollapsed);
+  const anchorRef = useRef(null);
+
   const isFromApplicationDetailPage = useMemo(() => !!pathname.match(/\/agents\/\d+/g), [pathname]);
   const isFromPipelineDetailPage = useMemo(() => !!pathname.match(/\/pipelines\/\d+/g), [pathname]);
   const isFromToolkitDetailPage = useMemo(() => !!pathname.match(/\/toolkits\/\d+/g), [pathname]);
@@ -42,7 +49,6 @@ const CreateEntityButton = memo(props => {
   );
   const isSystemPromptsPage = useMemo(() => pathname.includes('/settings/prompts'), [pathname]);
   const isSettingsUsersPage = useMemo(() => pathname.includes('/settings/users'), [pathname]);
-  const isAgentStudioPage = useMemo(() => pathname.startsWith(RouteDefinitions.AgentStudio), [pathname]);
   const shouldDisableCreatingChat = useMemo(
     () => selectedOption === CreateEntityConstants.OptionsMap.Chat && isCreatingNewConversation,
     [selectedOption, isCreatingNewConversation],
@@ -75,99 +81,121 @@ const CreateEntityButton = memo(props => {
       selectedOption === 'Integration' && ALLOW_PROJECT_OWN_LLMS === false && projectId != PUBLIC_PROJECT_ID,
     [selectedOption, projectId],
   );
-  const handleCommand = useCallback(() => {
-    if (pathname.startsWith(RouteDefinitions.AppsApplications)) {
-      navigate(RouteDefinitions.AppsCatalog, { state: locationState });
-      return;
-    }
 
-    // Special inline action for creating a Secret from Settings -> Secrets
-    switch (selectedOption) {
-      case 'Secret':
-        {
-          // Navigate to settings/secrets with a flag to trigger row creation
-          const secretsPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'secrets');
-          const search = 'createSecret=1';
-          navigate(
-            { pathname: secretsPath, search: search ? `?${search}` : '' },
-            {
-              replace: false,
-              state: locationState,
-            },
-          );
-        }
+  const isSimpleCreateRoute = useMemo(() => {
+    const lowerPathname = pathname.toLowerCase();
+    return CreateEntityConstants.SimpleCreateRoutes.some(route => lowerPathname.includes(route));
+  }, [pathname]);
+
+  const currentLabel = useMemo(() => {
+    const lowerPathname = pathname.toLowerCase();
+    const match = CreateEntityConstants.RouteToLabelMap.find(({ route }) => lowerPathname.includes(route));
+    return match?.label || null;
+  }, [pathname]);
+
+  const currentDropdownItem = useMemo(() => {
+    if (!currentLabel) return null;
+    return CreateEntityConstants.DropdownItems.find(item => item.label === currentLabel) || null;
+  }, [currentLabel]);
+
+  const handleCommand = useCallback(
+    (optionOverride = null) => {
+      const stateOption = optionOverride ?? selectedOption;
+      if (!optionOverride && pathname.startsWith(RouteDefinitions.AppsApplications)) {
+        navigate(RouteDefinitions.AppsCatalog, { state: locationState });
         return;
-      case 'User':
-        {
-          // Navigate to settings/users with a flag to trigger invite user dialog
-          const usersPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'users');
-          const search = 'inviteUsers=1';
-          navigate(
-            { pathname: usersPath, search: search ? `?${search}` : '' },
-            {
-              replace: false,
-              state: locationState,
-            },
-          );
-        }
-        return;
-      default: {
-        const destUrl = CreateEntityConstants.CommandPathMap[selectedOption];
-        const breadCrumb = CreateEntityConstants.BreadCrumbMap[selectedOption];
-        let search =
-          selectedOption === CreateEntityConstants.OptionsMap.Chat
-            ? 'create=1'
-            : `${SearchParams.ViewMode}=${ViewMode.Owner}`;
+      }
 
-        // Add special parameter for Model creation from Model Configuration Settings
-        if (selectedOption === 'Integration') {
-          search += '&from=model-configuration';
-        }
+      switch (stateOption) {
+        case 'Secret':
+          {
+            // Navigate to settings/secrets with a flag to trigger row creation
+            const secretsPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'secrets');
+            const search = 'createSecret=1';
+            navigate(
+              { pathname: secretsPath, search: search ? `?${search}` : '' },
+              {
+                replace: false,
+                state: locationState,
+              },
+            );
+          }
+          return;
+        case 'User':
+          {
+            // Navigate to settings/users with a flag to trigger invite user dialog
+            const usersPath = RouteDefinitions.SettingsWithTab.replace(':tab', 'users');
+            const search = 'inviteUsers=1';
+            navigate(
+              { pathname: usersPath, search: search ? `?${search}` : '' },
+              {
+                replace: false,
+                state: locationState,
+              },
+            );
+          }
+          return;
+        case 'Application':
+          navigate(RouteDefinitions.AppsCatalog, { state: locationState });
+          return;
+        default: {
+          const destUrl = CreateEntityConstants.CommandPathMap[stateOption];
+          const breadCrumb = CreateEntityConstants.BreadCrumbMap[stateOption];
+          let search =
+            stateOption === CreateEntityConstants.OptionsMap.Chat
+              ? 'create=1'
+              : `${SearchParams.ViewMode}=${ViewMode.Owner}`;
 
-        if (destUrl !== pathname || selectedOption === CreateEntityConstants.OptionsMap.Chat) {
-          let newRouteStack = [...locationState.routeStack];
+          if (stateOption === 'Integration') {
+            search += '&from=model-configuration';
+          }
 
-          //For opening creating page from solo url or from Discover, we treat it as opening it from My Library
-          newRouteStack =
-            selectedOption === CreateEntityConstants.OptionsMap.Chat
-              ? [
-                  {
-                    breadCrumb,
-                    viewMode: ViewMode.Owner,
-                    pagePath: destUrl,
-                  },
-                ]
-              : [
-                  {
-                    breadCrumb: CreateEntityConstants.BreadCrumbMap[destUrl],
-                    pagePath:
-                      destUrl === RouteDefinitions.CreatePersonalToken
-                        ? RouteDefinitions.SettingsWithTab.replace(':tab', 'tokens')
-                        : `${CreateEntityConstants.PrevUrlPathMap[destUrl]}?${SearchParams.ViewMode}=${ViewMode.Owner}`,
-                  },
-                  {
-                    breadCrumb,
-                    viewMode: ViewMode.Owner,
-                    pagePath: `${destUrl}${search ? `?${search}` : ''}`,
-                  },
-                ];
-          navigate(
-            { pathname: destUrl, search },
-            {
-              replace: shouldReplaceThePage,
-              state: { routeStack: newRouteStack },
-            },
-          );
-          if (destUrl === RouteDefinitions.CreateBucket) {
-            dispatch(artifactActions.setBucket(null));
+          if (destUrl !== pathname || stateOption === CreateEntityConstants.OptionsMap.Chat) {
+            let newRouteStack = [...locationState.routeStack];
+
+            newRouteStack =
+              stateOption === CreateEntityConstants.OptionsMap.Chat
+                ? [
+                    {
+                      breadCrumb,
+                      viewMode: ViewMode.Owner,
+                      pagePath: destUrl,
+                    },
+                  ]
+                : [
+                    {
+                      breadCrumb: CreateEntityConstants.BreadCrumbMap[destUrl],
+                      pagePath:
+                        destUrl === RouteDefinitions.CreatePersonalToken
+                          ? RouteDefinitions.SettingsWithTab.replace(':tab', 'tokens')
+                          : `${CreateEntityConstants.PrevUrlPathMap[destUrl]}?${SearchParams.ViewMode}=${ViewMode.Owner}`,
+                    },
+                    {
+                      breadCrumb,
+                      viewMode: ViewMode.Owner,
+                      pagePath: `${destUrl}${search ? `?${search}` : ''}`,
+                    },
+                  ];
+            navigate(
+              { pathname: destUrl, search },
+              {
+                replace: shouldReplaceThePage,
+                state: { routeStack: newRouteStack },
+              },
+            );
+            if (destUrl === RouteDefinitions.CreateBucket) {
+              dispatch(artifactActions.setBucket(null));
+            }
           }
         }
       }
-    }
-  }, [dispatch, selectedOption, pathname, locationState, navigate, shouldReplaceThePage]);
-  const handleClick = useCallback(() => {
-    handleCommand();
-  }, [handleCommand]);
+    },
+    [dispatch, selectedOption, pathname, locationState, navigate, shouldReplaceThePage],
+  );
+
+  const handleOpenMenu = useCallback(() => {
+    setOpenMenu(prev => !prev);
+  }, []);
 
   useEffect(() => {
     const lowerPathname = pathname.toLocaleLowerCase();
@@ -200,123 +228,207 @@ const CreateEntityButton = memo(props => {
       shouldDisablePersonalSpace ||
       !hasPermissionForSelectedOption ||
       isSystemPromptsPage ||
-      isAgentStudioPage ||
       shouldDisableInviteUser ||
       shouldDisableCreatingChat ||
-      shouldDisableOwnLLMs ||
-      isAppCatalogTab,
+      shouldDisableOwnLLMs,
     [
       shouldDisablePersonalSpace,
       hasPermissionForSelectedOption,
       isSystemPromptsPage,
-      isAgentStudioPage,
       shouldDisableInviteUser,
       shouldDisableCreatingChat,
       shouldDisableOwnLLMs,
-      isAppCatalogTab,
     ],
   );
 
-  const tootip = useMemo(() => {
+  const tooltip = useMemo(() => {
     if (isCreatingNewConversation) {
       return 'Creating conversation...';
     }
     if (isSettingsUsersPage) {
       return 'Invite users';
     }
-    return `Create ${selectedOption || 'entity'}`;
-  }, [isCreatingNewConversation, isSettingsUsersPage, selectedOption]);
+    if (isSimpleCreateRoute) {
+      return 'Create';
+    }
+    return `Create ${currentLabel || selectedOption || 'entity'}`;
+  }, [isCreatingNewConversation, isSettingsUsersPage, isSimpleCreateRoute, currentLabel, selectedOption]);
+
+  const handleDropdownItemClick = useCallback(
+    item => {
+      const permissions = CreateEntityConstants.CreationPermissions[item.option];
+      if (permissions?.length && !permissions.some(p => checkPermission(p))) {
+        return;
+      }
+      setOpenMenu(false);
+      handleCommand(item.option);
+    },
+    [handleCommand, checkPermission],
+  );
+
+  const handleClickAway = useCallback(() => {
+    setOpenMenu(false);
+  }, []);
+
+  const handleMainButtonClick = useCallback(() => {
+    if (isAppCatalogTab) {
+      navigate(RouteDefinitions.AppsCatalog, { state: locationState });
+      return;
+    }
+    handleCommand();
+  }, [isAppCatalogTab, navigate, locationState, handleCommand]);
+
+  const showSimpleButton = sideBarCollapsed || isSimpleCreateRoute;
 
   return (
-    <StyledTooltip
-      placement="right"
-      title={tootip}
-      enterDelay={500}
-      enterNextDelay={500}
-    >
+    <ClickAwayListener onClickAway={handleClickAway}>
       <Box
         component="span"
         data-tour={tourId}
-        sx={styles.span}
+        sx={styles.wrapper}
+        ref={anchorRef}
       >
-        <IconButton
-          disabled={disableCreateButton}
-          disableRipple
-          sx={styles.button}
-          onClick={handleClick}
+        <StyledTooltip
+          placement="right"
+          title={tooltip}
+          enterDelay={500}
+          enterNextDelay={500}
         >
-          <Box sx={styles.iconBox(disableCreateButton)}>
-            <PlusIcon />
+          <Box sx={styles.span}>
+            {showSimpleButton ? (
+              <Button.BaseBtn
+                variant="special"
+                disabled={disableCreateButton}
+                startIcon={<PlusIcon />}
+                sx={styles.simpleButton}
+                onClick={handleOpenMenu}
+              >
+                {!sideBarCollapsed ? 'Create' : null}
+              </Button.BaseBtn>
+            ) : (
+              <>
+                <Button.BaseBtn
+                  variant="special"
+                  disabled={disableCreateButton}
+                  startIcon={<PlusIcon />}
+                  sx={styles.mainButton}
+                  onClick={handleMainButtonClick}
+                >
+                  {currentLabel}
+                </Button.BaseBtn>
+                <Button.BaseBtn
+                  variant="special"
+                  disabled={disableCreateButton}
+                  sx={styles.chevronButton}
+                  onClick={handleOpenMenu}
+                >
+                  <ArrowDownIcon
+                    fill="currentColor"
+                    style={{ transform: openMenu ? 'rotate(180deg)' : 'none' }}
+                  />
+                </Button.BaseBtn>
+              </>
+            )}
           </Box>
-          {!sideBarCollapsed && (
-            <Typography
-              sx={styles.typography}
-              variant="labelSmall"
-            >
-              Create
-            </Typography>
-          )}
-        </IconButton>
+        </StyledTooltip>
+
+        <Popper
+          open={openMenu}
+          anchorEl={anchorRef.current}
+          placement={sideBarCollapsed ? 'right-start' : 'bottom-start'}
+          sx={styles.popper}
+        >
+          <Paper sx={styles.dropdown}>
+            {CreateEntityConstants.DropdownItems.map(item => (
+              <Box
+                key={item.label}
+                sx={styles.dropdownItem(currentDropdownItem?.label === item.label)}
+                onClick={() => handleDropdownItemClick(item)}
+              >
+                {item.label}
+                {currentDropdownItem?.label === item.label && (
+                  <CheckIcon
+                    fill={theme.palette.text.secondary}
+                    sx={styles.checkIcon}
+                  />
+                )}
+              </Box>
+            ))}
+          </Paper>
+        </Popper>
       </Box>
-    </StyledTooltip>
+    </ClickAwayListener>
   );
 });
 
 CreateEntityButton.displayName = 'CreateEntityButton';
 
-/** @type {MuiSx} */
 const createEntityButtonStyles = sideBarCollapsed => ({
-  span: {
+  wrapper: {
+    position: 'relative',
     display: 'flex',
     justifyContent: 'center',
     width: '100%',
     boxSizing: 'border-box',
   },
-  button: ({ palette }) => ({
-    boxSizing: 'border-box',
+  span: {
     display: 'flex',
-    width: '100%',
-    gap: '0.5rem',
     justifyContent: 'center',
-    alignItems: 'center',
-    height: '1.75rem',
-    color: palette.split.text.default,
-    background: palette.split.default,
-    borderRadius: '1.5rem',
-    ...(sideBarCollapsed
-      ? {
-          maxWidth: '1.75rem !important',
-          width: '1.75rem !important',
-          minWidth: '1.75rem !important',
-          borderRadius: '50%',
-          padding: 0,
-        }
-      : {}),
-    '&:hover': {
-      background: palette.split.hover,
-    },
-    '&:active': {
-      color: palette.split.text.pressed,
-      backgroundColor: palette.split.pressed,
-    },
-    '&:disabled': {
-      color: palette.split.text.disabled,
-      backgroundColor: palette.split.disabled,
-    },
+    width: '100%',
+    boxSizing: 'border-box',
+    gap: '0.0625rem',
+  },
+  simpleButton: {
+    width: '100%',
+    ...(sideBarCollapsed && {
+      width: '1.75rem !important',
+      minWidth: '1.75rem !important',
+    }),
+  },
+  mainButton: {
+    flex: '1 1 auto',
+    borderRadius: '0.875rem 0.125rem 0.125rem 0.875rem',
+  },
+  chevronButton: {
+    borderRadius: '0.125rem 0.875rem 0.875rem 0.125rem',
+    padding: '0 0.5rem',
+    minWidth: 'unset',
+    width: 'fit-content',
+  },
+  popper: {
+    zIndex: 1300,
+  },
+  dropdown: ({ palette }) => ({
+    backgroundColor: palette.background.secondary,
+    borderRadius: '0.5rem',
+    border: `0.0625rem solid ${palette.border.lines}`,
+    padding: '0.5rem 0',
+    minWidth: '11.5rem',
+    boxShadow: '0 0.5rem 0.75rem rgba(0, 0, 0, 0.30)',
+    marginTop: sideBarCollapsed ? 0 : '0.25rem',
+    marginLeft: sideBarCollapsed ? '0.25rem' : 0,
   }),
-  iconBox:
-    disableCreateButton =>
-    ({ palette }) => ({
+  dropdownItem:
+    isSelected =>
+    ({ palette, spacing }) => ({
       display: 'flex',
       alignItems: 'center',
-      justifyContent: 'center',
-      color: disableCreateButton ? palette.text.disabled : palette.text.createButton,
+      justifyContent: 'space-between',
+      padding: spacing(1, 2),
+      cursor: 'pointer',
+      color: palette.text.secondary,
+      fontSize: '0.875rem',
+      '&:hover': {
+        backgroundColor: palette.action.hover,
+      },
+      ...(isSelected && {
+        backgroundColor: palette.split.pressed,
+      }),
     }),
-  typography: ({ typography }) => ({
-    color: 'inherit',
-    fontFamily: typography.fontFamily,
-    fontFeatureSettings: typography.fontFeatureSettings,
-  }),
+  checkIcon: {
+    width: '1rem',
+    height: '1rem',
+  },
 });
 
 export default CreateEntityButton;

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -584,6 +584,7 @@ export const PERMISSIONS = {
     unsecret: 'configuration.secrets.secret.unsecret', //show/hide unsecret button
   },
   artifacts: {
+    create: 'configuration.artifacts.artifacts.create',
     delete: 'configuration.artifacts.artifacts.delete',
     view: 'configuration.artifacts.artifacts.view',
     buckets: {

--- a/src/components/Icons/CheckIcon.jsx
+++ b/src/components/Icons/CheckIcon.jsx
@@ -2,8 +2,9 @@ import { SvgIcon } from '@mui/material';
 
 import { useTheme } from '@emotion/react';
 
-export default function CheckIcon(props) {
+export default function CheckIcon({ fill, ...props }) {
   const theme = useTheme();
+  const fillColor = fill ?? theme.palette.icon.fill.default;
 
   return (
     <SvgIcon
@@ -12,7 +13,7 @@ export default function CheckIcon(props) {
     >
       <path
         d="M14.8359 3.94885L5.87629 12.8371C5.82429 12.8887 5.76253 12.9297 5.69455 12.9577C5.62657 12.9856 5.5537 13 5.48011 13C5.40652 13 5.33365 12.9856 5.26567 12.9577C5.19769 12.9297 5.13594 12.8887 5.08393 12.8371L1.1641 8.94848C1.05903 8.84424 1 8.70286 1 8.55545C1 8.40804 1.05903 8.26666 1.1641 8.16242C1.26918 8.05819 1.41169 7.99963 1.56029 7.99963C1.70888 7.99963 1.85139 8.05819 1.95647 8.16242L5.48011 11.6587L14.0435 3.1628C14.1486 3.05856 14.2911 3 14.4397 3C14.5883 3 14.7308 3.05856 14.8359 3.1628C14.941 3.26703 15 3.40841 15 3.55582C15 3.70324 14.941 3.84461 14.8359 3.94885Z"
-        fill={theme.palette.icon.fill.default}
+        fill={fillColor}
       />
     </SvgIcon>
   );


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5135

## Summary

| Where | What | Why |
|-------|------|-----|
| **CreateEntityButton.jsx** | Complete redesign from IconButton to split-button with dropdown | **Main feature:** New UI with split-button (main action + chevron for dropdown) |
| CreateEntityButton.jsx:299-331 | Two-button layout: main button with label + chevron button for dropdown | Split-button design with proper border-radius |
| CreateEntityButton.jsx:336-358 | Popper/Paper dropdown with DropdownItems list and CheckIcon for selected | Dropdown menu with visual selection indicator |
| CreateEntityButton.jsx:84-98 | Added `isSimpleCreateRoute`, `currentLabel`, `currentDropdownItem` computed values | Dynamic label based on current route |
| CreateEntityButton.jsx:139-141 | `case 'Application'` navigates to `AppsCatalog` | Application click always goes to apps/catalog |
| CreateEntityButton.jsx:274-278 | `handleMainButtonClick` checks `isAppCatalogTab` | Main button click for Application also goes to apps/catalog |
| CreateEntityButton.jsx:258-268 | `handleDropdownItemClick` with permission check | Dropdown item click with permission validation |
| CreateEntityButton.jsx:367-433 | New styles: `wrapper`, `simpleButton`, `mainButton`, `chevronButton`, `dropdown`, `dropdownItem` | Complete styling overhaul for split-button and dropdown |
| **createEntity.constant.js:19-51** | Added `RouteToLabelMap`, `DropdownItems`, `SimpleCreateRoutes` arrays | New constants for route-to-label mapping and dropdown configuration |
| createEntity.constant.js:72 | Added `Bucket` permission: `PERMISSIONS.artifacts.create` | Additional permission for bucket creation |
| createEntity.constant.js:76 | Added `User: [PERMISSIONS.users.create]` | Permission for invite user action |
| createEntity.constant.js:131-133 | Added paths to `PathToOptionMap`: `settings/create-integration`, `settings/create-personal-token` | Extended path-to-option mapping |
| **constants.js:587** | Added `artifacts.create` permission constant | New permission for artifacts creation |
| **SecretsContent.jsx:69-72** | Fixed `setSecretRows` to preserve new rows during refetch | Bug fix: New unsaved secret rows were lost on data refetch |
| **CheckIcon.jsx:5-7** | Added `fill` prop with fallback `fill ?? theme.palette.icon.fill.default` | Color override support with backward compatibility |

**Root cause / Summary:**
1. **CreateEntityButton redesign**: Transformed from simple IconButton to split-button UI pattern with dropdown menu. Main button shows contextual label based on current route, chevron opens dropdown for entity type selection.
2. **Navigation fix**: All "Application" clicks (dropdown or main button) now navigate to `apps/catalog` instead of `apps/applications`.
3. **Constants expansion**: Added route-to-label mappings, dropdown items configuration, and simple create routes for conditional rendering.
4. **Permissions**: Added missing artifact and user creation permissions.
5. **SecretsContent bug**: Fixed race condition where newly created (unsaved) secret rows were being overwritten when API data refreshed.
6. **CheckIcon flexibility**: Added explicit `fill` prop for color override while maintaining backward compatibility via nullish coalescing.

<img width="921" height="749" alt="Screenshot 2026-06-04 144459" src="https://github.com/user-attachments/assets/2bf6f66d-d5d3-49b9-914f-e7465ceb21dd" />
<img width="969" height="850" alt="Screenshot 2026-06-04 144506" src="https://github.com/user-attachments/assets/1e21c9a8-ea6c-40b4-9961-cc11f91e3064" />
<img width="994" height="891" alt="Screenshot 2026-06-04 144529" src="https://github.com/user-attachments/assets/0788cb0a-2bab-4107-87e4-edb7088f1e11" />
<img width="1003" height="827" alt="Screenshot 2026-06-04 144536" src="https://github.com/user-attachments/assets/6707d7a6-f273-49ef-9961-92d0a3730ee3" />
<img width="999" height="965" alt="Screenshot 2026-06-04 144541" src="https://github.com/user-attachments/assets/152dacfa-8fe6-4748-9c62-c35f3162389f" />
