### PR TITLE
fix: [EL-5167] Added regex validation and maximum limit

### DIFF
--- a/src/[fsd]/features/settings/ui/secrets/EditSecretInputGridTable.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/EditSecretInputGridTable.jsx
@@ -1,11 +1,26 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Input } from '@/[fsd]/shared/ui';
+import { MAX_VARIABLES_LENGTH } from '@/common/constants';
+
+const SECRET_NAME_PATTERN = /^[a-zA-Z0-9_-]*$/;
 
 const EditSecretInputGridTable = memo(props => {
-  const { id, field, value, row, setRows, setRowModesModel } = props;
+  const { id, field, value, row, setRows, setRowModesModel, onValidationChange } = props;
 
   const [inputValue, setInputValue] = useState(value ?? '');
+
+  const validationError = useMemo(() => {
+    const hasInvalidNameChars = field === 'name' && inputValue && !SECRET_NAME_PATTERN.test(inputValue);
+
+    if (hasInvalidNameChars) return 'Only alphanumeric characters, underscore and hyphen are allowed';
+    if (inputValue.length >= MAX_VARIABLES_LENGTH) return 'Maximum character limit reached';
+    return null;
+  }, [field, inputValue]);
+
+  useEffect(() => {
+    onValidationChange?.(id, field, Boolean(validationError));
+  }, [id, field, validationError, onValidationChange]);
 
   const handleOnChange = useCallback(
     event => {
@@ -69,6 +84,9 @@ const EditSecretInputGridTable = memo(props => {
       onChange={handleOnChange}
       onKeyDown={handleKeyDown}
       value={inputValue}
+      error={Boolean(validationError)}
+      helperText={validationError}
+      inputProps={{ maxLength: MAX_VARIABLES_LENGTH }}
     />
   );
 });

--- a/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
@@ -73,6 +73,7 @@ const SecretsTable = memo(props => {
   const styles = getStyles(isSafariBrowser);
   const [hoveredRowId, setHoveredRowId] = useState(null);
   const [editingRowsBackup, setEditingRowsBackup] = useState({});
+  const [validationErrors, setValidationErrors] = useState({});
   const { checkPermission } = useCheckPermission();
 
   const [addSecret, { isError: isAddingError, error: addingError }] = useSecretAddingMutation();
@@ -346,6 +347,20 @@ const SecretsTable = memo(props => {
     [rowModesModel],
   );
 
+  const handleValidationChange = useCallback((rowId, field, hasError) => {
+    setValidationErrors(prev => ({
+      ...prev,
+      [`${rowId}-${field}`]: hasError,
+    }));
+  }, []);
+
+  const hasRowValidationErrors = useCallback(
+    rowId => {
+      return validationErrors[`${rowId}-name`] || validationErrors[`${rowId}-secretValue`];
+    },
+    [validationErrors],
+  );
+
   // Custom name cell component for rendering name field
   const renderNameCell = useCallback(
     ({ row }) => {
@@ -363,6 +378,7 @@ const SecretsTable = memo(props => {
             row={row}
             setRows={setRows}
             setRowModesModel={setRowModesModel}
+            onValidationChange={handleValidationChange}
           />
         );
       }
@@ -376,7 +392,7 @@ const SecretsTable = memo(props => {
         </Text.EllipsisTypography>
       );
     },
-    [isRowInEditMode, setRows, setRowModesModel],
+    [isRowInEditMode, setRows, setRowModesModel, handleValidationChange],
   );
 
   const renderCell = useCallback(
@@ -394,6 +410,7 @@ const SecretsTable = memo(props => {
               row={row}
               setRows={setRows}
               setRowModesModel={setRowModesModel}
+              onValidationChange={handleValidationChange}
             />
           );
         }
@@ -414,13 +431,23 @@ const SecretsTable = memo(props => {
 
       return value || '-';
     },
-    [isRowInEditMode, setRowModesModel, setRows, isSafariBrowser, showSecret, projectId, toastInfo],
+    [
+      isRowInEditMode,
+      setRowModesModel,
+      setRows,
+      isSafariBrowser,
+      showSecret,
+      projectId,
+      toastInfo,
+      handleValidationChange,
+    ],
   );
 
   const renderActions = useCallback(
     row => {
       const isEditing = isRowInEditMode(row.id);
       const isSecretVisible = isShowSecretMap[row.id];
+      const hasValidationErrors = hasRowValidationErrors(row.id);
 
       if (isEditing) {
         return (
@@ -429,6 +456,7 @@ const SecretsTable = memo(props => {
               variant="elitea"
               color="tertiary"
               onClick={handleSaveClick(row.id)}
+              disabled={hasValidationErrors}
               sx={styles.actionButton}
             >
               <CheckIcon sx={styles.checkIcon} />
@@ -500,6 +528,7 @@ const SecretsTable = memo(props => {
       handleShowSecret,
       handleActionsMenuClick,
       checkPermission,
+      hasRowValidationErrors,
       styles,
     ],
   );

--- a/src/[fsd]/pages/settings/CreatePersonalToken.jsx
+++ b/src/[fsd]/pages/settings/CreatePersonalToken.jsx
@@ -4,19 +4,24 @@ import { useFormik } from 'formik';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
 
-import { Box, CircularProgress, TextField, Tooltip } from '@mui/material';
+import { Box, CircularProgress, Tooltip } from '@mui/material';
 
 import { DrawerPage, DrawerPageHeader } from '@/[fsd]/features/settings/ui/drawer-page';
 import { GeneratedTokenDialog } from '@/[fsd]/features/settings/ui/personal-tokes';
-import { Button } from '@/[fsd]/shared/ui';
+import { Button, Input } from '@/[fsd]/shared/ui';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
 import { useTokenCreateMutation, useTokenListQuery } from '@/api/auth';
-import { DEFAULT_TOKEN_EXPIRATION_DAYS, EXPIRATION_MEASURES } from '@/common/constants';
+import { DEFAULT_TOKEN_EXPIRATION_DAYS, EXPIRATION_MEASURES, MAX_VARIABLES_LENGTH } from '@/common/constants';
 import { capitalizeFirstChar } from '@/common/utils';
 import useNavBlocker from '@/hooks/useNavBlocker';
 
+const TOKEN_NAME_PATTERN = /^[a-zA-Z0-9_-]*$/;
+
 const validationSchema = yup.object({
-  name: yup.string('Enter token name').required('Name is required'),
+  name: yup
+    .string('Enter token name')
+    .matches(TOKEN_NAME_PATTERN, 'Only alphanumeric characters, underscore and hyphen are allowed')
+    .required('Name is required'),
 });
 
 const CreatePersonalToken = memo(() => {
@@ -80,6 +85,21 @@ const CreatePersonalToken = memo(() => {
     blockCondition: !data.uuid && hasChanged && !wantToCancel,
   });
 
+  const nameHasError =
+    (formik.touched.name && Boolean(formik.errors.name)) || formik.values.name.length >= MAX_VARIABLES_LENGTH;
+
+  const isGenerateDisabled = !formik.values.name || nameHasError || isGenerating || !!data.uuid;
+
+  const getNameHelperText = useCallback(() => {
+    if (formik.touched.name && formik.errors.name) {
+      return formik.errors.name;
+    }
+    if (formik.values.name.length >= MAX_VARIABLES_LENGTH) {
+      return 'Maximum character limit reached';
+    }
+    return undefined;
+  }, [formik.touched.name, formik.errors.name, formik.values.name.length]);
+
   const styles = createPersonalTokenStyles();
 
   return (
@@ -99,7 +119,7 @@ const CreatePersonalToken = memo(() => {
                 <Button.BaseBtn
                   variant="elitea"
                   color="primary"
-                  disabled={!formik.values.name || isGenerating || !!data.uuid}
+                  disabled={isGenerateDisabled}
                   onClick={() => formik.handleSubmit()}
                 >
                   Generate
@@ -126,7 +146,7 @@ const CreatePersonalToken = memo(() => {
           <form onSubmit={formik.handleSubmit}>
             <Box sx={styles.formFields}>
               <Box sx={styles.nameField}>
-                <TextField
+                <Input.InputBase
                   variant="standard"
                   fullWidth
                   id="name"
@@ -135,8 +155,9 @@ const CreatePersonalToken = memo(() => {
                   value={formik.values.name}
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
-                  error={formik.touched.name && Boolean(formik.errors.name)}
-                  helperText={formik.touched.name && formik.errors.name}
+                  error={nameHasError}
+                  helperText={getNameHelperText()}
+                  inputProps={{ maxLength: MAX_VARIABLES_LENGTH }}
                 />
               </Box>
               <Box sx={styles.expirationRow}>
@@ -157,7 +178,7 @@ const CreatePersonalToken = memo(() => {
                 </Box>
                 <Box sx={styles.valueField}>
                   {formik.values.measure !== EXPIRATION_MEASURES[0] && (
-                    <TextField
+                    <Input.InputBase
                       variant="standard"
                       fullWidth
                       id="expiration"


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5167

## Summary

### CreatePersonalToken (Token Creation Form)

| Where | What | Why |
|-------|------|-----|
| CreatePersonalToken.jsx:11 | Replaced MUI TextField with FSD `Input.InputBase` | **Main fix:** Consistent UI component usage per FSD architecture |
| CreatePersonalToken.jsx:14 | Added `MAX_VARIABLES_LENGTH` import | Required for 768 character limit |
| CreatePersonalToken.jsx:18 | Added `TOKEN_NAME_PATTERN` regex | Validates: only alphanumeric, underscore, hyphen |
| CreatePersonalToken.jsx:21-24 | Added `.matches()` to Yup schema | Formik validation with regex pattern |
| CreatePersonalToken.jsx:88-90 | Added `nameHasError` variable | Combines touched+error and limit check |
| CreatePersonalToken.jsx:91 | Added `isGenerateDisabled` variable | Clean condition for Generate button disabled state |
| CreatePersonalToken.jsx:93-101 | Added `getNameHelperText` callback | Returns error message or limit warning |
| CreatePersonalToken.jsx:149-161 | Updated Name field to Input.InputBase | With error, helperText, maxLength props |
| CreatePersonalToken.jsx:181-191 | Updated Expiration field to Input.InputBase | Consistent component usage |

### SecretsTable (Inline Editing)

| Where | What | Why |
|-------|------|-----|
| EditSecretInputGridTable.jsx:4 | Added `MAX_VARIABLES_LENGTH` import | Required for character limit validation |
| EditSecretInputGridTable.jsx:6 | Added `SECRET_NAME_PATTERN` regex | Validates name field |
| EditSecretInputGridTable.jsx:13-21 | Added `validationError` useMemo | Computes validation state reactively |
| EditSecretInputGridTable.jsx:23-25 | Added useEffect with `onValidationChange` | Notifies parent of validation state |
| EditSecretInputGridTable.jsx:95-97 | Added `error`, `helperText`, `maxLength` props | Visual error indication |
| SecretsTable.jsx:76 | Added `validationErrors` state | Tracks errors per row/field |
| SecretsTable.jsx:349-362 | Added `handleValidationChange`, `hasRowValidationErrors` | Validation state management |
| SecretsTable.jsx:459 | Added `disabled={hasValidationErrors}` | Blocks Save on validation errors |

**Root cause:** GitHub issue #5167 - Token/Secret name fields lacked validation, allowing special characters and potential XSS injection. Solution: Added regex validation (alphanumeric + underscore + hyphen only) and 768 character limit. Form submission/save blocked when validation fails.


<img width="609" height="295" alt="image" src="https://github.com/user-attachments/assets/7841b0fa-d9d2-4beb-8272-e2579ac59cce" />

<img width="1009" height="602" alt="Screenshot 2026-06-08 124719" src="https://github.com/user-attachments/assets/d41f8f73-f9fe-43f5-a4b1-f7ff5ecd694a" />

<img width="1358" height="710" alt="Screenshot 2026-06-08 132130" src="https://github.com/user-attachments/assets/d9917ab6-b3ad-4469-971f-72987fafa1b1" />
<img width="1360" height="667" alt="Screenshot 2026-06-08 132156" src="https://github.com/user-attachments/assets/cd549175-6d95-4b44-8a63-26637f323a4b" />
