### PR TITLE
fix: [EL-5201] Added routes for displaying simple create button

### DIFF
--- a/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
+++ b/src/[fsd]/widgets/sidebar-root/lib/constants/createEntity.constant.js
@@ -54,6 +54,8 @@ export const SimpleCreateRoutes = [
   'settings/analytics',
   'settings/prompts',
   'settings/environment',
+  RouteDefinitions.Onboarding,
+  RouteDefinitions.UserSettings,
   RouteDefinitions.AgentStudio,
   RouteDefinitions.Resources,
   RouteDefinitions.NotificationCenter,


### PR DESCRIPTION
- Added user-settings and onboarding routes for displaying simple create button

<img width="1163" height="545" alt="Screenshot 2026-06-09 151714" src="https://github.com/user-attachments/assets/d0a292ca-9ce7-4bf1-a01c-bb4048138153" />
<img width="1110" height="704" alt="Screenshot 2026-06-09 161233" src="https://github.com/user-attachments/assets/4dd310d1-fadd-406e-9137-15ad93324d59" />

