### PR TITLE
fix(chat): [EL-5108] update deleteConversation API URL to singular conversation endpoint

### DIFF
--- a/src/[fsd]/features/chat/api/chat.api.js
+++ b/src/[fsd]/features/chat/api/chat.api.js
@@ -185,7 +185,7 @@ export const apiSlice = eliteaApi
       deleteConversation: build.mutation({
         query: ({ projectId, id }) => {
           return {
-            url: apiSlicePath + '/conversations/prompt_lib/' + projectId + '/' + id,
+            url: apiSlicePath + '/conversation/prompt_lib/' + projectId + '/' + id,
             method: 'DELETE',
           };
         },


### PR DESCRIPTION
## Problem

The `deleteConversation` API call was using `/conversations/prompt_lib/{projectId}/{id}` (plural), but the backend `DELETE` handler was moved to `conversation.py` (singular) which is mapped to `/conversation/prompt_lib/{projectId}/{id}`.

## Changes

- **`src/[fsd]/features/chat/api/chat.api.js`**: Updated `deleteConversation` endpoint URL from `/conversations/` to `/conversation/` to match the new backend route.

Closes https://github.com/EliteaAI/elitea_issues/issues/5108