### PR TITLE
fix: [EL-5167] Added value of limit for display

### DIFF
--- a/src/[fsd]/features/settings/ui/secrets/EditSecretInputGridTable.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/EditSecretInputGridTable.jsx
@@ -14,9 +14,13 @@ const EditSecretInputGridTable = memo(props => {
     const hasInvalidNameChars = field === 'name' && inputValue && !SECRET_NAME_PATTERN.test(inputValue);
 
     if (hasInvalidNameChars) return 'Only alphanumeric characters, underscore and hyphen are allowed';
-    if (inputValue.length >= MAX_VARIABLES_LENGTH) return 'Maximum character limit reached';
     return null;
   }, [field, inputValue]);
+
+  const isAtCharacterLimit = inputValue.length >= MAX_VARIABLES_LENGTH;
+
+  const helperText =
+    validationError || (isAtCharacterLimit ? `Maximum ${MAX_VARIABLES_LENGTH} characters reached` : null);
 
   useEffect(() => {
     onValidationChange?.(id, field, Boolean(validationError));
@@ -84,8 +88,8 @@ const EditSecretInputGridTable = memo(props => {
       onChange={handleOnChange}
       onKeyDown={handleKeyDown}
       value={inputValue}
-      error={Boolean(validationError)}
-      helperText={validationError}
+      error={Boolean(validationError) || isAtCharacterLimit}
+      helperText={helperText}
       inputProps={{ maxLength: MAX_VARIABLES_LENGTH }}
     />
   );

--- a/src/[fsd]/pages/settings/CreatePersonalToken.jsx
+++ b/src/[fsd]/pages/settings/CreatePersonalToken.jsx
@@ -85,8 +85,8 @@ const CreatePersonalToken = memo(() => {
     blockCondition: !data.uuid && hasChanged && !wantToCancel,
   });
 
-  const nameHasError =
-    (formik.touched.name && Boolean(formik.errors.name)) || formik.values.name.length >= MAX_VARIABLES_LENGTH;
+  const nameHasError = formik.touched.name && Boolean(formik.errors.name);
+  const isAtCharacterLimit = formik.values.name.length >= MAX_VARIABLES_LENGTH;
 
   const isGenerateDisabled = !formik.values.name || nameHasError || isGenerating || !!data.uuid;
 
@@ -95,7 +95,7 @@ const CreatePersonalToken = memo(() => {
       return formik.errors.name;
     }
     if (formik.values.name.length >= MAX_VARIABLES_LENGTH) {
-      return 'Maximum character limit reached';
+      return `Maximum character limit reached (${MAX_VARIABLES_LENGTH})`;
     }
     return undefined;
   }, [formik.touched.name, formik.errors.name, formik.values.name.length]);
@@ -155,7 +155,7 @@ const CreatePersonalToken = memo(() => {
                   value={formik.values.name}
                   onChange={formik.handleChange}
                   onBlur={formik.handleBlur}
-                  error={nameHasError}
+                  error={nameHasError || isAtCharacterLimit}
                   helperText={getNameHelperText()}
                   inputProps={{ maxLength: MAX_VARIABLES_LENGTH }}
                 />


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5167

- Added maximum limit value of length for display in the helper Text
- Allowed to save when it equals maximum limit - 768