### PR TITLE
fix: [EL-5147] support voice feature toggle

### DIFF
--- a/src/[fsd]/features/chat/ui/chat-button/SendButton.jsx
+++ b/src/[fsd]/features/chat/ui/chat-button/SendButton.jsx
@@ -6,6 +6,7 @@ import { Box } from '@mui/material';
 import Tooltip from '@/ComponentsLib/Tooltip';
 import BaseBtn from '@/[fsd]/shared/ui/button/BaseBtn';
 import SpeakingModeIcon from '@/assets/voicewave.svg?react';
+import { VOICE_FEATURES_ENABLED, VOICE_FEATURES_TEMPORARILY_DISABLED } from '@/common/constants';
 import SendIcon from '@/components/Icons/SendIcon';
 
 const SendButton = memo(props => {
@@ -45,10 +46,15 @@ const SendButton = memo(props => {
     );
   }
 
-  if (!question && !isCreatingConversation) {
+  if (
+    !question &&
+    !isCreatingConversation &&
+    VOICE_FEATURES_ENABLED &&
+    !VOICE_FEATURES_TEMPORARILY_DISABLED
+  ) {
     return (
       <Tooltip
-        title="Speaking mode"
+        title={VOICE_FEATURES_TEMPORARILY_DISABLED ? 'Temporarily disabled by admin' : 'Speaking mode'}
         placement="top"
       >
         <Box component="span">

--- a/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
+++ b/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx
@@ -9,6 +9,7 @@ import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { useListModelsQuery } from '@/api/configurations';
 import MicIcon from '@/assets/microphone.svg?react';
 import StopIcon from '@/assets/stop_record.svg?react';
+import { VOICE_FEATURES_ENABLED, VOICE_FEATURES_TEMPORARILY_DISABLED } from '@/common/constants';
 import SocketContext from '@/contexts/SocketContext';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 import useToast from '@/hooks/useToast';
@@ -161,8 +162,10 @@ const VoiceButton = memo(
     useImperativeHandle(ref, () => ({ stop: handleStopRecording }), [handleStopRecording]);
 
     if (!isSupported) return null;
+    if (!VOICE_FEATURES_ENABLED) return null;
 
-    const styles = getStyles(isRecording, disabled);
+    const isAdminDisabled = VOICE_FEATURES_TEMPORARILY_DISABLED;
+    const styles = getStyles(isRecording, disabled || isAdminDisabled);
 
     return (
       <Box
@@ -170,17 +173,23 @@ const VoiceButton = memo(
         sx={styles.wrapper}
       >
         <Tooltip
-          title={isRecording ? 'Voice input active' : 'Start voice input'}
+          title={
+            isAdminDisabled
+              ? 'Temporarily disabled by admin'
+              : isRecording
+                ? 'Voice input active'
+                : 'Start voice input'
+          }
           placement="top"
         >
           <Box component="span">
             <BaseBtn
               variant={BUTTON_VARIANTS.icon}
               color={isRecording ? 'tertiary' : 'secondary'}
-              onClick={isRecording ? undefined : handleStartRecording}
+              onClick={isAdminDisabled || isRecording ? undefined : handleStartRecording}
               aria-label={isRecording ? 'voice input active' : 'start voice input'}
               aria-pressed={isRecording}
-              disabled={disabled || isRecording}
+              disabled={disabled || isRecording || isAdminDisabled}
               sx={styles.micButton}
             >
               <MicIcon sx={styles.icon} />

--- a/src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx
+++ b/src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx
@@ -5,11 +5,13 @@ import { Box } from '@mui/material';
 import BaseBtn from '@/[fsd]/shared/ui/button/BaseBtn';
 import MicphoneIcon from '@/assets/megaphone.svg?react';
 import StopIcon from '@/assets/stop_record.svg?react';
+import { VOICE_FEATURES_ENABLED } from '@/common/constants';
 
 const VoiceMiniPlayer = memo(props => {
   const { isPlaying, onStop } = props;
   const styles = getStyles();
 
+  if (!VOICE_FEATURES_ENABLED) return null;
   if (!isPlaying) return null;
 
   return (

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -18,6 +18,16 @@ export const VITE_PUBLIC_PROJECT_ID = getEnvVar('VITE_PUBLIC_PROJECT_ID');
 export const ALLOW_PROJECT_OWN_LLMS = getEnvVar('allow_project_own_llms', true);
 export const ELITEA_ASSISTANT_ENABLED = getEnvVar('VITE_ELITEA_ASSISTANT', false);
 
+const isFlagEnabled = (val, defaultVal) => {
+  if (val === undefined || val === null) return defaultVal;
+  return val === '1' || val === 1 || val === true;
+};
+export const VOICE_FEATURES_ENABLED = isFlagEnabled(getEnvVar('VITE_VOICE_FEATURES_ENABLED'), true);
+export const VOICE_FEATURES_TEMPORARILY_DISABLED = isFlagEnabled(
+  getEnvVar('VITE_VOICE_FEATURES_TEMPORARILY_DISABLED'),
+  false,
+);
+
 export const MISSING_ENVS = [
   { key: 'VITE_SERVER_URL', value: VITE_SERVER_URL },
   { key: 'VITE_BASE_URI', value: VITE_BASE_URI },

--- a/src/components/Chat/ApplicationAnswer.jsx
+++ b/src/components/Chat/ApplicationAnswer.jsx
@@ -23,6 +23,8 @@ import {
   TOOL_ACTION_NAMES,
   TOOL_ACTION_TYPES,
   ToolActionStatus,
+  VOICE_FEATURES_ENABLED,
+  VOICE_FEATURES_TEMPORARILY_DISABLED,
   WELCOME_MESSAGE_ID,
 } from '@/common/constants.js';
 import { getToolIcon } from '@/common/toolkitUtils';
@@ -721,19 +723,30 @@ const ApplicationAnswer = React.forwardRef((props, ref) => {
                   className="actionButtons"
                   sx={styles.buttonsContainer}
                 >
-                  {onAutoSpeak && hasSpeakableText && (
+                  {onAutoSpeak && hasSpeakableText && VOICE_FEATURES_ENABLED && (
                     <StyledTooltip
-                      title="Read out"
+                      title={
+                        VOICE_FEATURES_TEMPORARILY_DISABLED
+                          ? 'Voice features temporarily disabled'
+                          : 'Read out'
+                      }
                       placement="top"
                     >
-                      <BaseBtn
-                        disabled={isProcessing || !realAnswer || !!speakingMessageId}
-                        sx={styles.iconButton}
-                        variant="tertiary"
-                        onClick={() => onAutoSpeak(realAnswer, messageId)}
-                      >
-                        <MicphoneIcon sx={styles.icon} />
-                      </BaseBtn>
+                      <Box component="span">
+                        <BaseBtn
+                          disabled={
+                            VOICE_FEATURES_TEMPORARILY_DISABLED ||
+                            isProcessing ||
+                            !realAnswer ||
+                            !!speakingMessageId
+                          }
+                          sx={styles.iconButton}
+                          variant="tertiary"
+                          onClick={() => onAutoSpeak(realAnswer, messageId)}
+                        >
+                          <MicphoneIcon sx={styles.icon} />
+                        </BaseBtn>
+                      </Box>
                     </StyledTooltip>
                   )}
                   {onCopy && (!!answer || !!message_items?.length || !!exception) && (


### PR DESCRIPTION
# Solution: Admin Config Toggles for Voice Features (V2V / T2V / V2T)

**Issue:** [EliteaAI/elitea_issues#5147](https://github.com/EliteaAI/elitea_issues/issues/5147)

## Summary

Add two admin-controlled toggles under **Configuration → Voice Features** (positioned after Support Assistant):

1. **Voice Features Enabled** (default: ON) — completely hides/removes voice buttons when OFF
2. **Temporarily Disable Voice Features** (default: OFF) — keeps buttons visible but non-interactive with a tooltip when ON

---

## Files to Change

### 1. Backend Schema — `elitea_core/admin_schema.json`

Add two new fields to the end of the `properties` object (after `vite_elitea_assistant`):

```json
"vite_voice_features_enabled": {
  "type": "string",
  "title": "Voice Features Enabled",
  "description": "When disabled, all voice features (V2V, T2V, V2T) are completely hidden for all users.",
  "path": "extra_ui_config.vite_voice_features_enabled",
  "section": "voice_features",
  "default": "1"
},
"vite_voice_features_temporarily_disabled": {
  "type": "string",
  "title": "Temporarily Disable Voice Features",
  "description": "When enabled, voice buttons remain visible but are non-interactive with an admin tooltip.",
  "path": "extra_ui_config.vite_voice_features_temporarily_disabled",
  "section": "voice_features",
  "default": "0"
}
```

**Full diff location:** `elitea_core/admin_schema.json`, before the closing `}}` at line 444:

```diff
-    "vite_elitea_assistant": {
-      ...
-      "default": "0"
-    }
-  }
-}
+    "vite_elitea_assistant": {
+      ...
+      "default": "0"
+    },
+    "vite_voice_features_enabled": {
+      "type": "string",
+      "title": "Voice Features Enabled",
+      "description": "When disabled, all voice features (V2V, T2V, V2T) are completely hidden for all users.",
+      "path": "extra_ui_config.vite_voice_features_enabled",
+      "section": "voice_features",
+      "default": "1"
+    },
+    "vite_voice_features_temporarily_disabled": {
+      "type": "string",
+      "title": "Temporarily Disable Voice Features",
+      "description": "When enabled, voice buttons remain visible but are non-interactive with an admin tooltip.",
+      "path": "extra_ui_config.vite_voice_features_temporarily_disabled",
+      "section": "voice_features",
+      "default": "0"
+    }
+  }
+}
```

---

### 2. Admin Plugin — `admin/api/v2/plugin_config_schemas.py`

**Repo:** `admin/` (top-level)

Add the `voice_features` entry to `SECTION_DEFINITIONS` after `support_assistant` (line 94–100), and bump `maintenance` order from 90 → 91:

```python
    "support_assistant": {
        "title": "Support Assistant",
        "order": 89,
        "icon": "support_agent",
        "description": "Enable the in-app support assistant widget for all users.",
        "always_visible": True,
    },
    "voice_features": {                                                   # ADD
        "title": "Voice Features",
        "order": 90,
        "icon": "record_voice_over",
        "description": "Control Voice-to-Voice, Text-to-Voice, and Voice-to-Text features environment-wide.",
        "always_visible": True,
    },
    "maintenance": {
        "title": "Maintenance",
        "order": 91,                                                      # BUMPED from 90
        "icon": "construction",
        "description": "Enable maintenance mode to show a splash screen to all non-admin users.",
        "always_visible": True,
    },
```

### 3. Admin Plugin — `admin/api/v2/plugin_config_values.py`

**Repo:** `admin/` (top-level)

**No code changes required.** The existing `AdminAPI.get()` and `AdminAPI.put()` handlers are fully generic — they scan all active pylons' `runtime_info` for `admin_schema.json` fields matching `section_id` and read/write the YAML config automatically. Once the `voice_features` entry is in `SECTION_DEFINITIONS` (step 2) and the fields are in `elitea_core/admin_schema.json` (step 1), the endpoints `GET/PUT /api/v2/administration/plugin_config_values/voice_features` work without modification.

The `_PUBLIC_SECTIONS = {"resources"}` set does **not** need updating — voice feature flags reach the regular Chat UI via `window.elitea_ui_config` (injected server-side into `index.html`), not via a separate API call from EliteaUI.

---

### 4. Admin UI — New Component `admin_ui/frontend/src/components/SchemaForm/VoiceFeatures.jsx`

**Repo:** `admin_ui/` (top-level)

Create this file (mirrors `SupportAssistant.jsx` pattern):

```jsx
import { memo, useCallback } from "react";
import { Box, Switch, Typography } from "@mui/material";

const VoiceFeatures = memo((props) => {
  const { values, onChange } = props;

  const rawEnabled = values?.vite_voice_features_enabled;
  const enabled = rawEnabled === "1" || rawEnabled === 1 || rawEnabled === true;

  const rawDisabled = values?.vite_voice_features_temporarily_disabled;
  const temporarilyDisabled =
    rawDisabled === "1" || rawDisabled === 1 || rawDisabled === true;

  const handleToggleEnabled = useCallback(() => {
    onChange("vite_voice_features_enabled", enabled ? "0" : "1");
  }, [onChange, enabled]);

  const handleToggleTemporarilyDisabled = useCallback(() => {
    onChange(
      "vite_voice_features_temporarily_disabled",
      temporarilyDisabled ? "0" : "1",
    );
  }, [onChange, temporarilyDisabled]);

  return (
    <Box sx={styles.root}>
      <Typography variant="body2" sx={styles.description}>
        Control Voice-to-Voice, Text-to-Voice, and Voice-to-Text features
        environment-wide. These toggles apply to all three voice capabilities
        together.
      </Typography>

      <Box sx={styles.card}>
        <Box sx={styles.cardRow}>
          <Box sx={styles.cardLabel}>
            <Typography variant="body2" sx={styles.cardTitle}>
              Voice Features Enabled
            </Typography>
            <Typography variant="caption" sx={styles.cardHint}>
              When OFF, all voice buttons and icons are completely hidden for
              all users across the environment.
            </Typography>
          </Box>
          <Switch checked={enabled} onChange={handleToggleEnabled} />
        </Box>
      </Box>

      <Box sx={styles.card}>
        <Box sx={styles.cardRow}>
          <Box sx={styles.cardLabel}>
            <Typography variant="body2" sx={styles.cardTitle}>
              Temporarily Disable Voice Features
            </Typography>
            <Typography variant="caption" sx={styles.cardHint}>
              When ON, voice buttons remain visible but are non-interactive.
              Users see a tooltip: "Temporarily disabled by admin".
            </Typography>
          </Box>
          <Switch
            checked={temporarilyDisabled}
            onChange={handleToggleTemporarilyDisabled}
            disabled={!enabled}
          />
        </Box>
      </Box>
    </Box>
  );
});

VoiceFeatures.displayName = "VoiceFeatures";

const styles = {
  root: {
    display: "flex",
    flexDirection: "column",
    gap: "1.25rem",
    padding: "1.5rem",
  },
  description: ({ palette }) => ({
    color: palette.text.metrics,
    fontSize: "0.8125rem",
    lineHeight: 1.6,
  }),
  card: ({ palette }) => ({
    border: `1px solid ${palette.border.table}`,
    borderRadius: "0.5rem",
    overflow: "hidden",
  }),
  cardRow: ({ palette }) => ({
    display: "flex",
    alignItems: "center",
    justifyContent: "space-between",
    padding: "1rem 1.25rem",
    backgroundColor:
      palette.background.tabPanel || palette.background.userInputBackground,
  }),
  cardLabel: {
    display: "flex",
    flexDirection: "column",
    gap: "0.125rem",
  },
  cardTitle: {
    fontWeight: 600,
    fontSize: "0.875rem",
  },
  cardHint: ({ palette }) => ({
    color: palette.text.metrics,
    fontSize: "0.75rem",
  }),
};

export default VoiceFeatures;
```

---

### 5. Admin UI — Wire up in `ConfigurationPage.jsx`

**File:** `admin_ui/frontend/src/pages/ConfigurationPage/ConfigurationPage.jsx`  
**Repo:** `admin_ui/` (top-level)

**Change 1** — Add import at the top (near other icon imports):
```jsx
import RecordVoiceOverOutlinedIcon from "@mui/icons-material/RecordVoiceOverOutlined";
```

**Change 2** — Add import for VoiceFeatures component:
```jsx
import VoiceFeatures from "@/components/SchemaForm/VoiceFeatures";
```

**Change 3** — Add to `SECTION_ICONS` (after `support_assistant`):
```jsx
const SECTION_ICONS = {
  // ... existing entries ...
  support_assistant: SupportAgentIcon,
  voice_features: RecordVoiceOverOutlinedIcon,   // ADD THIS
  advanced: CodeIcon,
};
```

**Change 4** — Add `case "voice_features":` in the switch inside the render (after `case "support_assistant":`):
```jsx
case "voice_features":
  return valuesFetching ? (
    <Box sx={styles.loadingContainer}>
      <CircularProgress size={24} />
    </Box>
  ) : (
    <Box sx={styles.formScroll}>
      <VoiceFeatures
        values={localValues}
        onChange={handleFieldChange}
      />
    </Box>
  );
```

---

### 6. EliteaUI Constants — `EliteaUI/src/common/constants.js`

Add two new exports after the `ELITEA_ASSISTANT_ENABLED` line (line 19):

```js
export const ELITEA_ASSISTANT_ENABLED = getEnvVar('VITE_ELITEA_ASSISTANT', false);
// ADD BELOW:
export const VOICE_FEATURES_ENABLED = getEnvVar('VITE_VOICE_FEATURES_ENABLED', true);
export const VOICE_FEATURES_TEMPORARILY_DISABLED = getEnvVar('VITE_VOICE_FEATURES_TEMPORARILY_DISABLED', false);
```

**Note:** `getEnvVar` reads from `window.elitea_ui_config` using lowercase keys, so:
- `VITE_VOICE_FEATURES_ENABLED` → reads `window.elitea_ui_config.vite_voice_features_enabled`
- `VITE_VOICE_FEATURES_TEMPORARILY_DISABLED` → reads `window.elitea_ui_config.vite_voice_features_temporarily_disabled`

The backend stores values as `"0"` / `"1"` strings (matching the `vite_elitea_assistant` pattern). The constant will receive the raw string, so the components need to check for truthy string values.

To avoid repeating the `"1"` / `1` / `true` check everywhere, add a helper:

```js
// helper used in components
const isFlagEnabled = (val, defaultVal = true) => {
  if (val === undefined || val === null) return defaultVal;
  return val === "1" || val === 1 || val === true;
};

export const VOICE_FEATURES_ENABLED = isFlagEnabled(
  getEnvVar('VITE_VOICE_FEATURES_ENABLED'), true
);
export const VOICE_FEATURES_TEMPORARILY_DISABLED = isFlagEnabled(
  getEnvVar('VITE_VOICE_FEATURES_TEMPORARILY_DISABLED'), false
);
```

---

### 7. EliteaUI Voice Button — `EliteaUI/src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx`

**Logic to add:**
- If `VOICE_FEATURES_ENABLED` is false → return `null` (completely hidden)
- If `VOICE_FEATURES_TEMPORARILY_DISABLED` is true → render buttons as visually disabled (non-interactive) with tooltip "Temporarily disabled by admin"

**Changes:**

```jsx
// Add imports at top
import {
  VOICE_FEATURES_ENABLED,
  VOICE_FEATURES_TEMPORARILY_DISABLED,
} from '@/common/constants';
```

In the component body, after `if (!isSupported) return null;`:

```jsx
// Complete feature kill-switch — hides all voice UI
if (!VOICE_FEATURES_ENABLED) return null;

const isAdminDisabled = VOICE_FEATURES_TEMPORARILY_DISABLED;
```

Update the `<Tooltip>` on the mic button:

```jsx
<Tooltip
  title={
    isAdminDisabled
      ? 'Temporarily disabled by admin'
      : isRecording
        ? 'Voice input active'
        : 'Start voice input'
  }
  placement="top"
>
  <Box component="span">
    <BaseBtn
      variant={BUTTON_VARIANTS.icon}
      color={isRecording ? 'tertiary' : 'secondary'}
      onClick={isAdminDisabled || isRecording ? undefined : handleStartRecording}
      aria-label={isRecording ? 'voice input active' : 'start voice input'}
      aria-pressed={isRecording}
      disabled={disabled || isRecording || isAdminDisabled}
      sx={styles.micButton}
    >
      <MicIcon sx={styles.icon} />
    </BaseBtn>
  </Box>
</Tooltip>
```

When `isAdminDisabled` is true, the stop button should also not appear (no need to conditionally render it — the recording can never start when admin-disabled).

---

### 8. EliteaUI Speaking Mode (V2V) — `EliteaUI/src/pages/NewChat/ChatBox.jsx`

The speaking-mode toggle button is in ChatBox. Find where `onSpeakingModeToggle` or the speaking mode button is rendered and wrap it similarly:

```jsx
import {
  VOICE_FEATURES_ENABLED,
  VOICE_FEATURES_TEMPORARILY_DISABLED,
} from '@/common/constants';

// Where the speaking mode icon/button renders:
{VOICE_FEATURES_ENABLED && (
  <Tooltip
    title={VOICE_FEATURES_TEMPORARILY_DISABLED ? 'Temporarily disabled by admin' : 'Voice conversation mode'}
  >
    <span>
      <SpeakingModeButton
        disabled={VOICE_FEATURES_TEMPORARILY_DISABLED}
        ...
      />
    </span>
  </Tooltip>
)}
```

### 9. EliteaUI TTS Mini Player — `EliteaUI/src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx`

The `VoiceMiniPlayer` (T2V indicator) should also be gated:

```jsx
import { VOICE_FEATURES_ENABLED } from '@/common/constants';

// At the top of the component, before render:
if (!VOICE_FEATURES_ENABLED) return null;
```

For the temporarily-disabled case, the mini-player does not need to show since TTS playback is triggered automatically — if voice input is disabled, TTS auto-play should be suppressed. This is handled indirectly when voice buttons are non-interactive.

---

## Data Flow Summary

```
Admin saves toggle in Configuration UI
    ↓
PUT /api/v2/administration/plugin_config_values/voice_features
    ↓
elitea_core plugin YAML updated (extra_ui_config.vite_voice_features_enabled = "1")
    ↓
elitea_core/methods/config.py → get_elitea_ui_config() merges extra_ui_config.*
    ↓
elitea_core/routes/new_ui.py injects window.elitea_ui_config into index.html
    ↓
EliteaUI/src/utils/env.js → getEnvVar('VITE_VOICE_FEATURES_ENABLED')
    ↓
EliteaUI/src/common/constants.js → VOICE_FEATURES_ENABLED (evaluated at module load)
    ↓
VoiceButton.jsx / VoiceMiniPlayer.jsx → conditionally render / disable
```

**Important:** `VOICE_FEATURES_ENABLED` and `VOICE_FEATURES_TEMPORARILY_DISABLED` are module-level constants evaluated at app load time. They are read from `window.elitea_ui_config` which is embedded in the HTML by the server. A **page reload** is required after admin saves the config for the UI to pick up the new values. This is the same behavior as `ELITEA_ASSISTANT_ENABLED`.

---

## Behavior Matrix

| Voice Features Enabled | Temporarily Disable | Voice Button | Mic Recording | TTS/Speaker | V2V Mode |
|------------------------|---------------------|-------------|---------------|-------------|----------|
| ON (1)                 | OFF (0)             | Visible, enabled | Works normally | Works normally | Works normally |
| ON (1)                 | ON (1)              | Visible, **disabled** (tooltip: "Temporarily disabled by admin") | Cannot start | Cannot auto-play | Cannot start |
| OFF (0)                | any                 | **Hidden** | — | **Hidden** | — |

---

## Notes

- The "Temporarily Disable" toggle in the admin UI is itself disabled (greyed out) when "Voice Features Enabled" is OFF — no point configuring the temporary state if features are already globally off.
- Default values: `Voice Features Enabled = ON ("1")`, `Temporarily Disable = OFF ("0")`
- No container restart is required — the YAML config change is picked up by `bootstrap_runtime_update` event; only a browser page reload is needed to refresh `window.elitea_ui_config`.

## Repositories Changed

| Repo (top-level) | Files |
|------------------|-------|
| `elitea_core/` | `admin_schema.json` |
| `admin/` | `api/v2/plugin_config_schemas.py` |
| `admin_ui/` | `frontend/src/components/SchemaForm/VoiceFeatures.jsx` (new), `frontend/src/pages/ConfigurationPage/ConfigurationPage.jsx` |
| `EliteaUI/` | `src/common/constants.js`, `src/[fsd]/features/chat/ui/chat-button/VoiceButton.jsx`, `src/pages/NewChat/ChatBox.jsx`, `src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx` |
