### PR TITLE
fix: [EL-5138] Disable Save and apply when edited message is empty

### DIFF
--- a/src/[fsd]/features/chat/ui/chat-box/UserMessage.jsx
+++ b/src/[fsd]/features/chat/ui/chat-box/UserMessage.jsx
@@ -246,7 +246,7 @@ const UserMessage = React.forwardRef((props, ref) => {
               variant="elitea"
               color="primary"
               sx={styles.submitButton}
-              disabled={value === content}
+              disabled={value === content || !value.trim()}
               onClick={onClickSubmit}
             >
               Save and apply


### PR DESCRIPTION
## Summary
- Disables the **Save and apply** button when the edited message field is empty (or whitespace-only), preventing empty messages from being submitted to the LLM

## Changes
- `UserMessage.jsx`: Added `|| !value.trim()` to the button's `disabled` condition

## Test plan
- [ ] Edit a user message, clear all text — **Save and apply** should be greyed out/disabled
- [ ] Edit a user message, enter only spaces — button should remain disabled
- [ ] Edit a user message with valid text — button should be enabled as before
- [ ] Edit a user message without changing it — button remains disabled (existing behavior)

Closes https://github.com/EliteaAI/elitea_issues/issues/5138

🤖 Generated with [Claude Code](https://claude.com/claude-code)