### PR TITLE
fix: [EL-2931] remove dead agent_messages socket event handler

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -146,7 +146,6 @@ export const RoleOptions = [
 export const SocketMessageType = {
   AgentStart: 'agent_start',
   AgentResponse: 'agent_response',
-  AgentMessages: 'agent_messages',
   AgentException: 'agent_exception',
   AgentToolStart: 'agent_tool_start',
   AgentToolEnd: 'agent_tool_end',

--- a/src/components/Chat/hooks.js
+++ b/src/components/Chat/hooks.js
@@ -1184,7 +1184,6 @@ export const useChatSocket = ({
           setChatHistoryRef.current?.(prevHistory => [...prevHistory]);
           return;
         }
-        case SocketMessageType.AgentMessages:
         case SocketMessageType.AgentOnFunctionToolNode:
         case SocketMessageType.AgentOnToolNode:
         case SocketMessageType.AgentOnTransitionalEdge:


### PR DESCRIPTION
The agent_messages event was never acted upon — hooks.js routed it to parseRunEvent() which has no case for it. Remove the case from the switch and the AgentMessages constant.

Connected issue: https://github.com/EliteaAI/elitea_issues/issues/2931