### PR TITLE
fix: [EL-5135] Tooltip only shown in collapsed mode with universal text

### DIFF
--- a/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
+++ b/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
@@ -241,19 +241,6 @@ const CreateEntityButton = memo(props => {
     ],
   );
 
-  const tooltip = useMemo(() => {
-    if (isCreatingNewConversation) {
-      return 'Creating conversation...';
-    }
-    if (isSettingsUsersPage) {
-      return 'Invite users';
-    }
-    if (isSimpleCreateRoute) {
-      return 'Create';
-    }
-    return `Create ${currentLabel || selectedOption || 'entity'}`;
-  }, [isCreatingNewConversation, isSettingsUsersPage, isSimpleCreateRoute, currentLabel, selectedOption]);
-
   const handleDropdownItemClick = useCallback(
     item => {
       const permissions = CreateEntityConstants.CreationPermissions[item.option];
@@ -290,7 +277,7 @@ const CreateEntityButton = memo(props => {
       >
         <StyledTooltip
           placement="right"
-          title={tooltip}
+          title={sideBarCollapsed ? 'Create new...' : ''}
           enterDelay={500}
           enterNextDelay={500}
         >


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5135

## Summary

| Where | What | Why |
|-------|------|-----|
| CreateEntityButton.jsx:280 | Changed `title` prop to `{sideBarCollapsed ? 'Create new...' : ''}` inline in StyledTooltip | **Main fix:** Tooltip only shown in collapsed mode with universal "Create new..." text |
| CreateEntityButton.jsx | Removed `tooltip` variable (useMemo with complex logic) | Additional fix: Simplified by inlining condition directly in JSX |

**Root cause:** Tooltip showed dynamic context-specific text in both modes. Now: collapsed shows "Create new...", expanded shows nothing (empty string hides MUI Tooltip).

<img width="194" height="118" alt="Screenshot 2026-06-05 113740" src="https://github.com/user-attachments/assets/7675b8c9-2837-4d87-97c7-d3bcc7832016" />
