### PR TITLE
fix: [EL-5249] pre-configured mcp toolkit login issue

### DIFF
--- a/src/[fsd]/features/chat/ui/chat-continue/ChatContinue.jsx
+++ b/src/[fsd]/features/chat/ui/chat-continue/ChatContinue.jsx
@@ -91,6 +91,7 @@ const ChatContinue = memo(props => {
           mcpAuthMetadata={mcpAuthMetadata}
           projectId={projectId}
           toolkitId={mcpAuthMetadata?.toolkitId}
+          toolkitType={authRequiredAction.toolMeta?.toolkit_type}
           onClose={handleCloseModal}
           onCancel={handleCancelModal}
         />


### PR DESCRIPTION
# RCA: Remote MCP Server Repeatedly Prompts for Authentication (Issue #5249)

**Issue**: [EliteaAI/elitea_issues#5249](https://github.com/EliteaAI/elitea_issues/issues/5249)  
**Title**: Remote MCP Server Repeatedly Prompts for Authentication Instead of Persisting Connection After First Auth  
**Labels**: `rca:regression`, `current-release-regression`, `feat:mcp-remote`, `feat:agents`  
**Milestone**: R-2.0.4  
**Date**: 2026-06-12  

---

## Summary

For pre-configured MCP toolkits (type = `"mcp_<server_name>"`, e.g. `"mcp_Epam Staffing"`), the toolkit has **no `url` in its settings** — only `server_name` and `selected_tools`. After the user completes OAuth in the agent chat modal, the token is stored in sessionStorage under the **Keycloak/OAuth server URL** (e.g. `"https://mcp-key.access.epm-iass.projects.epam.com/keycloak_prod"`) instead of the toolkit type key (`"mcp_Epam Staffing"`).

On the next agent invocation, the backend looks up `mcp_tokens` by `server_name` (`"Epam Staffing"`) or `toolkit_name` (`"mcp_Epam Staffing"`) — neither matches the Keycloak URL. No token is found, no `Authorization` header is set, the MCP server returns HTTP 401, `McpAuthorizationRequired` is raised, and the auth modal appears again. This loop repeats indefinitely.

---

## Reproduction Steps

1. Create an agent with a pre-configured MCP toolkit (e.g. EPAM Staffing MCP, toolkit type `"mcp_Epam Staffing"`, no `url` in settings).
2. Open the Agent or Chat page and send a message.
3. Auth modal appears — complete OAuth authentication.
4. Send another message — auth modal reappears.
5. Repeat: every invocation triggers a new auth prompt.

**Evidence — actual `mcp_tokens` sent with each message:**
```json
{
  "https://mcp-key.access.epm-iass.projects.epam.com/keycloak_prod": {
    "access_token": "eyJhbG...",
    "session_id": null,
    "refresh_token": "eyJhbG..."
  }
}
```
Token key = Keycloak URL, but backend expects `"Epam Staffing"` or `"mcp_Epam Staffing"`. Mismatch → token never found.

---

## Root Cause Analysis

### Root Cause 1 (Primary): `mcp_authorization_required` event does not include `toolkit_type`

**File**: `elitea_sdk/runtime/utils/mcp_oauth.py` and `indexer_predict_agent.py`

When `McpAuthorizationRequired` is raised, the exception carries `server_url` (the MCP server URL or OAuth endpoint URL), but **not** the toolkit type (`"mcp_Epam Staffing"`). The socket event emitted to the frontend therefore has no `toolkit_type` field in its `response_metadata`.

---

### Root Cause 2: Chat auth modal opens without `toolkit_type` → token stored under wrong key

**File**: `EliteaUI/src/components/Chat/hooks.js:894–987`

When the `mcp_authorization_required` event arrives in the chat, the handler at lines 918–927 determines `effectiveServerUrl`:

```javascript
const effectiveServerUrl =
  configUuid && oauthEndpoint
    ? `${configUuid}:${oauthEndpoint}`
    : isSharePoint || isOpenApi
      ? oauthEndpoint || serverUrl
      : // Regular MCP: the MCP server URL is itself the OAuth endpoint.
        serverUrl;
```

For a pre-configured MCP that is neither SharePoint nor OpenAPI, this falls through to `serverUrl`, which — when the toolkit has no `url` in its settings — is the Keycloak/OAuth authorization server URL emitted by the backend (`"https://mcp-key.access.epm-iass.projects.epam.com/keycloak_prod"`).

No `toolkit_type` is present in `response_metadata`, so `toolkitType` is never set in the `toolActionPayload`.

**File**: `EliteaUI/src/[fsd]/features/mcp/lib/hooks/useMcpAuthModal.hooks.js:200`

When the modal opens from the chat action button, it renders with:
```javascript
toolkitType: isPrebuildMcp ? toolkitType : undefined,
```

Because the chat context does not know the toolkit type (it only has `response_metadata` from the socket event, which has no `toolkit_type`), `toolkitType` is `undefined` and `isPrebuildMcpType(undefined)` returns `false`. So `toolkitType: undefined` is passed.

**File**: `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuthFlow.helpers.js:464–490`

In `startMcpAuthFlow`, `setAccessToken(serverUrl, ..., toolkitType)` is called with `toolkitType = undefined`:

```javascript
McpAuthHelpers.setAccessToken(
  serverUrl,               // = Keycloak URL
  tokenJson.access_token,
  tokenJson.expires_in,
  sessionId,
  tokenJson.id_token,
  tokenJson.refresh_token,
  { ... },
  toolkitType,             // = undefined
);
```

**File**: `EliteaUI/src/[fsd]/features/mcp/lib/helpers/mcpAuth.helpers.js:74–89`

`setAccessToken` calls `getStorageKey({ serverUrl, toolkitType })`:

```javascript
export const getStorageKey = ({ serverUrl, toolkitType } = {}) => {
  if (isPrebuildMcpType(toolkitType)) {  // false: toolkitType is undefined
    return toolkitType;
  }
  // ...
  if (serverUrl) {
    return canonicalizeServerUrl(serverUrl);  // ← returns Keycloak URL
  }
  return null;
};
```

Because `toolkitType` is `undefined`, `isPrebuildMcpType` returns `false`, and the token is stored under `canonicalizeServerUrl(keycloakUrl)` = `"https://mcp-key.access.epm-iass.projects.epam.com/keycloak_prod"`.

---

### Root Cause 3: Backend token lookup uses `server_name`/`toolkit_name`, not Keycloak URL

**File**: `elitea_sdk/runtime/toolkits/mcp_config.py:600–607`

```python
# Apply OAuth token if available
token_data = None
for key in mcp_tokens:
    if key.endswith(server_name) or key.endswith(toolkit_name or ''):
        token_data = mcp_tokens[key]
        break
if not token_data:
    token_data = mcp_tokens.get(server_name) or mcp_tokens.get(toolkit_name)
```

The lookup searches for keys ending with `"Epam Staffing"` or `"mcp_Epam Staffing"`, and then directly looks up by those names. The actual key `"https://mcp-key.access.epm-iass.projects.epam.com/keycloak_prod"` does not match any of these patterns, so `token_data = None`.

No `Authorization: Bearer` header is set. The MCP server returns HTTP 401.

---

## Data Flow (Broken Path)

```
User sends message
  └─ messagePayloadUtils.js
       mcp_tokens = getAllTokens()
       → { "https://mcp-key.../keycloak_prod": { access_token: "eyJ...", session_id: null } }
         └─ tools.py:357: tool type = "mcp_Epam Staffing" → McpConfigToolkit
              └─ mcp_config.py:600–607: lookup by server_name "Epam Staffing" or toolkit_name
                   → no key ends with "Epam Staffing" in mcp_tokens
                   → token_data = None, no Bearer header set
                        └─ MCP Server: HTTP 401 Unauthorized
                             └─ McpAuthorizationRequired raised (server_url = Keycloak URL)
                                  └─ indexer_predict_agent.py emits mcp_authorization_required
                                       (response_metadata has no toolkit_type field)
                                            └─ Chat hooks.js processes event
                                                 effectiveServerUrl = Keycloak URL (not toolkit type)
                                                      └─ User clicks Login button
                                                           └─ McpAuthModal opens (toolkitType = undefined)
                                                                └─ startMcpAuthFlow(serverUrl=keycloakUrl, toolkitType=undefined)
                                                                     └─ getStorageKey: isPrebuildMcpType(undefined) = false
                                                                          └─ Token stored under Keycloak URL key
                                                                               └─ LOOP
```

---

## Impact Analysis

- **All agent/chat invocations** using pre-configured MCP toolkits that require OAuth are affected.
- The toolkit has no `url` in settings, so the token storage key is always the OAuth/Keycloak URL, which the backend never matches.
- Users are stuck in an authentication loop; the agent cannot use the MCP toolkit.
- Workaround: None available through the normal chat flow. (The Toolkit page "Connect" button uses a different code path that handles pre-built MCPs correctly with `valuesWithType` in `useGetRemoteMcpTools`.)

---

## Fix Recommendations

### Fix 1 (Proper fix): Include `toolkit_type` in the `mcp_authorization_required` event

**Backend** (`mcp_config.py` / `McpAuthorizationRequired`): When raising `McpAuthorizationRequired` for a pre-configured MCP, include the `toolkit_type` (e.g. `"mcp_Epam Staffing"`) in the exception or in the event metadata.

**Frontend** (`hooks.js:894–987`): Extract `toolkit_type` from `response_metadata` in the `McpAuthorizationRequired` handler and store it in `toolActionPayload.toolMeta`. Then pass it as `tokenStorageKey` or `toolkitType` when opening the auth modal:

```javascript
// In hooks.js McpAuthorizationRequired handler:
const toolkitType = response_metadata?.toolkit_type;
// In toolActionPayload:
toolkitType: toolkitType || undefined,
```

When `startMcpAuthFlow` is called with this `toolkitType`, `getStorageKey` will use the toolkit type as the storage key, matching what `mcp_config.py` looks up.

---

### Fix 2 (Backend fallback): Also look up `mcp_tokens` by OAuth URL

**File**: `elitea_sdk/runtime/toolkits/mcp_config.py:600–615`

Add a fallback that checks if any key in `mcp_tokens` is a URL pointing to the same OAuth server that the MCP server would use for authentication. This is harder since the OAuth server URL is not stored in the toolkit settings, but it could use the Keycloak URL from the server's `www-authenticate` header response.

---

### Fix 3 (Alternative): Store token under toolkit type in the Toolkit page "Connect" path

The Toolkit page already handles this correctly via `valuesWithType` in `useGetRemoteMcpTools.hooks.js:44–56`, which passes `type: effectiveToolkitType` to `useMcpAuthModal`. The fix is to ensure the same token-key-by-toolkit-type behavior happens in the agent chat auth modal path.

---

## Files Affected

| File | Location | Change Needed |
|------|----------|---------------|
| `mcp_config.py` | `elitea-sdk/elitea_sdk/runtime/toolkits/` | Include `toolkit_type` in `McpAuthorizationRequired` exception |
| `indexer_predict_agent.py` | `centry/pylon_indexer/plugins/indexer_worker/methods/` | Include `toolkit_type` in `mcp_authorization_required` socket event |
| `hooks.js` | `EliteaUI/src/components/Chat/` | Extract `toolkit_type` from event, pass to auth modal as storage key |

---

## Key Code References

| Location | Line | Description |
|----------|------|-------------|
| `mcp_config.py` | 600–607 | Token lookup: searches by `server_name`/`toolkit_name` — never matches Keycloak URL |
| `hooks.js` | 918–927 | `effectiveServerUrl` logic: pre-configured MCP falls through to `serverUrl` = Keycloak URL |
| `useMcpAuthModal.hooks.js` | 200 | `toolkitType: isPrebuildMcp ? toolkitType : undefined` — undefined in chat context |
| `mcpAuth.helpers.js` | 74–89 | `getStorageKey`: `isPrebuildMcpType(undefined)` = false, uses Keycloak URL as key |
| `mcpAuthFlow.helpers.js` | 464–490 | `setAccessToken(keycloakUrl, ..., undefined)` — token stored under Keycloak URL |
| `mcp_oauth.py` | 16–32 | `McpAuthorizationRequired`: has `server_url` but no `toolkit_type` field |
