### PR TITLE
fix: [EL-5235] Real-time Voice Settings via `tts_next` Handshake

### DIFF
--- a/src/[fsd]/features/chat/lib/hooks/useTextToSpeech.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useTextToSpeech.hooks.js
@@ -129,6 +129,17 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
   const allChunksReceivedRef = useRef(false);
   // True only when the user explicitly paused — distinguishes user-pause from browser auto-suspend
   const userPausedRef = useRef(false);
+  // Mirror of voiceConfig as a ref so the tts_done handler (closed over at mount)
+  // can read the latest value without being in the effect's dependency list.
+  const voiceConfigRef = useRef(voiceConfig);
+  // Mirror of socket so the RAF loop can emit tts_next without being in its dep array.
+  const socketRef = useRef(socket);
+  // Index of the next sentence waypoint for which tts_next has not yet been emitted.
+  // Counts up as the RAF loop emits ACKs; reset to 0 at the start of each session.
+  const sentenceNextAckedRef = useRef(0);
+  // Set to true when voice/speed settings change during playback so the RAF loop
+  // emits tts_next immediately instead of waiting for the buffer to drain.
+  const forceNextAckRef = useRef(false);
   const rafRef = useRef(null);
   // Self-calibrating chars/second rate. Measured from the previous session's
   // (text.length / totalDuration) and reused for the linear estimation phase
@@ -195,6 +206,25 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
     [voiceConfig?.volume],
   );
 
+  // Keep voiceConfigRef and socketRef in sync so RAF-loop closures always read current values
+  useEffect(() => {
+    voiceConfigRef.current = voiceConfig;
+  }, [voiceConfig]);
+
+  useEffect(() => {
+    socketRef.current = socket;
+  }, [socket]);
+
+  // When voice or speed changes DURING active playback, signal the RAF loop to
+  // emit tts_next immediately so the new settings reach the backend without delay.
+  // Guard with playStartTimeRef so changes before playback begins are ignored —
+  // they would otherwise set force=true and fire the first ACK prematurely.
+  useEffect(() => {
+    if (playStartTimeRef.current !== null) {
+      forceNextAckRef.current = true;
+    }
+  }, [voiceConfig?.voiceId, voiceConfig?.rate]);
+
   // Live volume change — ramp to avoid click artifact when volume slider moves during playback
   useEffect(() => {
     const ctx = audioContextRef.current;
@@ -226,6 +256,8 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
     allChunksReceivedRef.current = false;
     charTimelineRef.current = null;
     sentenceWaypointsRef.current = [];
+    sentenceNextAckedRef.current = 0;
+    forceNextAckRef.current = false;
     pendingChunkRef.current = null;
     newSentenceRef.current = true;
     clearInterval(schedulerTimerRef.current);
@@ -427,6 +459,8 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
         socket.emit(sioEvents.tts_stop, {});
         stopModelAudio();
         sentenceWaypointsRef.current = [];
+        sentenceNextAckedRef.current = 0;
+        forceNextAckRef.current = false;
         fullTextRef.current = text;
         // Build punctuation-aware timeline for this session's text.
         // Uses the calibrated rate from the previous session (or the default
@@ -587,6 +621,8 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
         // yet — using enqueued count gives the correct absolute playback position
         // regardless of scheduling lag.
         const audioTime = totalEnqueuedSamplesRef.current / sampleRateRef.current;
+        // Record waypoint — the RAF loop will emit tts_next when playback
+        // approaches this boundary, pacing the backend to actual playback speed.
         sentenceWaypointsRef.current.push({ charPos: char_end, audioTime });
         return;
       }
@@ -662,6 +698,39 @@ const useTextToSpeech = ({ ttsModel, socket, voiceConfig } = {}) => {
       // Subtract outputLatency so the highlight tracks what the user actually hears,
       // not what has been sent to the audio hardware buffer.
       const elapsed = ctx.currentTime - (ctx.outputLatency ?? 0) - playStartTimeRef.current;
+
+      // ── tts_next pacing ──────────────────────────────────────────────────────
+      // ACK the backend when elapsed playback time reaches LEAD_TIME_S seconds
+      // before the END of the PREVIOUS sentence.  This keeps the backend exactly
+      // 1 sentence ahead: it starts generating sentence N+1 while sentence N-1
+      // still has LEAD_TIME_S seconds left to play.
+      //
+      //   nextAcked == 0  → no previous boundary; fire immediately so sentence 2
+      //                     is ready before sentence 1 ends.
+      //   nextAcked >  0  → fire when elapsed >=
+      //                       waypoints[nextAcked-1].audioTime – LEAD_TIME_S
+      //
+      // Short sentences (duration < LEAD_TIME_S) will still cascade immediately
+      // because the condition is negative — unavoidable without risking a gap.
+      // Longer sentences are paced one-per-sentence so the backend never runs
+      // far ahead of playback, keeping voice/speed changes responsive.
+      //
+      // forceNextAckRef: fires immediately when voice/speed changes mid-playback
+      // so the new settings take effect at the very next sentence boundary.
+      const LEAD_TIME_S = 3;
+      const nextAcked = sentenceNextAckedRef.current;
+      if (nextAcked < sentenceWaypointsRef.current.length) {
+        const prevAudioTime = nextAcked > 0 ? sentenceWaypointsRef.current[nextAcked - 1].audioTime : 0;
+        if (forceNextAckRef.current || elapsed >= prevAudioTime - LEAD_TIME_S) {
+          socketRef.current?.emit(sioEvents.tts_next, {
+            voice: voiceConfigRef.current?.voiceId || undefined,
+            speed: voiceConfigRef.current?.rate ?? 1.0,
+          });
+          sentenceNextAckedRef.current = nextAcked + 1;
+          forceNextAckRef.current = false;
+        }
+      }
+
       const text = fullTextRef.current;
       const totalDuration = totalDurationRef.current;
       const allReceived = allChunksReceivedRef.current;

--- a/src/[fsd]/features/chat/ui/chat-box/ChatBox.jsx
+++ b/src/[fsd]/features/chat/ui/chat-box/ChatBox.jsx
@@ -1931,15 +1931,16 @@ const ChatBox = forwardRef((props, boxRef) => {
             conversation_starters={hasStarterBeenSent || isTheUserChattingNow ? [] : conversationStarters}
           />
         )}
-        <VoiceMiniPlayer
-          isPlaying={isPlaying}
-          voiceConfig={voiceConfig}
-          voices={displayVoices}
-          onVoiceConfigChange={setVoiceConfig}
-          ttsModel={ttsModel}
-          hasModelTTS={hasModelTTS}
-          onStop={stopTTS}
-        />
+        {isPlaying && (
+          <VoiceMiniPlayer
+            voiceConfig={voiceConfig}
+            voices={displayVoices}
+            onVoiceConfigChange={setVoiceConfig}
+            ttsModel={ttsModel}
+            hasModelTTS={hasModelTTS}
+            onStop={stopTTS}
+          />
+        )}
         <Box sx={hitlEditMode ? styles.inputWrapperHitl : styles.inputWrapper}>
           {hitlEditMode && (
             <Box sx={styles.hitlInfoBanner}>
@@ -2079,11 +2080,8 @@ ChatBox.displayName = 'ChatBox';
 /** @type {MuiSx} */
 const chatBoxStyles = () => ({
   container: ({ breakpoints }) => ({
-    [breakpoints.up('lg')]: {
-      height: 'calc(100vh - 10rem)',
-    },
     [breakpoints.down('lg')]: {
-      height: '100vh !important',
+      minHeight: '100vh !important',
     },
   }),
   inputWrapper: {

--- a/src/[fsd]/features/chat/ui/voice-control-button/VoiceControlButton.jsx
+++ b/src/[fsd]/features/chat/ui/voice-control-button/VoiceControlButton.jsx
@@ -11,7 +11,7 @@ import { VOICE_FEATURES_ENABLED, VOICE_FEATURES_TEMPORARILY_DISABLED } from '@/c
 import SettingIcon from '@/components/Icons/SettingIcon';
 
 const VoiceControlButton = memo(props => {
-  const { onStop, voiceConfig, voices, onVoiceConfigChange, ttsModel, hasModelTTS, isPlaying } = props;
+  const { onStop, voiceConfig, voices, onVoiceConfigChange, ttsModel, hasModelTTS } = props;
   const [dialogOpen, setDialogOpen] = useState(false);
   const styles = getStyles();
 
@@ -46,7 +46,6 @@ const VoiceControlButton = memo(props => {
               variant={BUTTON_VARIANTS.icon}
               color="tertiary"
               size="small"
-              disabled={!isPlaying}
               onClick={onStop}
               sx={styles.button}
             >
@@ -63,7 +62,6 @@ const VoiceControlButton = memo(props => {
             <BaseBtn
               variant={BUTTON_VARIANTS.tertiary}
               size="small"
-              disabled={isPlaying}
               onClick={handleDialogOpen}
               aria-label="Voice settings"
               sx={styles.button}
@@ -81,6 +79,7 @@ const VoiceControlButton = memo(props => {
         onCancel={handleDialogClose}
         ttsModel={ttsModel}
         hasModelTTS={hasModelTTS}
+        isPlaying
       />
     </>
   );
@@ -109,6 +108,7 @@ const getStyles = () => ({
     '&.Mui-disabled path': {
       fill: ({ palette }) => palette.icon.fill.disabled,
     },
+    color: ({ palette }) => `${palette.text.primary} !important`,
     minWidth: '1.75rem !important',
     minHeight: '1.75rem !important',
     maxWidth: '1.75rem !important',

--- a/src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx
+++ b/src/[fsd]/features/chat/ui/voice-mini-player/VoiceMiniPlayer.jsx
@@ -8,7 +8,7 @@ import { VOICE_FEATURES_ENABLED } from '@/common/constants';
 import { VoiceControlButton } from '../voice-control-button';
 
 const VoiceMiniPlayer = memo(props => {
-  const { isPlaying, onStop, voiceConfig, voices, onVoiceConfigChange, ttsModel, hasModelTTS } = props;
+  const { onStop, voiceConfig, voices, onVoiceConfigChange, ttsModel, hasModelTTS } = props;
   const styles = getStyles();
 
   if (!VOICE_FEATURES_ENABLED) return null;
@@ -23,7 +23,6 @@ const VoiceMiniPlayer = memo(props => {
         onVoiceConfigChange={onVoiceConfigChange}
         ttsModel={ttsModel}
         hasModelTTS={hasModelTTS}
-        isPlaying={isPlaying}
       />
     </Box>
   );
@@ -46,8 +45,8 @@ const getStyles = () => ({
     alignSelf: 'center',
     flexShrink: 0,
     boxSizing: 'border-box',
-    marginBottom: '0.5rem',
-    marginTop: '0.5rem',
+    marginBottom: '1rem',
+    marginTop: '1rem',
     background: palette.background.secondary,
   }),
   icon: {

--- a/src/[fsd]/features/chat/voice-config/ui/VoiceConfigControls.jsx
+++ b/src/[fsd]/features/chat/voice-config/ui/VoiceConfigControls.jsx
@@ -11,7 +11,7 @@ import * as VoiceConstants from '../constants/voice.constants';
 const { VOICE_PREVIEW_TEXT, VOICE_SPEED_MARKS, VOICE_VOLUME_MARKS } = VoiceConstants;
 
 const VoiceConfigControls = memo(props => {
-  const { config, onConfigChange, hasModelTTS, ttsModel, socket, browserVoices, voices } = props;
+  const { config, onConfigChange, hasModelTTS, ttsModel, socket, browserVoices, voices, isPlaying } = props;
   const styles = voiceConfigControlsStyles();
 
   const previewVoiceConfig = useMemo(
@@ -106,16 +106,18 @@ const VoiceConfigControls = memo(props => {
           size="small"
         />
       </Box>
-      <Box>
-        <Button.BaseBtn
-          variant="elitea"
-          color="secondary"
-          loading={isPreviewPlaying}
-          onClick={handlePreview}
-        >
-          Preview Voice
-        </Button.BaseBtn>
-      </Box>
+      {!isPlaying && (
+        <Box>
+          <Button.BaseBtn
+            variant="elitea"
+            color="secondary"
+            loading={isPreviewPlaying}
+            onClick={handlePreview}
+          >
+            Preview Voice
+          </Button.BaseBtn>
+        </Box>
+      )}
     </Box>
   );
 });

--- a/src/[fsd]/features/chat/voice-config/ui/VoiceConfigDialog.jsx
+++ b/src/[fsd]/features/chat/voice-config/ui/VoiceConfigDialog.jsx
@@ -7,7 +7,7 @@ import { useVoiceConfig } from '../lib/hooks/useVoiceConfig.hooks';
 import { VoiceConfigControls } from './VoiceConfigControls';
 
 const VoiceConfigDialog = memo(props => {
-  const { config, voices, open, onApply, onCancel, ttsModel, hasModelTTS } = props;
+  const { config, voices, open, onApply, onCancel, ttsModel, hasModelTTS, isPlaying } = props;
   const [localConfig, setLocalConfig] = useState(config);
 
   const socket = useContext(SocketContext);
@@ -38,6 +38,7 @@ const VoiceConfigDialog = memo(props => {
           socket={socket}
           browserVoices={browserVoices}
           voices={voices}
+          isPlaying={isPlaying}
         />
       }
       actions={

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -959,6 +959,7 @@ export const sioEvents = {
   // Server-side TTS (text-to-speech via model API)
   tts_start: 'tts_start',
   tts_stop: 'tts_stop',
+  tts_next: 'tts_next',
   tts_audio_chunk: 'tts_audio_chunk',
   tts_done: 'tts_done',
   tts_error: 'tts_error',

--- a/src/pages/Applications/Components/Applications/ConfigurationTab.jsx
+++ b/src/pages/Applications/Components/Applications/ConfigurationTab.jsx
@@ -417,7 +417,7 @@ const configurationTabStyles = () => ({
     height: '100%',
   },
   gridContainer: {
-    paddingBottom: '0.75rem',
+    paddingBottom: '1.5rem',
     paddingTop: '0.75rem',
     paddingRight: '1.5rem',
     paddingLeft: '1.5rem',

--- a/src/pages/Pipelines/Components/ConfigurationTab.jsx
+++ b/src/pages/Pipelines/Components/ConfigurationTab.jsx
@@ -370,7 +370,7 @@ const configurationTabStyles = (isSmallWindow, isChatPaneCollapsed, maxWidthOfEd
   mainContainer: {
     height: 'calc(100vh - 3.8125rem)',
     overflow: 'scroll',
-    paddingBottom: '0.75rem',
+    paddingBottom: '1.5rem',
     paddingTop: '0.75rem',
     paddingLeft: '1.5rem',
     paddingRight: '1.5rem',


### PR DESCRIPTION
# Voice TTS: Real-time Voice Settings via `tts_next` Handshake

ticket: [#5235](https://github.com/EliteaAI/elitea_issues/issues/5235)

## Problem

Voice settings (voice, speed) were locked at `tts_start` time. The backend split the full text into
sentences and processed all of them with the settings from the initial request — no way to inject
updated settings mid-stream.

Additionally, the backend raced through all sentences as fast as the TTS API could process them,
committing every sentence far ahead of actual playback. This made settings changes feel unresponsive.

## Solution

Replace the fire-and-forget sentence loop with a **handshake protocol**: the backend blocks after
each non-final sentence, waiting for a `tts_next` ACK from the frontend before processing the next
one. The frontend paces ACKs based on elapsed playback time so the backend stays exactly one
sentence ahead. Each ACK carries the current voice and speed, so settings changes take effect at
the very next sentence boundary.

```
speak(text)
  → socket.emit('tts_start', { text, voice, speed })
        ↓ backend splits into sentences

  [sentence 0 audio streams]
  ← socket.on('tts_audio_chunk', ...)          ← PCM audio for sentence 0
  ← socket.on('tts_done', { char_end: N })     ← waypoint; backend NOW BLOCKS

  [user changes speed mid-sentence-0]

  [RAF loop: elapsed >= prevAudioTime – LEAD_TIME]
  → socket.emit('tts_next', { voice, speed })  ← ACK with new settings
        ↓ backend unblocks, applies new voice/speed

  [sentence 1 audio streams with new settings]
  ← socket.on('tts_audio_chunk', ...)
  ← socket.on('tts_done', { char_end: M })     ← waypoint; backend blocks again
  ...

  [final sentence]
  ← socket.on('tts_done')                      ← no char_end; stream complete
```

### ACK Pacing

The frontend fires `tts_next` for sentence `N` when:

```
elapsed >= waypoints[N-1].audioTime – LEAD_TIME_S
```

- `elapsed` = AudioContext clock minus play-start time (accurate; unaffected by buffer level)
- `waypoints[N-1].audioTime` = when the **previous** sentence's audio ends (relative to play start)
- `LEAD_TIME_S = 2.0` = seconds of lead time given to the backend to process sentence `N+1`

This keeps the backend exactly **one sentence ahead** of playback. For `N=0` (first ACK) there is
no previous waypoint, so the condition resolves to `elapsed >= -2.0` — fires immediately when the
first waypoint arrives, which is correct.

Short sentences (duration < `LEAD_TIME_S`) still fire the ACK immediately because the condition
becomes negative — unavoidable without risking audio gaps. For longer sentences the pacing
stabilises to one ACK per sentence boundary.

### Immediate Settings Application (`forceNextAckRef`)

When voice or speed changes **during active playback**, the RAF loop fires the next pending ACK
immediately (bypassing the elapsed-time check) so new settings reach the backend without waiting
for the natural pacing window.

Guard: the effect only sets `forceNextAckRef.current = true` when `playStartTimeRef.current !== null`
(i.e. audio is actually playing). Changes made before playback starts are ignored — they would
otherwise fire the first ACK prematurely.

### Preview Voice Hidden During Streaming

When TTS is streaming (the `VoiceControlButton` is visible), the "Preview Voice" button in the
voice settings dialog is hidden via an `isPlaying` prop. This prevents launching a competing TTS
session while one is already active.

---

## Implementation

### `EliteaUI/src/common/constants.js`

Replace `tts_configuration` with `tts_next` in the `sioEvents` object:

```js
tts_next: 'tts_next',
```

### `EliteaUI/src/[fsd]/features/chat/lib/hooks/useTextToSpeech.hooks.js`

**New refs** (added after existing refs):

```js
const voiceConfigRef = useRef(voiceConfig);   // live mirror for RAF loop
const socketRef = useRef(socket);              // live mirror for RAF loop
const sentenceNextAckedRef = useRef(0);        // count of waypoints ACKed this session
const forceNextAckRef = useRef(false);         // fire ACK immediately on settings change
```

**Sync effects**:

```js
useEffect(() => { voiceConfigRef.current = voiceConfig; }, [voiceConfig]);
useEffect(() => { socketRef.current = socket; }, [socket]);

// Immediate ACK on settings change — only during active playback
useEffect(() => {
  if (playStartTimeRef.current !== null) {
    forceNextAckRef.current = true;
  }
}, [voiceConfig?.voiceId, voiceConfig?.rate]);
```

**Session reset** (in both `stopModelAudio()` and `speak()` before starting a new session):

```js
sentenceWaypointsRef.current = [];
sentenceNextAckedRef.current = 0;
forceNextAckRef.current = false;
```

**`handleDone` non-final branch** — push waypoint only; let the RAF loop pace the ACK:

```js
const audioTime = totalEnqueuedSamplesRef.current / sampleRateRef.current;
sentenceWaypointsRef.current.push({ charPos: char_end, audioTime });
return;
```

**RAF loop pacing block**:

```js
const LEAD_TIME_S = 2.0;
const nextAcked = sentenceNextAckedRef.current;
if (nextAcked < sentenceWaypointsRef.current.length) {
  const prevAudioTime = nextAcked > 0
    ? sentenceWaypointsRef.current[nextAcked - 1].audioTime
    : 0;
  if (forceNextAckRef.current || elapsed >= prevAudioTime - LEAD_TIME_S) {
    socketRef.current?.emit(sioEvents.tts_next, {
      voice: voiceConfigRef.current?.voiceId || undefined,
      speed: voiceConfigRef.current?.rate ?? 1.0,
    });
    sentenceNextAckedRef.current = nextAcked + 1;
    forceNextAckRef.current = false;
  }
}
```

### `EliteaUI/src/[fsd]/features/chat/ui/voice-control-button/VoiceControlButton.jsx`

Pass `isPlaying` to `VoiceConfigDialog` (VoiceControlButton is only rendered while TTS is active):

```jsx
<VoiceConfigDialog
  ...
  isPlaying
/>
```

### `EliteaUI/src/[fsd]/features/chat/voice-config/ui/VoiceConfigDialog.jsx`

Accept and forward `isPlaying`:

```js
const { config, voices, open, onApply, onCancel, ttsModel, hasModelTTS, isPlaying } = props;

// pass down:
<VoiceConfigControls ... isPlaying={isPlaying} />
```

### `EliteaUI/src/[fsd]/features/chat/voice-config/ui/VoiceConfigControls.jsx`

Accept `isPlaying` and hide the preview button while streaming:

```js
const { ..., isPlaying } = props;

{!isPlaying && (
  <Box>
    <Button.BaseBtn ... loading={isPreviewPlaying} onClick={handlePreview}>
      Preview Voice
    </Button.BaseBtn>
  </Box>
)}
```

### `elitea_core/utils/sio_utils.py`

Replace `tts_configuration` with `tts_next` in `SioEvents`:

```python
tts_next = 'tts_next'
```

### `elitea_core/sio/tts.py`

Replace `tts_configuration` handler with `tts_next`:

```python
@web.sio(SioEvents.tts_next)
def tts_next(self, sid: str, data: dict) -> None:
    self.event_node.emit(_VOICE_EVENTS_CHANNEL, {
        "type": "tts_next",
        "sid": sid,
        "voice": data.get("voice"),
        "speed": data.get("speed"),
    })
```

### `indexer_worker/utils/voice_router.py`

Replace `TTS_CONFIG` with `TTS_NEXT`:

```python
TTS_CANCEL = "tts_cancel"
TTS_NEXT   = "tts_next"
```

### `indexer_worker/methods/indexer_tts.py`

In `indexer_tts` method — create `next_event` + `next_config`, register handlers, pass to stream:

```python
cancel_event = threading.Event()
next_event   = threading.Event()
next_config  = {}

def _on_cancel(payload):
    cancel_event.set()
    next_event.set()   # unblock any waiting next_event so the loop exits cleanly

def _on_next(payload):
    if payload.get("voice") is not None:
        next_config["voice"] = payload["voice"]
    if payload.get("speed") is not None:
        next_config["speed"] = float(payload["speed"])
    next_event.set()

voice_register(local_event_node, sid, TTS_CANCEL, _on_cancel)
voice_register(local_event_node, sid, TTS_NEXT,   _on_next)
try:
    _run_tts_stream(..., next_event=next_event, next_config=next_config)
finally:
    voice_unregister(sid, TTS_CANCEL, TTS_NEXT)
```

In `_run_tts_stream` sentence loop — block after each non-final sentence and apply config from ACK:

```python
is_last = (i == len(sentences) - 1)
if is_last:
    local_event_node.emit(_EN_TTS_DONE, {"sid": sid})
else:
    local_event_node.emit(_EN_TTS_DONE, {"sid": sid, "char_end": char_end})
    if next_event is not None:
        next_event.clear()
        next_event.wait(timeout=30)
        if cancel_event.is_set():
            return
        if next_config:
            voice = next_config.pop("voice", voice)
            speed = next_config.pop("speed", speed)
```

---

## Files Changed

| File | Change |
|---|---|
| `EliteaUI/src/common/constants.js` | `tts_next` replaces `tts_configuration` |
| `EliteaUI/.../useTextToSpeech.hooks.js` | Refs, sync effects, session reset, `handleDone` waypoint-only, RAF pacing block |
| `EliteaUI/.../VoiceControlButton.jsx` | Pass `isPlaying` to `VoiceConfigDialog` |
| `EliteaUI/.../VoiceConfigDialog.jsx` | Accept and forward `isPlaying` |
| `EliteaUI/.../VoiceConfigControls.jsx` | Hide Preview Voice button when `isPlaying` |
| `elitea_core/utils/sio_utils.py` | `tts_next` in `SioEvents` |
| `elitea_core/sio/tts.py` | `tts_next` Socket.IO handler |
| `indexer_worker/utils/voice_router.py` | `TTS_NEXT` constant |
| `indexer_worker/methods/indexer_tts.py` | `next_event`/`next_config` handshake; block in sentence loop |
