### PR TITLE
feat: [EL-0000] add internal_mcp toggle for Elitea MCP Tools

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/switch/AgentInternalToolSwitch.jsx
@@ -9,6 +9,7 @@ import InfoTooltip from '@/[fsd]/shared/ui/tooltip/InfoTooltip';
 import AttachSvgIcon from '@/assets/attach-icon.svg?react';
 import CalendarIcon from '@/assets/calendar.svg?react';
 import ImageSvgIcon from '@/assets/image.svg?react';
+import McpIconSVG from '@/assets/mcp-icon.svg?react';
 import PieChartIcon from '@/assets/pie-chart-icon.svg?react';
 import PythonIcon from '@/assets/python.svg?react';
 import SwarmIconSVG from '@/assets/swarm-icon.svg?react';
@@ -50,6 +51,7 @@ const AgentInternalToolSwitch = memo(props => {
       ImageSvgIcon,
       UsersIcon: SwarmIconSVG,
       AttachSvgIcon,
+      McpIcon: McpIconSVG,
     }),
     [],
   );

--- a/src/[fsd]/shared/lib/constants/internalTools.constants.js
+++ b/src/[fsd]/shared/lib/constants/internalTools.constants.js
@@ -78,4 +78,13 @@ export const INTERNAL_TOOLS_LIST = [
     },
     toolkitNames: ['lazy_tools_mode'],
   },
+  {
+    name: 'internal_mcp',
+    title: 'Elitea MCP Tools',
+    icon: 'McpIcon',
+    infoTooltip: {
+      text: 'Enable Elitea platform MCP tools for managing applications, chat, and toolkits directly from conversations.',
+    },
+    toolkitNames: ['internal_mcp'],
+  },
 ];


### PR DESCRIPTION
## Summary
- Add UI toggle for enabling Elitea platform MCP tools in conversations
- Add `internal_mcp` entry to `INTERNAL_TOOLS_LIST` constant  
- Add McpIcon to iconMap in AgentInternalToolSwitch component

## Related
Requires backend changes from EliteaAI/elitea_core#110

## Test plan
- [ ] Toggle appears in agent internal tools configuration
- [ ] Toggle enables/disables `internal_mcp` in `internal_tools` array
- [ ] MCP icon displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)