### PR TITLE
fix: [EL-5134] Deletion Version Modal in Agent Pipeline Auto-Closes on Any Click

### DIFF
--- a/src/[fsd]/entities/application-tab-bar/ui/ApplicationControls.jsx
+++ b/src/[fsd]/entities/application-tab-bar/ui/ApplicationControls.jsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 
 import { useFormikContext } from 'formik';
 
@@ -14,6 +14,7 @@ import { usePin, usePinMenu } from '@/[fsd]/widgets/PinToggler/lib/hooks';
 import { PERMISSIONS, ViewMode } from '@/common/constants';
 import { useCopyLinkMenu } from '@/components/CopyLinkToEntityButton.jsx';
 import { useForkEntityMenu } from '@/components/Fork/ForkEntityButton';
+import DeleteIcon from '@/components/Icons/DeleteIcon';
 import PinIcon from '@/components/Icons/PinIcon';
 import useCheckPermission from '@/hooks/useCheckPermission';
 import { useIsFromPipelineDetail } from '@/hooks/useIsFromSpecificPageHooks';
@@ -28,6 +29,7 @@ const ApplicationControls = memo(({ setBlockNav, onSuccess }) => {
   const isFromPipeline = useIsFromPipelineDetail();
   const formik = useFormikContext();
   const viewMode = useViewMode();
+  const versionDeleteRef = useRef(null);
 
   const { values: { id } = {} } = formik;
 
@@ -138,9 +140,11 @@ const ApplicationControls = memo(({ setBlockNav, onSuccess }) => {
       ...(unpublishVersionMenuItem && !isFromPipeline ? [unpublishVersionMenuItem] : []),
       {
         key: 'delete-version',
-        label: <VersionDelete type="menuItem" />,
+        icon: <DeleteIcon sx={{ fontSize: '1rem' }} />,
+        label: 'Delete',
         disabled: disableDelete,
         addSeparator: true,
+        onClick: () => versionDeleteRef.current?.triggerDelete(),
       },
       {
         key: isFromPipeline ? 'pipeline' : 'agent',
@@ -212,6 +216,10 @@ const ApplicationControls = memo(({ setBlockNav, onSuccess }) => {
         </Box>
       )}
       <Controls.ControlsDropdown menuItems={menuItems} />
+      <VersionDelete
+        ref={versionDeleteRef}
+        type="standalone"
+      />
       {publishDialog}
       {unpublishDialog}
       {setDefaultVersionDialog}

--- a/src/[fsd]/entities/version/ui/VersionDelete.jsx
+++ b/src/[fsd]/entities/version/ui/VersionDelete.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { forwardRef, memo, useCallback, useImperativeHandle, useMemo, useState } from 'react';
 
 import { useFormikContext } from 'formik';
 import { useParams } from 'react-router-dom';
@@ -14,153 +14,166 @@ import useDeleteVersion from '@/hooks/application/useDeleteVersion';
 import useToast from '@/hooks/useToast';
 import useDiscardApplicationChanges from '@/pages/Applications/useDiscardApplicationChanges';
 
-const VersionDelete = memo(props => {
-  const { disabled, onDiscard, type = 'button' } = props;
-  const { version: versionId } = useParams();
+const VersionDelete = memo(
+  forwardRef((props, ref) => {
+    const { disabled, onDiscard, type = 'button' } = props;
+    const { version: versionId } = useParams();
 
-  const { toastError, toastInfo, toastSuccess } = useToast();
+    const { toastError, toastInfo, toastSuccess } = useToast();
 
-  const {
-    values: {
-      id: applicationId,
-      version_details: { id: versionIdFromDetail } = {},
-      versions = [],
-      meta: { default_version_id: defaultVersionID } = {},
-    } = {},
-  } = useFormikContext();
+    const {
+      values: {
+        id: applicationId,
+        version_details: { id: versionIdFromDetail } = {},
+        versions = [],
+        meta: { default_version_id: defaultVersionID } = {},
+      } = {},
+    } = useFormikContext();
 
-  const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
-  const [openReplacementModal, setOpenReplacementModal] = useState(false);
+    const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
+    const [openReplacementModal, setOpenReplacementModal] = useState(false);
 
-  const currentVersionId = useMemo(() => versionId || versionIdFromDetail, [versionId, versionIdFromDetail]);
-  const currentVersionName = useMemo(
-    () => versions?.find(version => version.id == currentVersionId)?.name,
-    [currentVersionId, versions],
-  );
-  const latestVersionId = useMemo(
-    () => versions?.find(version => version.name === LATEST_VERSION_NAME)?.id,
-    [versions],
-  );
+    const currentVersionId = useMemo(
+      () => versionId || versionIdFromDetail,
+      [versionId, versionIdFromDetail],
+    );
+    const currentVersionName = useMemo(
+      () => versions?.find(version => version.id == currentVersionId)?.name,
+      [currentVersionId, versions],
+    );
+    const latestVersionId = useMemo(
+      () => versions?.find(version => version.name === LATEST_VERSION_NAME)?.id,
+      [versions],
+    );
 
-  const { discardApplicationChanges } = useDiscardApplicationChanges(onDiscard);
+    const { discardApplicationChanges } = useDiscardApplicationChanges(onDiscard);
 
-  const {
-    doCheckVersionInUse,
-    isCheckingInUse,
-    versionInUseData,
-    resetVersionInUseData,
-    doDeleteVersion,
-    isDeletingVersion,
-  } = useDeleteVersion({
-    versionId: currentVersionId,
-    applicationId,
-    toastError,
-    toastInfo,
-    toastSuccess,
-    versions,
-    defaultVersionID,
-  });
+    const {
+      doCheckVersionInUse,
+      isCheckingInUse,
+      versionInUseData,
+      resetVersionInUseData,
+      doDeleteVersion,
+      isDeletingVersion,
+    } = useDeleteVersion({
+      versionId: currentVersionId,
+      applicationId,
+      toastError,
+      toastInfo,
+      toastSuccess,
+      versions,
+      defaultVersionID,
+    });
 
-  const isLoading = useMemo(() => isCheckingInUse || isDeletingVersion, [isCheckingInUse, isDeletingVersion]);
+    const isLoading = useMemo(
+      () => isCheckingInUse || isDeletingVersion,
+      [isCheckingInUse, isDeletingVersion],
+    );
 
-  const onDeleteVersionClick = useCallback(async () => {
-    if (isLoading) return;
+    const onDeleteVersionClick = useCallback(async () => {
+      if (isLoading) return;
 
-    const checkResult = await doCheckVersionInUse();
+      const checkResult = await doCheckVersionInUse();
 
-    if (!checkResult) return;
+      if (!checkResult) return;
 
-    if (checkResult.in_use) setOpenReplacementModal(true);
-    else setOpenConfirmDialog(true);
-  }, [doCheckVersionInUse, isLoading]);
+      if (checkResult.in_use) setOpenReplacementModal(true);
+      else setOpenConfirmDialog(true);
+    }, [doCheckVersionInUse, isLoading]);
 
-  const onCloseConfirmDialog = useCallback(() => {
-    setOpenConfirmDialog(false);
-    resetVersionInUseData();
-  }, [resetVersionInUseData]);
+    useImperativeHandle(ref, () => ({ triggerDelete: onDeleteVersionClick }), [onDeleteVersionClick]);
 
-  const onCloseReplacementModal = useCallback(() => {
-    setOpenReplacementModal(false);
-    resetVersionInUseData();
-  }, [resetVersionInUseData]);
+    const onCloseConfirmDialog = useCallback(() => {
+      setOpenConfirmDialog(false);
+      resetVersionInUseData();
+    }, [resetVersionInUseData]);
 
-  const onConfirmSimpleDelete = useCallback(async () => {
-    setOpenConfirmDialog(false);
-    discardApplicationChanges();
+    const onCloseReplacementModal = useCallback(() => {
+      setOpenReplacementModal(false);
+      resetVersionInUseData();
+    }, [resetVersionInUseData]);
 
-    await doDeleteVersion(null);
-  }, [discardApplicationChanges, doDeleteVersion]);
-
-  const onConfirmReplaceAndDelete = useCallback(
-    async newVersionId => {
+    const onConfirmSimpleDelete = useCallback(async () => {
+      setOpenConfirmDialog(false);
       discardApplicationChanges();
 
-      const success = await doDeleteVersion(newVersionId);
+      await doDeleteVersion(null);
+    }, [discardApplicationChanges, doDeleteVersion]);
 
-      if (success) {
-        setOpenReplacementModal(false);
-        resetVersionInUseData();
-      }
-    },
-    [discardApplicationChanges, doDeleteVersion, resetVersionInUseData],
-  );
+    const onConfirmReplaceAndDelete = useCallback(
+      async newVersionId => {
+        discardApplicationChanges();
 
-  if (currentVersionId === latestVersionId && type === 'button') return null;
+        const success = await doDeleteVersion(newVersionId);
 
-  return (
-    <>
-      {type === 'menuItem' ? (
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'flex-start',
-            alignItems: 'center',
-            gap: '0.75rem',
-            fontSize: '1rem',
-          }}
-          onClick={e => {
-            e.stopPropagation();
-            onDeleteVersionClick();
-          }}
-        >
-          <DeleteIcon sx={{ fontSize: '1rem' }} />
-          <Typography sx={{ fontWeight: 500, fontSize: '.875rem', lineHeight: '1.5rem' }}>Delete</Typography>
-        </Box>
-      ) : (
-        <Button
-          disabled={isLoading || disabled}
-          variant="elitea"
-          color="secondary"
-          onClick={onDeleteVersionClick}
-        >
-          Delete Version
-          {isLoading && <StyledCircleProgress size={20} />}
-        </Button>
-      )}
+        if (success) {
+          setOpenReplacementModal(false);
+          resetVersionInUseData();
+        }
+      },
+      [discardApplicationChanges, doDeleteVersion, resetVersionInUseData],
+    );
 
-      <AlertDialog
-        title="Delete version"
-        alertContent={`Are you sure to delete ${currentVersionName}?`}
-        open={openConfirmDialog}
-        alarm
-        onClose={onCloseConfirmDialog}
-        onCancel={onCloseConfirmDialog}
-        onConfirm={onConfirmSimpleDelete}
-      />
+    if (currentVersionId === latestVersionId && type === 'button') return null;
 
-      <AgentDetails.VersionReplacementModal
-        open={openReplacementModal}
-        onClose={onCloseReplacementModal}
-        versionName={versionInUseData?.version_name || currentVersionName}
-        referencingParents={versionInUseData?.referencing_parents || []}
-        replacementVersions={versionInUseData?.replacement_versions || []}
-        onReplace={onConfirmReplaceAndDelete}
-        isReplacing={isDeletingVersion}
-        defaultVersionId={defaultVersionID}
-      />
-    </>
-  );
-});
+    return (
+      <>
+        {type === 'menuItem' && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              gap: '0.75rem',
+              fontSize: '1rem',
+            }}
+            onClick={e => {
+              e.stopPropagation();
+              onDeleteVersionClick();
+            }}
+          >
+            <DeleteIcon sx={{ fontSize: '1rem' }} />
+            <Typography sx={{ fontWeight: 500, fontSize: '.875rem', lineHeight: '1.5rem' }}>
+              Delete
+            </Typography>
+          </Box>
+        )}
+        {type === 'button' && (
+          <Button
+            disabled={isLoading || disabled}
+            variant="elitea"
+            color="secondary"
+            onClick={onDeleteVersionClick}
+          >
+            Delete Version
+            {isLoading && <StyledCircleProgress size={20} />}
+          </Button>
+        )}
+
+        <AlertDialog
+          title="Delete version"
+          alertContent={`Are you sure to delete ${currentVersionName}?`}
+          open={openConfirmDialog}
+          alarm
+          onClose={onCloseConfirmDialog}
+          onCancel={onCloseConfirmDialog}
+          onConfirm={onConfirmSimpleDelete}
+        />
+
+        <AgentDetails.VersionReplacementModal
+          open={openReplacementModal}
+          onClose={onCloseReplacementModal}
+          versionName={versionInUseData?.version_name || currentVersionName}
+          referencingParents={versionInUseData?.referencing_parents || []}
+          replacementVersions={versionInUseData?.replacement_versions || []}
+          onReplace={onConfirmReplaceAndDelete}
+          isReplacing={isDeletingVersion}
+          defaultVersionId={defaultVersionID}
+        />
+      </>
+    );
+  }),
+);
 
 VersionDelete.displayName = 'VersionDelete';
 


### PR DESCRIPTION
# Root Cause Analysis Report — Issue #5134

**Issue:** [BUG] Deletion Version Modal in Agent Pipeline Auto-Closes on Any Click
**URL:** https://github.com/EliteaAI/elitea_issues/issues/5134
**Date:** 2026-06-05
**Investigator:** Claude Code RCA Specialist

---

## Executive Summary

The "Version in use" replacement modal (`VersionReplacementModal`) auto-closes on any click because the MUI `Select` component (rendered inside `SingleSelect`) creates its dropdown Menu as a **Portal** appended directly to `document.body`, outside the DOM subtree of the parent `Dialog`. When MUI's `Dialog` detects a click event that originates from outside its own modal DOM subtree — which is exactly what happens when the user interacts with the portaled `Select` dropdown — the Dialog interprets it as a backdrop click and fires `onClose`, dismissing itself. No `disablePortal` prop or equivalent guard is set on the `Select` inside `VersionReplacementModal`.

---

## Issue Classification

- **Category:** Logic Error / UI Framework Interaction
- **Severity Assessment:** High (completely blocks the version migration and deletion workflow)
- **Scope:** Isolated (only `VersionReplacementModal.jsx` is affected; the pattern does exist in other dialogs in the codebase)

---

## Root Cause Details

### Primary Cause

MUI's `Dialog` component wraps its content in a `Modal` that listens for `mousedown` events on the backdrop element. When MUI's `Select` (used inside `SingleSelect`) opens its dropdown, it renders that dropdown via a `Portal` into `document.body` — completely **outside** the Dialog's DOM hierarchy.

When the user clicks any part of the Select dropdown (including menu items, the select trigger itself, or even just outside the select popover), the `mousedown` event target is not a descendant of the Dialog's paper/root element. MUI's Modal backdrop logic sees this as a backdrop click and calls the `onClose` prop, which in `VersionReplacementModal` calls `handleClose`, closing the entire dialog.

This interaction is a well-known MUI gotcha: "A Select inside a Dialog will close the Dialog when opened." The fix is to pass `disablePortal: true` to the Select's `MenuProps` so the dropdown renders **inside** the Dialog's DOM subtree, making click events descendants of the Dialog rather than appearing as backdrop clicks.

### Code Location(s)

| File | Line(s) | Description |
|------|---------|-------------|
| `EliteaUI/src/[fsd]/features/agent/ui/agent-details/version/VersionReplacementModal.jsx` | 168–178 | `SingleSelect` rendered inside `Dialog` without `disablePortal` in `customMenuProps` |
| `EliteaUI/src/[fsd]/shared/ui/select/SingleSelect.jsx` | 639–657 | MUI `Select` receives `MenuProps` (merged via `mergedMenuProps`) — no `disablePortal` set |
| `EliteaUI/src/[fsd]/shared/ui/select/SingleSelect.jsx` | 511–609 | `mergedMenuProps` construction — does not include `disablePortal` |

### Evidence

**VersionReplacementModal.jsx — lines 113–178:**
```jsx
return (
  <Dialog
    open={open}
    onClose={handleClose}   // <-- This fires on any backdrop click
    onKeyDown={handleKeyDown}
    fullWidth
    slotProps={{ paper: { sx: styles.paper } }}
  >
    ...
    <DialogContent>
      ...
      <Box>
        <SingleSelect
          onValueChange={onSelectVersion}
          value={selectedVersionId}
          options={versionSelectOptions}
          inputSX={styles.versionSelectInput}
          labelSX={styles.versionSelectLabel}
          maxDisplayValueLength={'200px'}
          label="Replace with version"
          showBorder
          // NO customMenuProps with disablePortal is passed here
        />
      </Box>
    </DialogContent>
    ...
  </Dialog>
);
```

**SingleSelect.jsx — mergedMenuProps construction (lines 511–609):**
```js
const mergedMenuProps = useMemo(() => {
  // Merges customMenuProps into the MenuProps passed to MUI Select
  // Never adds disablePortal — no mechanism to do so without explicit caller input
  return {
    ...restCustomMenu,
    sx: { ... },
    slotProps: {
      list: mergedListSlotProps,
      paper: mergedPaperSlotProps,
    },
  };
}, [...]);
```

**MUI Select rendering (SingleSelect.jsx — lines 639–657):**
```jsx
<Select
  ...
  open={menuOpen}
  onOpen={handleMenuOpen}
  onClose={handleMenuClose}
  ...
  MenuProps={mergedMenuProps}  // No disablePortal in here
>
  ...
</Select>
```

**Comparable fix pattern already used in the codebase:**
In `EliteaUI/src/[fsd]/features/chat/ui/chat-modal/AttachmentSettingsModal.jsx` (lines 275–279), a `SingleSelect` inside a `Dialog` partially mitigates this by raising the z-index:
```jsx
customMenuProps={{
  slotProps: {
    paper: { sx: { zIndex: 1400 } },
  },
}}
```
However that only ensures the dropdown renders visually above the dialog — it does **not** fix the backdrop-click dismissal because the portal is still outside the Dialog DOM tree. The correct fix requires `disablePortal: true`.

### Contributing Factors

1. **MUI Portal behavior by default:** MUI's `Select`, `Autocomplete`, `Menu`, and `Popper` all default to rendering in a Portal outside the parent DOM tree. This is intended for z-index and overflow stacking control, but it has the side effect of breaking Dialog click-outside detection.
2. **No guard on `Dialog.onClose`:** The `Dialog` in `VersionReplacementModal` does not use `disableBackdropClick` (deprecated in MUI v5+) or the newer equivalent of providing a custom `onClose` that ignores `"backdropClick"` reason. If it did, the dialog would not close on backdrop clicks, which would also solve the immediate symptom.
3. **`customMenuProps` not used:** The `SingleSelect` component accepts a `customMenuProps` prop that passes through to MUI `Select`'s `MenuProps`. The caller (`VersionReplacementModal`) passes no `customMenuProps`, leaving the portal default in place.
4. **Pattern recognized but not universally applied:** The codebase has other `Select`-in-`Dialog` usages (`AttachmentSettingsModal`, `IndexScheduleModal`) that work around z-index issues, showing the problem is known, but none apply the proper `disablePortal` fix.

---

## Impact Analysis

### Usage Locations of `VersionReplacementModal`

| File | Line(s) | Usage Type | Risk Level |
|------|---------|------------|------------|
| `EliteaUI/src/[fsd]/entities/version/ui/VersionDelete.jsx` | 151–160 | Direct usage — only caller | N/A (read-only) |

The component has exactly one usage in the entire codebase.

### Usage Locations of `SingleSelect` inside a `Dialog`

The following locations render a `SingleSelect` (or `Select.SingleSelect`) inside a Dialog/Modal and may exhibit the same issue to varying degrees:

| File | Notes |
|------|-------|
| `EliteaUI/src/[fsd]/features/chat/ui/chat-modal/AttachmentSettingsModal.jsx` | Has `zIndex: 1400` workaround but not `disablePortal` |
| `EliteaUI/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexScheduleModal.jsx` | Uses `CredentialsSelect` inside `BaseModal` |

### Dependency Map

- **Upstream (callers of `VersionReplacementModal`):** Only `VersionDelete.jsx`
- **Downstream (used by `VersionReplacementModal`):** `SingleSelect` → MUI `Select` → MUI `Menu`/`Popover`/`Modal`
- **Shared State:** `open`, `onClose`, `onReplace` props managed in `VersionDelete.jsx`

### Regression Risk Matrix

| Location | Current Behavior | Post-Fix Behavior | Risk | Mitigation |
|----------|------------------|-------------------|------|------------|
| `VersionReplacementModal.jsx` | Modal closes on Select dropdown interaction | Modal stays open; dropdown renders inside dialog | None | Fix is additive |
| `SingleSelect.jsx` (shared component) | No change needed | No change (fix is at call site) | None | Fix is in `customMenuProps` at call site only |
| `AttachmentSettingsModal.jsx` | Has partial workaround; may still auto-close in some edge cases | Unaffected by this fix | Low | Separate fix recommended |

### Test Impact

- **Existing tests affected:** No tests exist for `VersionReplacementModal` or `VersionDelete`
- **Tests requiring updates:** None (no existing coverage)
- **New tests recommended:**
  - E2E test: Open version replacement modal, open the Select dropdown, click a menu item — assert dialog remains open and item is selected
  - E2E test: Confirm that clicking "Replace & Delete" after selection calls the delete API with the correct `replacementVersionId`

---

## Suggested Remediation

### Recommended Approach — Minimal Regression, Targeted Fix

**File:** `EliteaUI/src/[fsd]/features/agent/ui/agent-details/version/VersionReplacementModal.jsx`

Pass `customMenuProps` with `disablePortal: true` to the `SingleSelect`. This makes the MUI `Select` dropdown render inside the Dialog's DOM tree rather than as a body-level Portal, preventing the Dialog's Modal from interpreting dropdown interactions as backdrop clicks.

**Change in `VersionReplacementModal.jsx`:**

```jsx
// Before (lines 168–178):
<SingleSelect
  onValueChange={onSelectVersion}
  value={selectedVersionId}
  options={versionSelectOptions}
  inputSX={styles.versionSelectInput}
  labelSX={styles.versionSelectLabel}
  maxDisplayValueLength={'200px'}
  label="Replace with version"
  showBorder
/>

// After:
<SingleSelect
  onValueChange={onSelectVersion}
  value={selectedVersionId}
  options={versionSelectOptions}
  inputSX={styles.versionSelectInput}
  labelSX={styles.versionSelectLabel}
  maxDisplayValueLength={'200px'}
  label="Replace with version"
  showBorder
  customMenuProps={{ disablePortal: true }}
/>
```

**Why this approach is optimal:**
- It is a single-line addition with zero risk to unrelated code.
- `customMenuProps` is already a supported, typed prop of `SingleSelect` and is passed directly to MUI `Select`'s `MenuProps`.
- `disablePortal: true` on a `Menu`/`Popover` is the standard MUI-recommended fix for Select-inside-Dialog scenarios.
- No changes to the shared `SingleSelect` component are needed, preventing any potential regressions in the many other places `SingleSelect` is used.
- The dropdown will still receive correct z-index from the Dialog's own stacking context, so it will render above the Dialog content correctly.

### Alternative Approach: Guard `onClose` against backdrop clicks

**File:** `VersionReplacementModal.jsx`

```jsx
// Change Dialog onClose handler to ignore 'backdropClick' reason
const handleClose = useCallback((event, reason) => {
  if (reason === 'backdropClick') return;
  setSelectedVersionId('');
  onClose();
}, [onClose]);
```

| Approach | Pros | Cons | Regression Risk |
|----------|------|------|-----------------|
| `customMenuProps={{ disablePortal: true }}` | Standard MUI fix, minimal change, addresses root cause | Dropdown scrolls with Dialog (acceptable) | None |
| Guard `onClose` against `backdropClick` | Prevents accidental dismissal in general | Symptom fix only; Select popover still renders as a portal (wrong z-index if Dialog has `overflow: hidden`) | None |
| Fix `SingleSelect` to always use `disablePortal` | Would fix all instances at once | Breaking change for all callers; most Select usages are NOT inside dialogs and would lose correct overflow/positioning | High |

### Implementation Safety Checklist

- [x] Only 1 caller of `VersionReplacementModal` — `VersionDelete.jsx` — no API changes needed
- [x] No breaking changes to public APIs or shared components
- [x] Backward compatibility maintained — `customMenuProps` is an existing prop
- [x] No database or schema changes
- [x] Feature flag: Not needed — the change is visually identical except the modal no longer closes
- [x] The `mergedMenuProps` in `SingleSelect.jsx` uses `...restCustomMenu` spread which includes `disablePortal` — the prop passes through correctly

### Files Requiring Modification

| File | Change Type | Complexity | Test Coverage |
|------|-------------|------------|---------------|
| `EliteaUI/src/[fsd]/features/agent/ui/agent-details/version/VersionReplacementModal.jsx` | Add `customMenuProps={{ disablePortal: true }}` prop | Trivial | None (new E2E test recommended) |

---

## Additional Observations

1. **`AttachmentSettingsModal` has the same underlying bug.** The z-index workaround `{ paper: { sx: { zIndex: 1400 } } }` makes the dropdown visible but does not prevent the Dialog from closing when the user clicks outside the portaled Select. It should also receive `disablePortal: true`.

2. **`SplitButton.jsx` and `MenuButton.jsx` already use `disablePortal` on `Popper`** — confirming the team is aware of the portal/dialog interaction issue in other components, but it has not been applied consistently to `Select` usages inside dialogs.

3. **No `disableEscapeKeyDown` is set on the Dialog** — pressing Escape during `isReplacing` would still close the modal. The existing `handleKeyDown` handler guards against this for keyboard events, but the Dialog's built-in Escape handling fires before `onKeyDown` on the Dialog. This is a secondary issue and unrelated to this bug.

4. **`useEffect` in `VersionReplacementModal` resets `selectedVersionId` only when `open && !selectedVersionId`** — meaning if the dialog is closed and reopened without clearing state, it retains the previous selection. This is functionally acceptable but worth noting.

---

## Investigation Artifacts

- **Files examined:** 12
  - `EliteaUI/src/[fsd]/entities/version/ui/VersionDelete.jsx`
  - `EliteaUI/src/hooks/application/useDeleteVersion.js`
  - `EliteaUI/src/[fsd]/features/agent/ui/agent-details/version/VersionReplacementModal.jsx`
  - `EliteaUI/src/[fsd]/features/agent/ui/agent-details/version/index.js`
  - `EliteaUI/src/[fsd]/shared/ui/select/SingleSelect.jsx`
  - `EliteaUI/src/[fsd]/shared/ui/select/SingleSelectDropdown.jsx`
  - `EliteaUI/src/[fsd]/shared/ui/select/SingleSelectMenuItem.jsx`
  - `EliteaUI/src/components/AlertDialog.jsx`
  - `EliteaUI/src/components/StyledDialog.jsx`
  - `EliteaUI/src/[fsd]/features/chat/ui/chat-modal/AttachmentSettingsModal.jsx`
  - `EliteaUI/src/[fsd]/features/toolkits/indexes/ui/IndexDetails/IndexScheduleModal.jsx`
  - `EliteaUI/src/ComponentsLib/MenuButton.jsx`
  - `EliteaUI/src/components/SplitButton.jsx`
- **Related commits reviewed:** None (history not investigated; issue is structural, not regression-from-change)
- **MUI version:** `@mui/material: ^7.0.2`
