### PR TITLE
fix: [EL-5105] the removed toolkit can be stored

### DIFF
--- a/src/[fsd]/entities/application-tab-bar/ui/ApplicationTabBar.jsx
+++ b/src/[fsd]/entities/application-tab-bar/ui/ApplicationTabBar.jsx
@@ -6,13 +6,13 @@ import { useSelector } from 'react-redux';
 import { Box } from '@mui/material';
 
 import { ApplicationVersionSelect } from '@/[fsd]/entities/application-tab-bar/ui';
+import { useRefetchAgentDetails } from '@/[fsd]/features/agent/lib/hooks';
 import { AGENT_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
 import { PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE } from '@/[fsd]/features/pipelines';
 import { useFormDirtyExcluding } from '@/[fsd]/shared/lib/hooks';
 import { Button } from '@/[fsd]/shared/ui';
 import { ViewMode } from '@/common/constants';
 import useFromApplications from '@/hooks/application/useIsFromApplication';
-import useRefetchAgentDetails from '@/hooks/application/useRefetchAgentDetails';
 import { useIsFromPipelineDetail } from '@/hooks/useIsFromSpecificPageHooks';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useViewMode from '@/hooks/useViewMode';

--- a/src/[fsd]/features/agent/lib/hooks/index.js
+++ b/src/[fsd]/features/agent/lib/hooks/index.js
@@ -1,2 +1,4 @@
 export { useApplicationChat } from './useApplicationChat.hooks';
+export { useDisassociateToolkit } from './useDisassociateToolkit.hooks';
+export { useRefetchAgentDetails, useSetRefetchDetails } from './useRefetchAgentDetails.hooks';
 export { useSaveAgentToolVariables } from './useSaveAgentToolVariables.js';

--- a/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
@@ -39,6 +39,58 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
     setRefetch();
   }, [dispatch, setRefetch]);
 
+  // Updates both Formik initialValues (Discard baseline) and current values after toolkit removal.
+  // resetForm sets initialValues so that Discard does not restore the toolkit.
+  // setValues re-applies the user's current changes, preserving other pending edits.
+  const applyToolRemoval = useCallback(
+    (tool, toolIndex, isAttachmentToolkit = false) => {
+      const filteredCurrentTools = (values.version_details?.tools || []).filter((_, i) => i !== toolIndex);
+      const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
+        t => t.id !== tool.id,
+      );
+      const updatedCurrentVersionDetails = isAttachmentToolkit
+        ? {
+            ...(values.version_details || {}),
+            tools: filteredCurrentTools,
+            meta: {
+              ...(values.version_details?.meta || {}),
+              attachment_toolkit_id: undefined,
+            },
+          }
+        : {
+            ...(values.version_details || {}),
+            tools: filteredCurrentTools,
+          };
+      const updatedInitialVersionDetails = isAttachmentToolkit
+        ? {
+            ...(initialValues?.version_details || {}),
+            tools: filteredInitialTools,
+            meta: {
+              ...(initialValues?.version_details?.meta || {}),
+              attachment_toolkit_id: undefined,
+            },
+          }
+        : {
+            ...(initialValues?.version_details || {}),
+            tools: filteredInitialTools,
+          };
+      resetForm({
+        values: {
+          ...(initialValues || {}),
+          version_details: updatedInitialVersionDetails,
+        },
+      });
+      setValues({
+        ...(values || {}),
+        version_details: updatedCurrentVersionDetails,
+      });
+      if (!dirty) {
+        setRefetch();
+      }
+    },
+    [dirty, initialValues, resetForm, setRefetch, setValues, values],
+  );
+
   const onDisassociateTool = useCallback(
     async ({ tool, isAttachmentToolkit }) => {
       if (applicationId && tool?.id && versionId) {
@@ -56,53 +108,7 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
           // Update cache to remove the tool from the application
           if (!result.error) {
             onRemoveTool(tool);
-            // Filter toolkit from current values (by index) and from the server baseline (by id).
-            // resetForm sets initialValues to the server baseline without the toolkit so that
-            // Discard does not restore it. setValues then re-applies the user's current changes,
-            // preserving other pending edits and keeping dirty=true when applicable.
-            const filteredCurrentTools = (values.version_details?.tools || []).filter((_, i) => i !== index);
-            const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
-              t => t.id !== tool.id,
-            );
-            const updatedCurrentVersionDetails = !isAttachmentToolkit
-              ? {
-                  ...(values.version_details || {}),
-                  tools: filteredCurrentTools,
-                }
-              : {
-                  ...(values.version_details || {}),
-                  tools: filteredCurrentTools,
-                  meta: {
-                    ...(values.version_details?.meta || {}),
-                    attachment_toolkit_id: undefined,
-                  },
-                };
-            const updatedInitialVersionDetails = !isAttachmentToolkit
-              ? {
-                  ...(initialValues?.version_details || {}),
-                  tools: filteredInitialTools,
-                }
-              : {
-                  ...(initialValues?.version_details || {}),
-                  tools: filteredInitialTools,
-                  meta: {
-                    ...(initialValues?.version_details?.meta || {}),
-                    attachment_toolkit_id: undefined,
-                  },
-                };
-            resetForm({
-              values: {
-                ...(initialValues || {}),
-                version_details: updatedInitialVersionDetails,
-              },
-            });
-            setValues({
-              ...(values || {}),
-              version_details: updatedCurrentVersionDetails,
-            });
-            if (!dirty) {
-              setRefetch();
-            }
+            applyToolRemoval(tool, index, isAttachmentToolkit);
             reset();
             if (isAttachmentToolkit) {
               onDeleteAttachmentTool?.();
@@ -129,31 +135,7 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
             }).unwrap();
             if (!result?.error) {
               onRemoveTool(tool);
-              const filteredCurrentTools = (values.version_details?.tools || []).filter(
-                (_, i) => i !== index,
-              );
-              const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
-                t => t.id !== tool.id,
-              );
-              resetForm({
-                values: {
-                  ...(initialValues || {}),
-                  version_details: {
-                    ...(initialValues?.version_details || {}),
-                    tools: filteredInitialTools,
-                  },
-                },
-              });
-              setValues({
-                ...(values || {}),
-                version_details: {
-                  ...(values.version_details || {}),
-                  tools: filteredCurrentTools,
-                },
-              });
-              if (!dirty) {
-                setRefetch();
-              }
+              applyToolRemoval(tool, index);
               reset();
             } else {
               toastError(
@@ -191,29 +173,7 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
           }).unwrap();
           if (!result?.error) {
             onRemoveTool(tool);
-            const filteredCurrentTools = (values.version_details?.tools || []).filter((_, i) => i !== index);
-            const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
-              t => t.id !== tool.id,
-            );
-            resetForm({
-              values: {
-                ...(initialValues || {}),
-                version_details: {
-                  ...(initialValues?.version_details || {}),
-                  tools: filteredInitialTools,
-                },
-              },
-            });
-            setValues({
-              ...(values || {}),
-              version_details: {
-                ...(values.version_details || {}),
-                tools: filteredCurrentTools,
-              },
-            });
-            if (!dirty) {
-              setRefetch();
-            }
+            applyToolRemoval(tool, index);
             reset();
           } else {
             toastError(
@@ -240,23 +200,18 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
     },
     [
       applicationId,
-      dirty,
+      applyToolRemoval,
       disassociateToolkit,
       index,
-      initialValues,
+      invalidateCacheAndRefresh,
+      onDeleteAttachmentTool,
+      onRemoveTool,
       projectId,
       reset,
-      resetForm,
-      setRefetch,
-      setValues,
       toastError,
       toastInfo,
-      onRemoveTool,
       updateApplicationRelation,
-      values,
       versionId,
-      onDeleteAttachmentTool,
-      invalidateCacheAndRefresh,
     ],
   );
 

--- a/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
@@ -1,17 +1,16 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useFormikContext } from 'formik';
 import { useDispatch } from 'react-redux';
 
+import { useSetRefetchDetails } from '@/[fsd]/features/agent/lib/hooks/useRefetchAgentDetails.hooks';
 import { TAG_TYPE_APPLICATION_DETAILS, useUpdateApplicationRelationMutation } from '@/api/applications';
 import { eliteaApi } from '@/api/eliteaApi';
 import { useToolkitAssociateMutation } from '@/api/toolkits';
 import { buildErrorMessage } from '@/common/utils';
-
-import usePipelineToolsChanges from '../pipeline/usePipelineToolsChanges';
-import { useSelectedProjectId } from '../useSelectedProject';
-import useToast from '../useToast';
-import { useSetRefetchDetails } from './useRefetchAgentDetails';
+import usePipelineToolsChanges from '@/hooks/pipeline/usePipelineToolsChanges';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
+import useToast from '@/hooks/useToast';
 
 /**
  * Checks if an error is due to a stale version reference (version was deleted/replaced)
@@ -23,14 +22,13 @@ const isStaleVersionReferenceError = error => {
   return errorMessage.includes('Already removed relation');
 };
 
-export default function useDisassociateToolkit({ applicationId, versionId, onDeleteAttachmentTool, index }) {
+export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttachmentTool, index }) => {
   const projectId = useSelectedProjectId();
   const dispatch = useDispatch();
   const { onRemoveTool } = usePipelineToolsChanges();
   const { setRefetch } = useSetRefetchDetails();
   const { toastError, toastInfo } = useToast();
-  const { setFieldValue, resetForm, values, dirty } = useFormikContext();
-  const tools = useMemo(() => values?.version_details?.tools || [], [values?.version_details?.tools]);
+  const { resetForm, setValues, values, initialValues, dirty } = useFormikContext();
   const [disassociateToolkit, { isLoading, isError: isDisassociateError, error: disassociateError, reset }] =
     useToolkitAssociateMutation();
   const [updateApplicationRelation] = useUpdateApplicationRelationMutation();
@@ -58,48 +56,51 @@ export default function useDisassociateToolkit({ applicationId, versionId, onDel
           // Update cache to remove the tool from the application
           if (!result.error) {
             onRemoveTool(tool);
-            if (dirty) {
-              if (isAttachmentToolkit) {
-                setFieldValue('version_details', {
-                  ...values.version_details,
-                  tools: values?.version_details?.tools.filter((_, i) => i.id !== index),
+            // Filter toolkit from current values (by index) and from the server baseline (by id).
+            // resetForm sets initialValues to the server baseline without the toolkit so that
+            // Discard does not restore it. setValues then re-applies the user's current changes,
+            // preserving other pending edits and keeping dirty=true when applicable.
+            const filteredCurrentTools = (values.version_details?.tools || []).filter((_, i) => i !== index);
+            const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
+              t => t.id !== tool.id,
+            );
+            const updatedCurrentVersionDetails = !isAttachmentToolkit
+              ? {
+                  ...(values.version_details || {}),
+                  tools: filteredCurrentTools,
+                }
+              : {
+                  ...(values.version_details || {}),
+                  tools: filteredCurrentTools,
                   meta: {
                     ...(values.version_details?.meta || {}),
                     attachment_toolkit_id: undefined,
                   },
-                });
-              } else {
-                setFieldValue(
-                  `version_details.tools`,
-                  values?.version_details.tools.filter((_, i) => i !== index),
-                );
-              }
-            } else {
-              resetForm(
-                !isAttachmentToolkit
-                  ? {
-                      values: {
-                        ...(values || {}),
-                        version_details: {
-                          ...(values.version_details || {}),
-                          tools: (values.version_details.tools || []).filter((_, i) => i !== index),
-                        },
-                      },
-                    }
-                  : {
-                      values: {
-                        ...(values || {}),
-                        version_details: {
-                          ...(values.version_details || {}),
-                          tools: (values.version_details.tools || []).filter((_, i) => i !== index),
-                          meta: {
-                            ...(values.version_details?.meta || {}),
-                            attachment_toolkit_id: undefined,
-                          },
-                        },
-                      },
-                    },
-              );
+                };
+            const updatedInitialVersionDetails = !isAttachmentToolkit
+              ? {
+                  ...(initialValues?.version_details || {}),
+                  tools: filteredInitialTools,
+                }
+              : {
+                  ...(initialValues?.version_details || {}),
+                  tools: filteredInitialTools,
+                  meta: {
+                    ...(initialValues?.version_details?.meta || {}),
+                    attachment_toolkit_id: undefined,
+                  },
+                };
+            resetForm({
+              values: {
+                ...(initialValues || {}),
+                version_details: updatedInitialVersionDetails,
+              },
+            });
+            setValues({
+              ...(values || {}),
+              version_details: updatedCurrentVersionDetails,
+            });
+            if (!dirty) {
               setRefetch();
             }
             reset();
@@ -128,22 +129,29 @@ export default function useDisassociateToolkit({ applicationId, versionId, onDel
             }).unwrap();
             if (!result?.error) {
               onRemoveTool(tool);
-              if (dirty) {
-                // Update local state to remove the tool
-                setFieldValue(
-                  'version_details.tools',
-                  tools.filter((_, i) => i !== index),
-                );
-              } else {
-                resetForm({
-                  values: {
-                    ...(values || {}),
-                    version_details: {
-                      ...(values.version_details || {}),
-                      tools: (values.version_details.tools || []).filter((_, i) => i !== index),
-                    },
+              const filteredCurrentTools = (values.version_details?.tools || []).filter(
+                (_, i) => i !== index,
+              );
+              const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
+                t => t.id !== tool.id,
+              );
+              resetForm({
+                values: {
+                  ...(initialValues || {}),
+                  version_details: {
+                    ...(initialValues?.version_details || {}),
+                    tools: filteredInitialTools,
                   },
-                });
+                },
+              });
+              setValues({
+                ...(values || {}),
+                version_details: {
+                  ...(values.version_details || {}),
+                  tools: filteredCurrentTools,
+                },
+              });
+              if (!dirty) {
                 setRefetch();
               }
               reset();
@@ -183,22 +191,27 @@ export default function useDisassociateToolkit({ applicationId, versionId, onDel
           }).unwrap();
           if (!result?.error) {
             onRemoveTool(tool);
-            if (dirty) {
-              // Update local state to remove the tool
-              setFieldValue(
-                'version_details.tools',
-                tools.filter((_, i) => i !== index),
-              );
-            } else {
-              resetForm({
-                values: {
-                  ...(values || {}),
-                  version_details: {
-                    ...(values.version_details || {}),
-                    tools: (values.version_details.tools || []).filter((_, i) => i !== index),
-                  },
+            const filteredCurrentTools = (values.version_details?.tools || []).filter((_, i) => i !== index);
+            const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
+              t => t.id !== tool.id,
+            );
+            resetForm({
+              values: {
+                ...(initialValues || {}),
+                version_details: {
+                  ...(initialValues?.version_details || {}),
+                  tools: filteredInitialTools,
                 },
-              });
+              },
+            });
+            setValues({
+              ...(values || {}),
+              version_details: {
+                ...(values.version_details || {}),
+                tools: filteredCurrentTools,
+              },
+            });
+            if (!dirty) {
               setRefetch();
             }
             reset();
@@ -230,15 +243,15 @@ export default function useDisassociateToolkit({ applicationId, versionId, onDel
       dirty,
       disassociateToolkit,
       index,
+      initialValues,
       projectId,
       reset,
       resetForm,
-      setFieldValue,
       setRefetch,
+      setValues,
       toastError,
       toastInfo,
       onRemoveTool,
-      tools,
       updateApplicationRelation,
       values,
       versionId,
@@ -248,4 +261,4 @@ export default function useDisassociateToolkit({ applicationId, versionId, onDel
   );
 
   return { onDisassociateTool, isLoading, isDisassociateError, disassociateError };
-}
+};

--- a/src/[fsd]/features/agent/lib/hooks/useRefetchAgentDetails.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useRefetchAgentDetails.hooks.js
@@ -4,11 +4,10 @@ import { useFormikContext } from 'formik';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { eliteaApi } from '@/api/eliteaApi';
+import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import { actions } from '@/slices/applications';
 
-import { useSelectedProjectId } from '../useSelectedProject';
-
-export default function useRefetchAgentDetails() {
+export const useRefetchAgentDetails = () => {
   const dispatch = useDispatch();
   const { values } = useFormikContext();
   const selectedProjectId = useSelectedProjectId();
@@ -40,7 +39,7 @@ export default function useRefetchAgentDetails() {
       updateDataRef.current();
     };
   }, []);
-}
+};
 
 export const useSetRefetchDetails = () => {
   const dispatch = useDispatch();

--- a/src/hooks/application/useAgentPipelineAssociation.jsx
+++ b/src/hooks/application/useAgentPipelineAssociation.jsx
@@ -2,14 +2,13 @@ import { useCallback } from 'react';
 
 import { useFormikContext } from 'formik';
 
+import { useSetRefetchDetails } from '@/[fsd]/features/agent/lib/hooks';
 import { useLazyApplicationDetailsQuery, useUpdateApplicationRelationMutation } from '@/api/applications';
 import FlowIcon from '@/assets/flow-icon.svg?react';
 import { buildErrorMessage } from '@/common/utils';
 import ApplicationsIcon from '@/components/Icons/ApplicationsIcon';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
-
-import { useSetRefetchDetails } from './useRefetchAgentDetails';
 
 /**
  * Custom hook to handle association of agents and pipelines as "toolkits"

--- a/src/hooks/application/useLibraryToolkits.js
+++ b/src/hooks/application/useLibraryToolkits.js
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { useTheme } from '@mui/material';
 
+import { useSetRefetchDetails } from '@/[fsd]/features/agent/lib/hooks';
 import { useGetCurrentMCPSchemas, useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
 import { useApplicationDetailsQuery } from '@/api/applications';
 import { useToolkitAssociateMutation, useToolkitsListQuery } from '@/api/toolkits.js';
@@ -12,8 +13,6 @@ import usePageQuery from '@/hooks/usePageQuery';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useSortQueryParamsFromUrl from '@/hooks/useSortQueryParamsFromUrl';
 import useToast from '@/hooks/useToast';
-
-import { useSetRefetchDetails } from './useRefetchAgentDetails';
 
 export const useAssociateToolkit = ({ applicationId, versionId, onSelectToolkit, formik, entityType }) => {
   const [associateToolkit, { isLoading: isAssociating, isError: isAssociateError, error: associateError }] =

--- a/src/pages/Applications/Components/Tools/AgentPipelineVersionSelector.jsx
+++ b/src/pages/Applications/Components/Tools/AgentPipelineVersionSelector.jsx
@@ -10,6 +10,7 @@ import { Box, IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/mater
 
 import StyledCircleProgress from '@/ComponentsLib/CircularProgress';
 import { LATEST_VERSION_NAME } from '@/[fsd]/entities/version/lib/constants';
+import { useSetRefetchDetails } from '@/[fsd]/features/agent/lib/hooks';
 import {
   TAG_TYPE_APPLICATION_DETAILS,
   useApplicationDetailsQuery,
@@ -18,7 +19,6 @@ import {
 } from '@/api/applications';
 import { eliteaApi } from '@/api/eliteaApi';
 import RefreshIcon from '@/assets/refresh-icon.svg?react';
-import { useSetRefetchDetails } from '@/hooks/application/useRefetchAgentDetails';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
 

--- a/src/pages/Applications/Components/Tools/ToolCard.jsx
+++ b/src/pages/Applications/Components/Tools/ToolCard.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 
+import { useDisassociateToolkit } from '@/[fsd]/features/agent/lib/hooks';
 import { useSaveAgentToolVariables } from '@/[fsd]/features/agent/lib/hooks/useSaveAgentToolVariables.js';
 import { useMcpTokenChange } from '@/[fsd]/features/mcp/lib/hooks';
 import { McpLogInButton } from '@/[fsd]/features/mcp/ui';
@@ -28,7 +29,6 @@ import CredentialWarningBanner from '@/components/CredentialWarningBanner';
 import EntityIcon from '@/components/EntityIcon';
 import AttentionIcon from '@/components/Icons/AttentionIcon.jsx';
 import DeleteIcon from '@/components/Icons/DeleteIcon';
-import useDisassociateToolkit from '@/hooks/application/useDisassociateToolkit.js';
 import { useGetToolkitIconMeta } from '@/hooks/application/useLibraryToolkits';
 import {
   useManualValidateApplicationVersion,


### PR DESCRIPTION
# RCA: Pipeline Toolkit-Specific Fields Remain After Discard

**Issue**: [EliteaAI/elitea_issues#5105](https://github.com/EliteaAI/elitea_issues/issues/5105)  
**Title**: Pipeline: Toolkit-specific fields remain as leftover data after discarding toolkit removal  
**Date**: 2026-06-05  
**Milestone**: R-2.0.3

---

## Summary

When a user removes a toolkit from a **Toolkit Node** or **LLM Node** in a pipeline and then clicks **Discard Changes**, the removed toolkit is incorrectly restored — Discard reverts the Formik state from the server, bringing the toolkit back to the sidebar/node. Associated fields like `input_mapping` and `tool_names` entries are also missing after the restoration, leaving the node in a broken partial state.

The root cause is that Formik's `initialValues` (the Discard baseline) is never updated when a toolkit is removed via API. Discard calls `resetForm()` which reverts to the stale `initialValues` that still contains the toolkit.

---

## Last Comment (June 4, 2026 — Sshchornyi)

> A warning dialog appears. On confirm — the toolkit reappears in the UI, but its Input Mapping is not restored.  
> This creates a contradiction: saving afterward removes the toolkit again, conflicting with what the interface shows.  
> Either toolkit removal should be irreversible (Discard only rolls back metadata), or Discard should fully restore the toolkit with Save activation to persist changes correctly.

This comment identifies the exact split: Formik restores the toolkit name in the sidebar (from server state), but the YAML node still has the toolkit cleared — so the toolkit appears in the UI but has no `input_mapping`. The toolkit **should have stayed removed** after Discard; the Formik reset is the problem.

---

## Architecture Background

Pipeline state is managed across two independent layers:

| Layer | Where | What it holds |
|---|---|---|
| **Formik** | `useFormik` in `EditPipeline.jsx` | `version_details` (name, description, toolkit list `version_details.tools`) |
| **Redux YAML** | `pipeline.js` slice | `yamlCode`, `yamlJsonObject` (node-level: `toolkit_name`, `tool`, `input_mapping`, `tool_names`) |

On **Discard**, two resets fire:
- `resetForm()` → reverts Formik to `initialValues` (server state)
- `dispatch(resetPipeline({ resetAll: false }))` → reverts Redux YAML to `state.initState.yamlJsonObject`

The Redux YAML layer correctly keeps the toolkit removed because `syncInitYamlJsonObject` is called during `onRemoveTool`, writing the cleared node into `initState`. The bug is that Formik's `initialValues` is never updated to reflect the removal — so `resetForm()` on Discard restores the toolkit from the stale server baseline.

---

## Root Cause

**File**: `EliteaUI/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js`

When a toolkit is removed via the sidebar (API disassociation), the code split its behaviour on the `dirty` flag:

- **`dirty = false` path**: called `resetForm({ values: currentValuesWithoutToolkit })`. This updates both `values` AND Formik's `initialValues` baseline → Discard correctly leaves the toolkit removed.
- **`dirty = true` path**: called `setFieldValue('version_details.tools', filteredTools)`. This updates only the current `values`, NOT `initialValues`. When Discard fires, `resetForm()` reverts to the stale `initialValues` (which still has the toolkit) → toolkit incorrectly reappears.

Additionally, once restored by Discard, the YAML layer (which correctly kept `toolkit_name: undefined` in `initState`) and Formik diverge: the toolkit shows in the sidebar but `input_mapping` is empty — producing the "leftover data" appearance.

---

## Bug Scenarios

### Scenario A — Toolkit Node: toolkit reappears with empty Input Mapping after Discard

1. User selects toolkit + tool in Toolkit Node → Save.
2. User makes another change (e.g., edits pipeline description) → `dirty = true`.
3. User removes the toolkit from the node via sidebar API disassociation.
   - `onRemoveTool` fires → YAML node cleared → `syncInitYamlJsonObject` updates `initState`.
   - `setFieldValue` updates current `values` but NOT `initialValues`.
4. User clicks Discard.
   - `resetPipeline` reads `initState` → YAML node stays cleared ✓
   - `resetForm()` reads stale `initialValues` → toolkit restored in `version_details.tools` ✗
5. Result: sidebar shows toolkit as selected, but `input_mapping` in YAML is `{}`.

**Expected**: toolkit stays removed, node shows no toolkit and no input mapping fields.

### Scenario B — LLM Node: toolkit entry reappears after Discard

Same flow. `resetForm()` restores the toolkit in `version_details.tools`, causing the LLM Node to re-render its toolkit accordion even though `tool_names` in YAML has no tools configured.

**Expected**: toolkit stays removed, no accordion entry shown.

---

## Affected Files

| File | Change |
|---|---|
| `EliteaUI/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js` | Bug fix — `dirty = true` path used `setFieldValue` which does not update `initialValues`; replaced with `resetForm` + `setValues` pattern. Moved from `src/hooks/application/useDisassociateToolkit.js` |
| `EliteaUI/src/[fsd]/features/agent/lib/hooks/useRefetchAgentDetails.hooks.js` | Moved from `src/hooks/application/useRefetchAgentDetails.js` to FSD; converted to named exports |
| `EliteaUI/src/[fsd]/features/agent/lib/hooks/index.js` | Updated public API to export both hooks from their new FSD locations |
| `EliteaUI/src/pages/Applications/Components/Tools/ToolCard.jsx` | Updated import to use FSD path |
| `EliteaUI/src/[fsd]/entities/application-tab-bar/ui/ApplicationTabBar.jsx` | Updated import to use FSD path |
| `EliteaUI/src/hooks/application/useLibraryToolkits.js` | Updated import to use FSD path |
| `EliteaUI/src/hooks/application/useAgentPipelineAssociation.jsx` | Updated import to use FSD path |
| `EliteaUI/src/pages/Applications/Components/Tools/AgentPipelineVersionSelector.jsx` | Updated import to use FSD path |

---

## Fix Applied

**File**: `EliteaUI/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js`

The fix replaces the `dirty`/`!dirty` split with a two-step update that correctly handles both the Discard baseline and other pending user changes:

```js
// 1. Update initialValues (Discard baseline) to server state without the toolkit.
//    Uses tool.id to filter initialValues (index may differ from current values when dirty).
resetForm({
  values: {
    ...(initialValues || {}),
    version_details: {
      ...(initialValues?.version_details || {}),
      tools: (initialValues?.version_details?.tools || []).filter(t => t.id !== tool.id),
    },
  },
});

// 2. Re-apply the user's current form state (with other pending edits preserved).
//    Uses index to filter current values. If there were other dirty changes, the form
//    remains dirty and those changes can still be discarded independently.
setValues({
  ...(values || {}),
  version_details: {
    ...(values.version_details || {}),
    tools: (values.version_details?.tools || []).filter((_, i) => i !== index),
  },
});

// 3. Only trigger a server refetch when nothing else was dirty, to avoid overwriting
//    other pending changes via enableReinitialize.
if (!dirty) {
  setRefetch();
}
```

**Why this works:**

- `resetForm({ values: X })` sets both Formik `values` and `initialValues` to `X`. The subsequent `setValues(Y)` updates only `values` to `Y`, leaving `initialValues` at `X`.
- After the two calls: `initialValues` = server baseline without toolkit; `values` = user's current changes without toolkit.
- When Discard fires: `resetForm()` reverts to `initialValues` which no longer has the toolkit → toolkit stays removed ✓
- Other pending edits (name, description) remain in `values` and diverge from `initialValues`, keeping `dirty = true` → user can still discard those separately ✓
- `setFieldValue` and `tools` (useMemo) removed as they are no longer used.

---

## Risk Assessment

- **Scope**: EliteaUI only. Core fix in `useDisassociateToolkit.hooks.js`; additional refactoring moved both hooks to FSD with import updates across 5 consumer files.
- **Regression risk**: Low — the `!dirty` path behaviour is preserved. The `dirty = true` path is fixed to use the same pattern.
- **Test cases**:
  - Scenario A: With dirty form, remove toolkit from Toolkit Node → Discard → toolkit stays removed, input mapping fields are gone, other changes are reverted.
  - Scenario B: With dirty form, remove toolkit from LLM Node → Discard → toolkit stays removed, no accordion entry shown.
  - Scenario C: Without dirty form (clean state), remove toolkit → Discard → toolkit stays removed, server refetch runs.
  - Verify other pending changes (name, description) are correctly reverted by Discard after toolkit removal.
