### PR TITLE
fix: [EL-5190] Apps catalog use split button like other entity pages

### DIFF
--- a/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
+++ b/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
@@ -57,7 +57,6 @@ export const SimpleCreateRoutes = [
   RouteDefinitions.AgentStudio,
   RouteDefinitions.Resources,
   RouteDefinitions.NotificationCenter,
-  RouteDefinitions.AppsCatalog,
 ];
 
 export const CreationPermissions = {

--- a/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
+++ b/src/[fsd]/widgets/sidebar-root/ui/button/CreateEntityButton.jsx
@@ -209,6 +209,8 @@ const CreateEntityButton = memo(props => {
   }, [pathname]);
 
   const hasPermissionForSelectedOption = useMemo(() => {
+    if (isSimpleCreateRoute) return true;
+
     const permissions = CreateEntityConstants.CreationPermissions[selectedOption];
     if (!permissions || !permissions.length) return true;
 
@@ -221,7 +223,7 @@ const CreateEntityButton = memo(props => {
 
     // Check if user has any of the required permissions for other entities
     return permissions.some(permission => checkPermission(permission));
-  }, [selectedOption, checkPermission]);
+  }, [selectedOption, checkPermission, isSimpleCreateRoute]);
 
   const disableCreateButton = useMemo(
     () =>


### PR DESCRIPTION
## Summary

| Where | What | Why |
|-------|------|-----|
| createEntity.constant.js:60 | Removed `RouteDefinitions.AppsCatalog` from `SimpleCreateRoutes` | **Main fix:** Apps catalog should use split button like other entity pages, not simple "Create" dropdown |
| CreateEntityButton.jsx:212 | Added `if (isSimpleCreateRoute) return true;` check | Additional fix: skip permission check for pages where button only opens dropdown |
| CreateEntityButton.jsx:225 | Added `isSimpleCreateRoute` to useMemo dependencies | Additional fix: required for React dependency tracking |

**Root cause:** Apps catalog was incorrectly listed in `SimpleCreateRoutes`, showing generic "Create" button instead of split button with "Application" label. Secondary issue discovered: when navigating from `/settings/users` to `/settings/analytics`, the `selectedOption` state remained `'User'`, causing permission check to block the button on pages where it should only open a dropdown menu.


<img width="1052" height="706" alt="Screenshot 2026-06-09 124637" src="https://github.com/user-attachments/assets/85f32481-c01f-4d67-80f5-c83d1120c2bb" />


### BUG
**BEFORE**
<img width="838" height="815" alt="Screenshot 2026-06-09 122933" src="https://github.com/user-attachments/assets/152d5644-4df5-4785-ac68-3f394eee9cff" />

<img width="917" height="789" alt="Screenshot 2026-06-09 123009" src="https://github.com/user-attachments/assets/af95668c-678d-4e33-9262-f0e201871514" />

**AFTER**
<img width="590" height="680" alt="Screenshot 2026-06-09 124049" src="https://github.com/user-attachments/assets/be48f9bd-6487-43e4-8f7f-a5f2549fff63" />
