### PR TITLE
fix: [EL-5222] ensure selected bucket expands correctly in BucketsListContent

### DIFF
--- a/src/pages/Artifacts/Components/BucketsListContent.jsx
+++ b/src/pages/Artifacts/Components/BucketsListContent.jsx
@@ -37,13 +37,21 @@ const BucketsListContent = memo(props => {
   }, []);
 
   useEffect(() => {
-    if (selectedBucketName && !expandedBuckets[selectedBucketName]) {
-      setExpandedBuckets(prev => ({
+    if (!selectedBucketName) {
+      return;
+    }
+
+    setExpandedBuckets(prev => {
+      if (prev[selectedBucketName]) {
+        return prev;
+      }
+
+      return {
         ...prev,
         [selectedBucketName]: true,
-      }));
-    }
-  }, [expandedBuckets, selectedBucketName]);
+      };
+    });
+  }, [selectedBucketName]);
 
   const styles = bucketsListContentStyles();
 


### PR DESCRIPTION
# Fix: Bucket tree collapse not working in Artifacts sidebar

## Description

Fixed an issue where clicking on an already-selected and expanded bucket in the Artifacts sidebar would not
collapse its file/folder tree view.

## Root Cause

The auto-expand effect in `BucketsListContent` had `expandedBuckets` in its dependency array, causing it to
re-run and immediately re-expand a bucket after the user clicked to collapse it.

## Solution

Removed `expandedBuckets` from the effect's dependency array so it only runs when the selection changes. This
allows manual collapse actions to persist while still auto-expanding when a new bucket is selected.

**File changed:**

- `src/pages/Artifacts/Components/BucketsListContent.jsx`

## Testing

- [x] Lint validation passed
- [x] Manual test: Verify bucket tree collapse/expand works correctly in sidebar

related to https://github.com/EliteaAI/elitea_issues/issues/5222