### PR TITLE
fix: [EL-5105] auto save pipeline when removing a tool

### DIFF
--- a/src/[fsd]/entities/application-tab-bar/ui/ApplicationTabBar.jsx
+++ b/src/[fsd]/entities/application-tab-bar/ui/ApplicationTabBar.jsx
@@ -8,7 +8,6 @@ import { Box } from '@mui/material';
 import { ApplicationVersionSelect } from '@/[fsd]/entities/application-tab-bar/ui';
 import { useRefetchAgentDetails } from '@/[fsd]/features/agent/lib/hooks';
 import { AGENT_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
-import { PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE } from '@/[fsd]/features/pipelines';
 import { useFormDirtyExcluding } from '@/[fsd]/shared/lib/hooks';
 import { Button } from '@/[fsd]/shared/ui';
 import { ViewMode } from '@/common/constants';
@@ -39,13 +38,8 @@ const ApplicationTabBar = memo(({ onSuccess, onDiscard }) => {
   const selectedProjectId = useSelectedProjectId();
 
   const { discardApplicationChanges } = useDiscardApplicationChanges(onDiscard);
-  const { hasIrreversibleChanges } = useSelector(state => state.pipeline);
 
   const isPublic = useMemo(() => viewMode === ViewMode.Public, [viewMode]);
-
-  const discardAlertContent = hasIrreversibleChanges
-    ? PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE
-    : undefined;
 
   useRefetchAgentDetails();
 
@@ -78,7 +72,6 @@ const ApplicationTabBar = memo(({ onSuccess, onDiscard }) => {
           <Button.DiscardButton
             disabled={!isFormDirtyExcluding && !isYamlCodeDirty}
             onDiscard={discardApplicationChanges}
-            alertContent={discardAlertContent}
           />
         </Box>
       </Box>

--- a/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
+++ b/src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js
@@ -1,12 +1,17 @@
 import { useCallback } from 'react';
 
 import { useFormikContext } from 'formik';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useSetRefetchDetails } from '@/[fsd]/features/agent/lib/hooks/useRefetchAgentDetails.hooks';
-import { TAG_TYPE_APPLICATION_DETAILS, useUpdateApplicationRelationMutation } from '@/api/applications';
+import {
+  TAG_TYPE_APPLICATION_DETAILS,
+  useApplicationEditMutation,
+  useUpdateApplicationRelationMutation,
+} from '@/api/applications';
 import { eliteaApi } from '@/api/eliteaApi';
 import { useToolkitAssociateMutation } from '@/api/toolkits';
+import clearTools from '@/common/applicationUtils';
 import { buildErrorMessage } from '@/common/utils';
 import usePipelineToolsChanges from '@/hooks/pipeline/usePipelineToolsChanges';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
@@ -25,19 +30,109 @@ const isStaleVersionReferenceError = error => {
 export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttachmentTool, index }) => {
   const projectId = useSelectedProjectId();
   const dispatch = useDispatch();
-  const { onRemoveTool } = usePipelineToolsChanges();
+  const { onRemoveTool, isFromPipeline, getCleanYamlForInitial, syncInitStateWithCleanYaml } =
+    usePipelineToolsChanges();
   const { setRefetch } = useSetRefetchDetails();
   const { toastError, toastInfo } = useToast();
   const { resetForm, setValues, values, initialValues, dirty } = useFormikContext();
+  const { id: currentUserId } = useSelector(state => state.user);
   const [disassociateToolkit, { isLoading, isError: isDisassociateError, error: disassociateError, reset }] =
     useToolkitAssociateMutation();
   const [updateApplicationRelation] = useUpdateApplicationRelationMutation();
+  const [saveApplication] = useApplicationEditMutation();
 
   // Helper function to invalidate cache and trigger refetch
   const invalidateCacheAndRefresh = useCallback(() => {
     dispatch(eliteaApi.util.invalidateTags([TAG_TYPE_APPLICATION_DETAILS]));
     setRefetch();
   }, [dispatch, setRefetch]);
+
+  // Saves the pipeline to DB immediately after toolkit removal, using the last-saved state as base
+  // with only the toolkit removal applied. Other pending unsaved changes are NOT included.
+  const savePipelineAfterToolkitRemoval = useCallback(
+    async (updatedInitialVersionDetails, tool, isAttachmentToolkit = false) => {
+      // Derive clean YAML from the last-saved instructions, not from the current Redux YAML state
+      // which may contain other unsaved edits unrelated to this toolkit removal.
+      const newYamlCode = getCleanYamlForInitial(initialValues.version_details?.instructions, tool);
+      if (!newYamlCode) return;
+      const { error, data } = await saveApplication({
+        name: initialValues.name?.trim() || '',
+        description: initialValues.description,
+        id: applicationId,
+        projectId,
+        owner_id: initialValues.owner_id,
+        webhook_secret: initialValues.webhook_secret || null,
+        version: {
+          ...updatedInitialVersionDetails,
+          tools: clearTools(updatedInitialVersionDetails.tools || [], currentUserId),
+          instructions: newYamlCode,
+          pipeline_settings: initialValues.version_details?.pipeline_settings,
+        },
+      });
+      if (!error && data) {
+        // Only update the version detail cache — not applicationDetails, which would trigger
+        // enableReinitialize on the Formik form and discard the user's unsaved changes.
+        dispatch(
+          eliteaApi.util.updateQueryData(
+            'getApplicationVersionDetail',
+            { applicationId, projectId, versionId: updatedInitialVersionDetails?.id },
+            () => ({
+              ...updatedInitialVersionDetails,
+              instructions: newYamlCode,
+            }),
+          ),
+        );
+        // Update Formik baseline so Discard restores to the auto-saved state (toolkit removed + clean YAML).
+        resetForm({
+          values: {
+            ...(initialValues || {}),
+            version_details: {
+              ...updatedInitialVersionDetails,
+              instructions: newYamlCode,
+            },
+          },
+        });
+        // Restore user's current unsaved changes (name, LLM settings, etc.) on top of the new baseline.
+        // `values` is the pre-removal snapshot from the closure; we recompute the toolkit removal here.
+        const filteredCurrentTools = (values.version_details?.tools || []).filter(t => t.id !== tool.id);
+        const currentVersionDetails = isAttachmentToolkit
+          ? {
+              ...(values.version_details || {}),
+              tools: filteredCurrentTools,
+              instructions: newYamlCode,
+              meta: {
+                ...(values.version_details?.meta || {}),
+                attachment_toolkit_id: undefined,
+              },
+            }
+          : {
+              ...(values.version_details || {}),
+              tools: filteredCurrentTools,
+              instructions: newYamlCode,
+            };
+        setValues({
+          ...(values || {}),
+          version_details: currentVersionDetails,
+        });
+        // Sync Redux initState with the clean saved YAML so Discard resets to the
+        // saved state and does not re-include unsaved flow editor changes.
+        syncInitStateWithCleanYaml(newYamlCode);
+      }
+    },
+    [
+      applicationId,
+      currentUserId,
+      dispatch,
+      getCleanYamlForInitial,
+      initialValues,
+      projectId,
+      resetForm,
+      saveApplication,
+      setValues,
+      syncInitStateWithCleanYaml,
+      values,
+    ],
+  );
 
   // Updates both Formik initialValues (Discard baseline) and current values after toolkit removal.
   // resetForm sets initialValues so that Discard does not restore the toolkit.
@@ -91,27 +186,100 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
     [dirty, initialValues, resetForm, setRefetch, setValues, values],
   );
 
+  const handleApplicationRelationRemoval = useCallback(
+    async (tool, updatedInitialVersionDetails) => {
+      try {
+        const result = await updateApplicationRelation({
+          projectId,
+          selectedApplicationId: tool.settings?.application_id,
+          selectedVersionId: tool.settings?.application_version_id,
+          application_id: applicationId,
+          version_id: versionId,
+          has_relation: false,
+        }).unwrap();
+        if (!result?.error) {
+          onRemoveTool(tool);
+          applyToolRemoval(tool, index);
+          reset();
+          if (isFromPipeline) {
+            await savePipelineAfterToolkitRemoval(updatedInitialVersionDetails, tool);
+          }
+        } else {
+          toastError(
+            buildErrorMessage(
+              result?.error?.data?.error || result?.error?.message || 'Failed to update application relation',
+            ),
+          );
+        }
+      } catch (error) {
+        if (isStaleVersionReferenceError(error)) {
+          invalidateCacheAndRefresh();
+          toastInfo('Tool reference was outdated. Page has been refreshed with current state.');
+          reset();
+        } else {
+          toastError(buildErrorMessage(error));
+        }
+      }
+    },
+    [
+      applicationId,
+      applyToolRemoval,
+      index,
+      invalidateCacheAndRefresh,
+      isFromPipeline,
+      onRemoveTool,
+      projectId,
+      reset,
+      savePipelineAfterToolkitRemoval,
+      toastError,
+      toastInfo,
+      updateApplicationRelation,
+      versionId,
+    ],
+  );
+
   const onDisassociateTool = useCallback(
     async ({ tool, isAttachmentToolkit }) => {
+      // Compute updated initialVersionDetails before any state mutations so we can use it
+      // as the base for the pipeline auto-save (last-saved state minus the removed toolkit).
+      const filteredInitialTools = (initialValues?.version_details?.tools || []).filter(
+        t => t.id !== tool.id,
+      );
+      const updatedInitialVersionDetails = isAttachmentToolkit
+        ? {
+            ...(initialValues?.version_details || {}),
+            tools: filteredInitialTools,
+            meta: {
+              ...(initialValues?.version_details?.meta || {}),
+              attachment_toolkit_id: undefined,
+            },
+          }
+        : {
+            ...(initialValues?.version_details || {}),
+            tools: filteredInitialTools,
+          };
+
       if (applicationId && tool?.id && versionId) {
-        // For regular toolkits, use the disassociate API
         if (tool.type !== 'application') {
+          // For regular toolkits, use the disassociate API
           const result = await disassociateToolkit({
             projectId,
             toolkitId: tool?.id,
             entity_version_id: versionId,
             entity_id: applicationId,
             entity_type: 'agent',
-            has_relation: false, // This removes the association
+            has_relation: false,
           });
 
-          // Update cache to remove the tool from the application
           if (!result.error) {
             onRemoveTool(tool);
             applyToolRemoval(tool, index, isAttachmentToolkit);
             reset();
             if (isAttachmentToolkit) {
               onDeleteAttachmentTool?.();
+            }
+            if (isFromPipeline) {
+              await savePipelineAfterToolkitRemoval(updatedInitialVersionDetails, tool, isAttachmentToolkit);
             }
           } else {
             toastError(
@@ -123,94 +291,27 @@ export const useDisassociateToolkit = ({ applicationId, versionId, onDeleteAttac
             );
           }
         } else {
-          // For agents and pipelines (type 'application'), use the new API to remove relation
-          try {
-            const result = await updateApplicationRelation({
-              projectId,
-              selectedApplicationId: tool.settings?.application_id,
-              selectedVersionId: tool.settings?.application_version_id,
-              application_id: applicationId,
-              version_id: versionId,
-              has_relation: false,
-            }).unwrap();
-            if (!result?.error) {
-              onRemoveTool(tool);
-              applyToolRemoval(tool, index);
-              reset();
-            } else {
-              toastError(
-                buildErrorMessage(
-                  result?.error?.data?.error ||
-                    result?.error?.message ||
-                    'Failed to update application relation',
-                ),
-              );
-            }
-          } catch (error) {
-            // Check if error is due to stale version reference (version was already deleted/replaced)
-            // In this case, the local state is out of sync with the backend - trigger a refresh
-            if (isStaleVersionReferenceError(error)) {
-              // The tool reference was outdated - force invalidate cache and refresh from server
-              invalidateCacheAndRefresh();
-              toastInfo('Tool reference was outdated. Page has been refreshed with current state.');
-              reset();
-            } else {
-              toastError(buildErrorMessage(error));
-            }
-          }
+          // For agents and pipelines (type 'application'), use the relation API
+          await handleApplicationRelationRemoval(tool, updatedInitialVersionDetails);
         }
       } else {
-        // Fallback for local state update when no applicationId
-        // For agents and pipelines (type 'application'), use the new API to remove relation
-        try {
-          const result = await updateApplicationRelation({
-            projectId,
-            selectedApplicationId: tool.settings?.application_id,
-            selectedVersionId: tool.settings?.application_version_id,
-            application_id: applicationId,
-            version_id: versionId,
-            has_relation: false,
-          }).unwrap();
-          if (!result?.error) {
-            onRemoveTool(tool);
-            applyToolRemoval(tool, index);
-            reset();
-          } else {
-            toastError(
-              buildErrorMessage(
-                result?.error?.data?.error ||
-                  result?.error?.message ||
-                  'Failed to update application relation',
-              ),
-            );
-          }
-        } catch (error) {
-          // Check if error is due to stale version reference (version was already deleted/replaced)
-          // In this case, the local state is out of sync with the backend - trigger a refresh
-          if (isStaleVersionReferenceError(error)) {
-            // The tool reference was outdated - force invalidate cache and refresh from server
-            invalidateCacheAndRefresh();
-            toastInfo('Tool reference was outdated. Page has been refreshed with current state.');
-            reset();
-          } else {
-            toastError(buildErrorMessage(error));
-          }
-        }
+        await handleApplicationRelationRemoval(tool, updatedInitialVersionDetails);
       }
     },
     [
       applicationId,
       applyToolRemoval,
       disassociateToolkit,
+      handleApplicationRelationRemoval,
       index,
-      invalidateCacheAndRefresh,
+      initialValues,
+      isFromPipeline,
       onDeleteAttachmentTool,
       onRemoveTool,
       projectId,
       reset,
+      savePipelineAfterToolkitRemoval,
       toastError,
-      toastInfo,
-      updateApplicationRelation,
       versionId,
     ],
   );

--- a/src/[fsd]/features/pipelines/index.js
+++ b/src/[fsd]/features/pipelines/index.js
@@ -1,1 +1,0 @@
-export { PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE } from './lib/constants';

--- a/src/[fsd]/features/pipelines/lib/constants/index.js
+++ b/src/[fsd]/features/pipelines/lib/constants/index.js
@@ -1,1 +1,0 @@
-export { PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE } from './pipeline.constants';

--- a/src/[fsd]/features/pipelines/lib/constants/pipeline.constants.js
+++ b/src/[fsd]/features/pipelines/lib/constants/pipeline.constants.js
@@ -1,2 +1,0 @@
-export const PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE =
-  'One or more tools were removed from this pipeline. The selected tool and input mapping configurations associated with those nodes must be permanently cleared and must not be restored by discarding. Are you sure you want to discard all remaining changes?';

--- a/src/hooks/application/useCreateApplication.jsx
+++ b/src/hooks/application/useCreateApplication.jsx
@@ -112,7 +112,7 @@ const useCreateApplication = (formik, resetBlockNav, options = {}) => {
       const isForPipeline = !!formik.values?.version_details?.pipeline_settings;
       formik.resetForm(data);
       if (isForPipeline) {
-        dispatch(actions.resetPipeline({ resetAll: true })); // Reset pipeline state to clear out any leftover data from the template used for creation
+        dispatch(actions.resetPipeline());
       }
 
       // Call custom onSuccess callback if provided (for chat context)

--- a/src/hooks/pipeline/usePipelineToolsChanges.js
+++ b/src/hooks/pipeline/usePipelineToolsChanges.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import YAML from 'js-yaml';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { PipelineNodeTypes } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
@@ -10,6 +11,66 @@ import RouteDefinitions from '@/routes';
 import { actions } from '@/slices/pipeline.js';
 
 import { useIsFrom, useIsFromPipelineDetail } from '../useIsFromSpecificPageHooks';
+
+// Removes a single key from a tool_names object.
+const removeToolName = (toolNames, name) =>
+  Object.keys(toolNames).reduce((acc, key) => {
+    if (key !== name) acc[key] = toolNames[key];
+    return acc;
+  }, {});
+
+// Returns true if a node is affected by removing the given tool.
+// `toolkitName` is pre-resolved by the caller (null for application tools).
+const isNodeAffectedByRemoval = (node, tool, toolkitName) => {
+  if (tool.type === ToolTypes.application.value) {
+    const matchNodeType =
+      tool.agent_type === 'pipeline' ? PipelineNodeTypes.Pipeline : PipelineNodeTypes.Agent;
+    return (
+      (node.type === matchNodeType && node.tool === tool.name) ||
+      (node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name])
+    );
+  }
+  return (
+    (node.type !== PipelineNodeTypes.Agent &&
+      node.type !== PipelineNodeTypes.Pipeline &&
+      node.type !== PipelineNodeTypes.LLM &&
+      node.toolkit_name === toolkitName) ||
+    (node.type === PipelineNodeTypes.LLM && node.tool_names?.[toolkitName])
+  );
+};
+
+// Pure function — applies toolkit/agent/pipeline tool removal to a nodes array.
+// `toolkitName` is pre-resolved by the caller (null for application tools).
+const applyToolRemovalToNodes = (nodes, tool, toolkitName) => {
+  if (tool.type === ToolTypes.application.value) {
+    const isPipelineTool = tool.agent_type === 'pipeline';
+    const matchNodeType = isPipelineTool ? PipelineNodeTypes.Pipeline : PipelineNodeTypes.Agent;
+    return nodes.map(node => {
+      if (node.type === matchNodeType && node.tool === tool.name) {
+        return isPipelineTool
+          ? { ...node, tool: undefined }
+          : { ...node, tool: undefined, input_mapping: undefined };
+      }
+      if (node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name]) {
+        return { ...node, tool_names: removeToolName(node.tool_names, tool.name) };
+      }
+      return node;
+    });
+  }
+  return nodes.map(node => {
+    if (
+      node.type !== PipelineNodeTypes.Agent &&
+      node.type !== PipelineNodeTypes.Pipeline &&
+      node.toolkit_name === toolkitName
+    ) {
+      return { ...node, tool: undefined, toolkit_name: undefined, input_mapping: {} };
+    }
+    if (node.type === PipelineNodeTypes.LLM && node.tool_names?.[toolkitName]) {
+      return { ...node, tool_names: removeToolName(node.tool_names, toolkitName) };
+    }
+    return node;
+  });
+};
 
 const usePipelineToolsChanges = () => {
   const isFromPipelineDetail = useIsFromPipelineDetail();
@@ -39,141 +100,77 @@ const usePipelineToolsChanges = () => {
       if (Object.keys(newYamlJsonObject).length && yamlString !== yamlCode) {
         setYamlCode(yamlString);
       }
+      return yamlString;
     },
     [dispatch, setYamlCode, yamlCode],
   );
 
   const onRemoveTool = useCallback(
     tool => {
-      if (isFromPipeline && yamlJsonObject.nodes?.length) {
-        if (tool.type === ToolTypes.application.value) {
-          if (tool.agent_type === 'pipeline') {
-            // pipeliine tool
-            if (
-              yamlJsonObject.nodes.find(
-                node =>
-                  (node.type === PipelineNodeTypes.Pipeline && node.tool === tool.name) ||
-                  (node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name]),
-              )
-            ) {
-              const newYamlJsonObject = { ...yamlJsonObject };
-              newYamlJsonObject.nodes = [
-                ...newYamlJsonObject.nodes.map(node => {
-                  return node.type === PipelineNodeTypes.Pipeline && node.tool === tool.name
-                    ? {
-                        ...node,
-                        tool: undefined,
-                      }
-                    : node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name]
-                      ? {
-                          ...node,
-                          tool_names: Object.keys(node.tool_names || {})
-                            .filter(key => key !== tool.name)
-                            .reduce((acc, key) => {
-                              acc[key] = node.tool_names[key];
-                              return acc;
-                            }, {}),
-                        }
-                      : node;
-                }),
-              ];
-              setYamlJsonObject(newYamlJsonObject);
-              dispatch(actions.syncInitYamlJsonObject({ yamlJsonObject: newYamlJsonObject }));
-            }
-          } else {
-            // agent tool
-            if (
-              yamlJsonObject.nodes.find(
-                node =>
-                  (node.type === PipelineNodeTypes.Agent && node.tool === tool.name) ||
-                  (node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name]),
-              )
-            ) {
-              const newYamlJsonObject = { ...yamlJsonObject };
-              newYamlJsonObject.nodes = [
-                ...newYamlJsonObject.nodes.map(node => {
-                  return node.type === PipelineNodeTypes.Agent && node.tool === tool.name
-                    ? {
-                        ...node,
-                        tool: undefined,
-                        input_mapping: undefined,
-                      }
-                    : node.type === PipelineNodeTypes.LLM && node.tool_names?.[tool.name]
-                      ? {
-                          ...node,
-                          tool_names: Object.keys(node.tool_names || {})
-                            .filter(key => key !== tool.name)
-                            .reduce((acc, key) => {
-                              acc[key] = node.tool_names[key];
-                              return acc;
-                            }, {}),
-                        }
-                      : node;
-                }),
-              ];
-              setYamlJsonObject(newYamlJsonObject);
-              dispatch(actions.syncInitYamlJsonObject({ yamlJsonObject: newYamlJsonObject }));
-            }
-          }
-        } else {
-          // toolkit tool
-          const toolkitName = tool.toolkit_name || getToolkitNameFromSchema(tool);
-          const affectedToolkitNodes = yamlJsonObject.nodes.filter(
-            node =>
-              (node.type !== PipelineNodeTypes.Agent &&
-                node.type !== PipelineNodeTypes.Pipeline &&
-                node.type !== PipelineNodeTypes.LLM &&
-                node.toolkit_name === toolkitName) ||
-              (node.type === PipelineNodeTypes.LLM && node.tool_names?.[toolkitName]),
-          );
-          if (affectedToolkitNodes.length) {
-            const newYamlJsonObject = { ...yamlJsonObject };
-            newYamlJsonObject.nodes = [
-              ...newYamlJsonObject.nodes.map(node => {
-                return node.type !== PipelineNodeTypes.Agent &&
-                  node.type !== PipelineNodeTypes.Pipeline &&
-                  node.toolkit_name === toolkitName
-                  ? {
-                      ...node,
-                      tool: undefined,
-                      toolkit_name: undefined,
-                      input_mapping: {},
-                    }
-                  : node.type === PipelineNodeTypes.LLM && node.tool_names?.[toolkitName]
-                    ? {
-                        ...node,
-                        tool_names: Object.keys(node.tool_names || {})
-                          .filter(key => key !== toolkitName)
-                          .reduce((acc, key) => {
-                            acc[key] = node.tool_names[key];
-                            return acc;
-                          }, {}),
-                      }
-                    : node;
-              }),
-            ];
-            setYamlJsonObject(newYamlJsonObject);
-            dispatch(actions.syncInitYamlJsonObject({ yamlJsonObject: newYamlJsonObject }));
-            const hasIrreversible = affectedToolkitNodes.some(
-              node =>
-                (node.type !== PipelineNodeTypes.Agent &&
-                  node.type !== PipelineNodeTypes.Pipeline &&
-                  node.type !== PipelineNodeTypes.LLM &&
-                  node.toolkit_name === toolkitName &&
-                  (node.tool || Object.keys(node.input_mapping || {}).length > 0)) ||
-                (node.type === PipelineNodeTypes.LLM && node.tool_names?.[toolkitName]),
-            );
-            if (hasIrreversible) {
-              dispatch(actions.markIrreversibleChanges());
-            }
-          }
-        }
+      if (!isFromPipeline || !yamlJsonObject.nodes?.length) return null;
+
+      const toolkitName =
+        tool.type !== ToolTypes.application.value
+          ? tool.toolkit_name || getToolkitNameFromSchema(tool)
+          : null;
+
+      // Early exit if no nodes reference this tool
+      if (!yamlJsonObject.nodes.some(node => isNodeAffectedByRemoval(node, tool, toolkitName))) {
+        return null;
       }
+
+      const newNodes = applyToolRemovalToNodes(yamlJsonObject.nodes, tool, toolkitName);
+      const newYamlJsonObject = { ...yamlJsonObject, nodes: newNodes };
+      const newYamlCode = setYamlJsonObject(newYamlJsonObject);
+      return newYamlCode;
     },
-    [dispatch, getToolkitNameFromSchema, isFromPipeline, setYamlJsonObject, yamlJsonObject],
+    [getToolkitNameFromSchema, isFromPipeline, setYamlJsonObject, yamlJsonObject],
   );
 
-  return { onRemoveTool };
+  // Syncs initState with a clean YAML string (e.g. after auto-save) so Discard
+  // resets to the saved state and does not re-include unsaved flow editor changes.
+  const syncInitStateWithCleanYaml = useCallback(
+    cleanYamlCode => {
+      try {
+        const cleanYamlJsonObject = YAML.load(cleanYamlCode);
+        dispatch(actions.syncInitYamlJsonObject({ yamlJsonObject: cleanYamlJsonObject }));
+      } catch {
+        // ignore parse errors — initState stays at its last value
+      }
+    },
+    [dispatch],
+  );
+
+  // Computes clean YAML by applying the toolkit removal to the given initial YAML string
+  // (not to the current Redux state), so no unsaved changes bleed into the result.
+  const getCleanYamlForInitial = useCallback(
+    (initialYamlCode, tool) => {
+      if (!initialYamlCode) return null;
+      let baseYamlJson;
+      try {
+        baseYamlJson = YAML.load(initialYamlCode);
+      } catch {
+        return null;
+      }
+      if (!baseYamlJson?.nodes?.length) return null;
+
+      const toolkitName =
+        tool.type !== ToolTypes.application.value
+          ? tool.toolkit_name || getToolkitNameFromSchema(tool)
+          : null;
+
+      // No nodes in the saved YAML reference this toolkit — nothing to clean, skip save.
+      if (!baseYamlJson.nodes.some(node => isNodeAffectedByRemoval(node, tool, toolkitName))) {
+        return null;
+      }
+
+      const newNodes = applyToolRemovalToNodes(baseYamlJson.nodes, tool, toolkitName);
+      return DumpYamlHelpers.dumpYaml({ ...baseYamlJson, nodes: newNodes });
+    },
+    [getToolkitNameFromSchema],
+  );
+
+  return { onRemoveTool, isFromPipeline, getCleanYamlForInitial, syncInitStateWithCleanYaml };
 };
 
 export default usePipelineToolsChanges;

--- a/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
+++ b/src/pages/Applications/Components/Applications/SaveApplicationButton.jsx
@@ -17,7 +17,7 @@ export default function SaveApplicationButton({ onSuccess }) {
   const isYamlCodeDirty = useIsPipelineYamlCodeDirty();
   const { values } = useFormikContext();
   const isFromChat = useIsFrom(RouteDefinitions.Chat);
-  const { stateValidationErrors, hasIrreversibleChanges } = useSelector(state => state.pipeline);
+  const { stateValidationErrors } = useSelector(state => state.pipeline);
 
   const isFormDirtyExcluding = useFormDirtyExcluding();
 
@@ -46,7 +46,7 @@ export default function SaveApplicationButton({ onSuccess }) {
   );
 
   const isButtonDisabled = useMemo(() => {
-    const hasNoChanges = !isFormDirtyExcluding && !isYamlCodeDirty && !hasIrreversibleChanges;
+    const hasNoChanges = !isFormDirtyExcluding && !isYamlCodeDirty;
 
     // In chat context (edit mode), skip field validation since version data comes without description
     if (isFromChat && !!values?.id) {
@@ -66,7 +66,6 @@ export default function SaveApplicationButton({ onSuccess }) {
     isFromChat,
     hasStateErrors,
     hasEmptyStarters,
-    hasIrreversibleChanges,
   ]);
 
   return (

--- a/src/pages/NewChat/PipelineEditor.jsx
+++ b/src/pages/NewChat/PipelineEditor.jsx
@@ -413,7 +413,7 @@ const PipelineEditor = forwardRef(
       fileReaderEnhancerRef.current?.restoreValue(initialValues?.version_details?.instructions || '');
       setIsDirty(false);
       setIsYamlDirty(false);
-      dispatch(actions.resetPipeline({ resetAll: false }));
+      dispatch(actions.resetPipeline());
       dispatch(editorActions.resetPipelineEditor());
     }, [dispatch, initialValues?.version_details?.instructions]);
 

--- a/src/pages/NewChat/components/EditorHeader.jsx
+++ b/src/pages/NewChat/components/EditorHeader.jsx
@@ -1,10 +1,8 @@
 import { useFormikContext } from 'formik';
-import { useSelector } from 'react-redux';
 
 import { Box, IconButton, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
-import { PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE } from '@/[fsd]/features/pipelines';
 import { Button } from '@/[fsd]/shared/ui';
 import CloseIcon from '@/components/Icons/CloseIcon';
 import useDiscardApplicationChanges from '@/pages/Applications/useDiscardApplicationChanges';
@@ -24,10 +22,6 @@ const EditorHeader = ({ title, subtitle, onCancel, onDiscard, saveButton, isPubl
   const { discardApplicationChanges } = useDiscardApplicationChanges(onDiscard);
   const { dirty: isFormDirty } = useFormikContext();
   const isYamlCodeDirty = useIsPipelineYamlCodeDirty();
-  const { hasIrreversibleChanges } = useSelector(state => state.pipeline);
-  const discardAlertContent = hasIrreversibleChanges
-    ? PIPELINE_DISCARD_IRREVERSIBLE_CHANGES_MESSAGE
-    : undefined;
 
   return (
     <Box sx={styles.container}>
@@ -69,7 +63,6 @@ const EditorHeader = ({ title, subtitle, onCancel, onDiscard, saveButton, isPubl
         <TabBarItems>
           {!isPublic && (
             <Button.DiscardButton
-              alertContent={discardAlertContent}
               disabled={!isFormDirty && !isYamlCodeDirty}
               onDiscard={discardApplicationChanges}
               size="small"

--- a/src/pages/Pipelines/EditPipeline.jsx
+++ b/src/pages/Pipelines/EditPipeline.jsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Form, Formik } from 'formik';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 import { InstructionsInputRefProvider } from '@/[fsd]/app/providers';
@@ -36,13 +36,11 @@ const EditPipeline = memo(() => {
   const [dirty, setDirty] = useState(false);
   const [isYamlDirty, setIsYamlDirty] = useState(false);
   const [unsavedLLMSettings, setUnsavedLLMSettings] = useState();
-  const { hasIrreversibleChanges } = useSelector(state => state.pipeline);
-
   const styles = useMemo(() => editPipelineStyles(), []);
 
   const handleDiscard = useCallback(() => {
     setDirty(false);
-    dispatch(actions.resetPipeline({ resetAll: false }));
+    dispatch(actions.resetPipeline());
     dispatch(editorActions.resetPipelineEditor());
     setUnsavedLLMSettings(undefined);
   }, [dispatch]);
@@ -54,9 +52,9 @@ const EditPipeline = memo(() => {
 
   const blockOptions = useMemo(
     () => ({
-      blockCondition: viewMode === ViewMode.Owner && (dirty || isYamlDirty || hasIrreversibleChanges),
+      blockCondition: viewMode === ViewMode.Owner && (dirty || isYamlDirty),
     }),
-    [dirty, isYamlDirty, viewMode, hasIrreversibleChanges],
+    [dirty, isYamlDirty, viewMode],
   );
 
   const { setBlockNav } = useNavBlocker(blockOptions);

--- a/src/slices/pipeline.js
+++ b/src/slices/pipeline.js
@@ -23,7 +23,6 @@ const pipelineSlice = createSlice({
     orientation: localStorage.getItem(OrientationKey) || ORIENTATION.vertical,
     layout_version: '',
     stateValidationErrors: {}, // Store validation errors by variable name
-    hasIrreversibleChanges: false, // True when toolkit disassociation has cleared input mappings
   },
   reducers: {
     initThePipeline: (state, action) => {
@@ -35,7 +34,6 @@ const pipelineSlice = createSlice({
       state.resetFlag = true;
       state.layout_version = layout_version;
       state.stateValidationErrors = {}; // Clear validation errors on init
-      state.hasIrreversibleChanges = false;
       state.initState = {
         nodes: [...nodes],
         edges: [...edges],
@@ -44,8 +42,7 @@ const pipelineSlice = createSlice({
         layout_version,
       };
     },
-    resetPipeline: (state, action) => {
-      const { resetAll } = action.payload || {};
+    resetPipeline: state => {
       const { nodes, edges, yamlJsonObject, yamlCode, layout_version } = state.initState;
       state.nodes = [...nodes];
       state.edges = [...edges];
@@ -54,7 +51,6 @@ const pipelineSlice = createSlice({
       state.resetFlag = true;
       state.layout_version = layout_version;
       state.stateValidationErrors = {}; // Clear validation errors on reset
-      state.hasIrreversibleChanges = resetAll ? false : state.hasIrreversibleChanges;
     },
     clearResetFlag: state => {
       state.resetFlag = false;
@@ -103,9 +99,6 @@ const pipelineSlice = createSlice({
     },
     clearStateValidationErrors: state => {
       state.stateValidationErrors = {};
-    },
-    markIrreversibleChanges: state => {
-      state.hasIrreversibleChanges = true;
     },
   },
 });


### PR DESCRIPTION
# Pipeline Toolkit Removal — Fix Description

## Overview

When a toolkit is removed from a pipeline, any pipeline YAML nodes that reference that toolkit retain stale `tool`, `toolkit_name`, and `input_mapping` fields. These dangling references are not saved to the DB, leaving the pipeline in an inconsistent state. This fix auto-saves the cleaned YAML to the DB immediately after toolkit removal, and ensures the UI state (Formik, Redux) stays consistent with what was saved.

---

## Main Fix: Auto-save Cleaned YAML on Toolkit Removal

**`savePipelineAfterToolkitRemoval`** (`useDisassociateToolkit.hooks.js`) is called after a successful API disassociation. It:

1. **Derives clean YAML** from `initialValues.version_details.instructions` (the last-saved version) using `getCleanYamlForInitial`. This ensures only the toolkit removal is written — no other unsaved flow editor changes bleed in.
2. **Saves the cleaned pipeline to the DB** via `saveApplication`, with the toolkit removed from both the `tools` array and the YAML `instructions`.
3. **Updates the RTK Query cache** (`getApplicationVersionDetail` only — not `applicationDetails`, to avoid triggering Formik `enableReinitialize` which would discard unsaved form changes).
4. **Updates Formik state** so the UI stays consistent:
   - `resetForm({ values: newBaseline })` — sets the Discard target to the saved state (toolkit removed + clean YAML).
   - `setValues(currentUserState)` — re-applies the user's current unsaved changes (name, LLM settings, etc.) on top of the new baseline.
5. **Syncs Redux `initState`** via `syncInitStateWithCleanYaml(newYamlCode)` so the flow editor's Discard also resets to the saved state without including unsaved flow editor changes.

### Node Cleanup Logic

`getCleanYamlForInitial` returns `null` (skipping the DB save) when:
- `initialValues.version_details.instructions` is absent or unparseable
- The parsed YAML has no nodes
- No nodes in the saved YAML reference the removed toolkit

This prevents a redundant API request when the toolkit was added but never referenced in any pipeline node.

When cleanup is needed, `applyToolRemovalToNodes` clears stale references:

| Node type | Tool removed | Fields cleared |
|-----------|-------------|----------------|
| Regular toolkit node (`toolkit_name === removed`) | Any toolkit | `tool`, `toolkit_name`, `input_mapping` |
| LLM node with `tool_names` entry | Any toolkit | Entry removed from `tool_names` |
| Agent node (`tool === removed agent name`) | Agent (type `application`) | `tool`, `input_mapping` |
| Pipeline node (`tool === removed pipeline name`) | Pipeline (type `application`) | `tool` |
| LLM node with `tool_names` entry | Agent/Pipeline (type `application`) | Entry removed from `tool_names` |

---

## Secondary Fixes

### Unsaved form changes preserved

Previously, updating the `applicationDetails` RTK Query cache after save triggered Formik's `enableReinitialize` to reset the form, discarding the user's in-progress edits. Fixed by only updating `getApplicationVersionDetail` (not subscribed to by `useApplicationInitialValues`) and managing Formik state directly with `resetForm` + `setValues`.

### Discard baseline includes the toolkit removal

`syncInitStateWithCleanYaml(newYamlCode)` dispatches `syncInitYamlJsonObject` with the clean saved YAML after DB save. Previously, `onRemoveTool` called `syncInitYamlJsonObject` with the current (potentially dirty) Redux `yamlJsonObject`, which could bake unsaved flow editor changes into the Discard baseline. Now `initState` is only updated from the clean saved YAML.

### `hasIrreversibleChanges` removed

The `hasIrreversibleChanges` flag in the pipeline Redux slice was a nav-blocker workaround for the fact that YAML cleanup was never saved to the DB. With auto-save now handling the DB write, this flag is obsolete and has been removed from the slice, `EditPipeline.jsx`, and the nav-block condition.

---

## Refactors

### `usePipelineToolsChanges.js` — shared node-mapping logic

The "find affected nodes" and "apply removal to nodes" logic was duplicated between `onRemoveTool` and `getCleanYamlForInitial`. Extracted to three module-level pure functions:

- `removeToolName(toolNames, name)` — removes a key from a `tool_names` object.
- `isNodeAffectedByRemoval(node, tool, toolkitName)` — returns `true` if a node references the given tool.
- `applyToolRemovalToNodes(nodes, tool, toolkitName)` — applies the cleanup described in the node cleanup table above.

### `useDisassociateToolkit.hooks.js` — deduplicated application-relation removal

The `updateApplicationRelation` try/catch block (success, logical error, stale-version-reference) was duplicated in both the `tool.type === 'application'` branch and the `else` fallback. Extracted to `handleApplicationRelationRemoval(tool, updatedInitialVersionDetails)`.

---

## Files Changed

| File | Change |
|------|--------|
| `src/[fsd]/features/agent/lib/hooks/useDisassociateToolkit.hooks.js` | `savePipelineAfterToolkitRemoval`: auto-save cleaned YAML, preserve unsaved changes via `resetForm`+`setValues`, sync Redux `initState`; extracted `handleApplicationRelationRemoval` |
| `src/hooks/pipeline/usePipelineToolsChanges.js` | Extracted `removeToolName`, `isNodeAffectedByRemoval`, `applyToolRemovalToNodes`; removed `syncInitYamlJsonObject` from `onRemoveTool`; added `syncInitStateWithCleanYaml` |
| `src/slices/pipeline.js` | Removed `hasIrreversibleChanges` state and `markIrreversibleChanges` reducer |
| `src/pages/Pipelines/EditPipeline.jsx` | Removed `hasIrreversibleChanges` from nav-block condition |
