### PR TITLE
fix: [EL-4866] New rows stay pinned at top while existing rows maintain alphabetical sorting

### DIFF
--- a/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
+++ b/src/[fsd]/features/settings/ui/secrets/SecretsTable.jsx
@@ -144,12 +144,10 @@ const SecretsTable = memo(props => {
 
   const filteredRows = useMemo(() => rows.filter(row => row && row.id != null), [rows]);
   const sortedRows = useMemo(() => {
-    // Don't sort when there's a new row being created to avoid disrupting the editing state
-    if (hasNewRow) {
-      return filteredRows;
-    }
-    return sortData(filteredRows);
-  }, [hasNewRow, filteredRows, sortData]);
+    const newRows = filteredRows.filter(row => row.isNew);
+    const existingRows = filteredRows.filter(row => !row.isNew);
+    return [...newRows, ...sortData(existingRows)];
+  }, [filteredRows, sortData]);
 
   const pagination = usePagination({
     totalRows: sortedRows.length,


### PR DESCRIPTION
## Summary
 
| Where | What | Why |
|-------|------|-----|
| SecretsTable.jsx:146-150 | Changed sorting logic: split rows into new/existing, sort only existing, keep new rows at top | **Main fix:** Sorting now stays consistent (A→Z) during secret creation instead of switching to creation date order |
 
**Root cause:** When `hasNewRow === true`, sorting was completely disabled (`return filteredRows`), causing the table to display data in API response order (old→new by creation date). Now new rows stay pinned at top while existing rows maintain alphabetical sorting.

<img width="1585" height="819" alt="Screenshot 2026-06-09 111809" src="https://github.com/user-attachments/assets/fdb57363-b62d-44f2-ade7-6e5ab05b9b9f" />
