### PR TITLE
fix: [EL-5260] show or hide mcps according to mcp configurations

### DIFF
--- a/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
+++ b/src/[fsd]/features/agent/ui/agent-details/configurations/ApplicationTools.jsx
@@ -9,7 +9,8 @@ import { AGENT_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/co
 import { ToolkitsHelpers } from '@/[fsd]/features/toolkits/lib/helpers';
 import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
-import { useAvailableInternalTools } from '@/[fsd]/shared/lib/hooks';
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useAvailableInternalTools, useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
 import { markAllDuplicatesByMultipleKeys } from '@/common/utils';
 import ToolCard from '@/pages/Applications/Components/Tools/ToolCard';
@@ -30,6 +31,7 @@ const ApplicationTools = memo(props => {
 
   const { values } = useFormikContext();
   const { toolkitSchemas } = useGetCurrentToolkitSchemas();
+  const isMcpVisible = useIsMcpVisible();
   // Use POC approach: get available internal tools based on toolkit availability
   // Include agent-only tools since this is agent configuration
   const availableInternalTools = useAvailableInternalTools({ includeAgentOnly: true });
@@ -96,15 +98,17 @@ const ApplicationTools = memo(props => {
   const markedDuplicateTools = useMemo(
     () =>
       markAllDuplicatesByMultipleKeys(
-        tools.map((tool, originalIndex) => ({
-          tool,
-          originalIndex, // Keep track of the original index in the tools array
-          type: tool.type,
-          label: ToolkitsHelpers.genToolkitName(tool, toolkitSchemas || {}),
-        })),
+        tools
+          .map((tool, originalIndex) => ({
+            tool,
+            originalIndex, // Keep track of the original index in the tools array
+            type: tool.type,
+            label: ToolkitsHelpers.genToolkitName(tool, toolkitSchemas || {}),
+          }))
+          .filter(({ tool }) => isMcpVisible || !isMcpToolkit(tool)),
         ['type', 'label'],
       ),
-    [toolkitSchemas, tools],
+    [toolkitSchemas, tools, isMcpVisible],
   );
 
   return (

--- a/src/[fsd]/features/chat/lib/hooks/chat-button/useApplicationSubmenu.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/chat-button/useApplicationSubmenu.hooks.js
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { ChatParticipantType } from '@/common/constants';
 import useFilteredEntityItems from '@/hooks/chat/useFilteredEntityItems';
 import { useDropdownData } from '@/hooks/useDropdownData';
@@ -8,6 +10,7 @@ export const useApplicationSubmenu = props => {
   const { participants = [], onSelectParticipant, onDeleteParticipant, onClose, isOpen = false } = props;
 
   const hasBeenOpenedRef = useRef(false);
+  const isMcpVisible = useIsMcpVisible();
 
   if (isOpen) hasBeenOpenedRef.current = true;
 
@@ -155,15 +158,17 @@ export const useApplicationSubmenu = props => {
 
   const toolkitItems = useMemo(
     () =>
-      toolkitMenuItems.map(item => {
-        const key = `${item.data.id}_${item.data.project_id || ''}`;
-        return {
-          ...item,
-          checked: toolkitParticipantIds.has(key),
-          onToggle: () => handleToolkitToggle(item, false),
-        };
-      }),
-    [toolkitMenuItems, toolkitParticipantIds, handleToolkitToggle],
+      toolkitMenuItems
+        .map(item => {
+          const key = `${item.data.id}_${item.data.project_id || ''}`;
+          return {
+            ...item,
+            checked: toolkitParticipantIds.has(key),
+            onToggle: () => handleToolkitToggle(item, false),
+          };
+        })
+        .filter(({ tool }) => isMcpVisible || !isMcpToolkit(tool)),
+    [toolkitMenuItems, toolkitParticipantIds, handleToolkitToggle, isMcpVisible],
   );
 
   const mcpItems = useMemo(

--- a/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
+++ b/src/[fsd]/features/chat/lib/hooks/useSlashMention.hooks.js
@@ -3,6 +3,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTheme } from '@mui/system';
 
 import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
+import { isMcpToolkitType } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { ChatParticipantType } from '@/common/constants';
 import { getToolIconByType } from '@/common/toolkitUtils';
 
@@ -43,6 +45,7 @@ export const useSlashMention = ({ chatInput, activeConversation }) => {
     onConfirmActiveRef: slashOnConfirmActiveRef,
   } = useSlashCommandHandler({ setInputContent });
   const theme = useTheme();
+  const isMcpVisible = useIsMcpVisible();
 
   // IDs of toolkit participants in the current conversation, used by SlashSuggestionList
   // to filter the autosuggest to only those already added (AC1).
@@ -50,6 +53,10 @@ export const useSlashMention = ({ chatInput, activeConversation }) => {
     () =>
       (activeConversation?.participants || [])
         .filter(p => p.entity_name === ChatParticipantType.Toolkits)
+        .filter(p => {
+          const toolkitType = p.entity_settings?.toolkit_type;
+          return isMcpVisible || !isMcpToolkitType(toolkitType);
+        })
         .map(p => ({
           id: p.entity_meta.id,
           project_id: p.entity_meta.project_id,
@@ -65,7 +72,7 @@ export const useSlashMention = ({ chatInput, activeConversation }) => {
               },
           participantType: p.entity_name,
         })),
-    [activeConversation?.participants, theme, toolkitSchemas],
+    [activeConversation?.participants, theme, toolkitSchemas, isMcpVisible],
   );
   // Replace the typed "/query" or "/query/" fragment with "/toolkit.name" in the input.
   // Uses mentionAnchorRef so that editing an earlier mention in the middle of the text

--- a/src/[fsd]/features/chat/participants/ui/CollapsedParticipants/CollapsedPerticapantsList.jsx
+++ b/src/[fsd]/features/chat/participants/ui/CollapsedParticipants/CollapsedPerticapantsList.jsx
@@ -6,6 +6,8 @@ import { Box, IconButton, SvgIcon } from '@mui/material';
 
 import StyledTooltip from '@/ComponentsLib/Tooltip';
 import { useParticipantDetailsContext } from '@/[fsd]/features/chat/participants/lib/context/ParticipantDetailsContext';
+import { isMcpToolkitType } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import AgentSvg from '@/assets/agent.svg?react';
 import FlowSvg from '@/assets/flow-icon.svg?react';
 import MCPSvg from '@/assets/mcp-icon.svg?react';
@@ -75,6 +77,7 @@ const CollapsedPerticapantsList = memo(props => {
   const sectionAnchorsRef = useRef({});
 
   const selectedProjectId = useSelectedProjectId();
+  const isMcpVisible = useIsMcpVisible();
   const user = useSelector(state => state.user);
   const isPrivateProject = selectedProjectId == user.personal_project_id;
   const showUsersSection = !isPrivateProject;
@@ -93,10 +96,12 @@ const CollapsedPerticapantsList = memo(props => {
 
         if (!acc[key]) acc[key] = { count: 0, participants: [] };
         acc[key].count += 1;
-        acc[key].participants.push(p);
+        if (isMcpVisible || !isMcpToolkitType(p.entity_settings?.toolkit_type)) {
+          acc[key].participants.push(p);
+        }
         return acc;
       }, {}),
-    [participants],
+    [isMcpVisible, participants],
   );
 
   const usersGroup = groupedByType[USERS_SECTION.type];
@@ -166,7 +171,8 @@ const CollapsedPerticapantsList = memo(props => {
       {ENTITY_SECTIONS.map(entity => {
         const group = groupedByType[entity.type];
 
-        if (!group) return null;
+        if (!group || group.participants?.length === 0) return null;
+        if (entity.type === 'mcp' && !isMcpVisible) return null;
 
         const sectionHasError = group.participants.some(p =>
           hasParticipantError(p.entity_name, p.entity_meta?.id, p.entity_meta?.project_id),

--- a/src/[fsd]/features/chat/participants/ui/ExpandedParticipants/ExpandedParticipantsList.jsx
+++ b/src/[fsd]/features/chat/participants/ui/ExpandedParticipants/ExpandedParticipantsList.jsx
@@ -4,6 +4,8 @@ import { useSelector } from 'react-redux';
 
 import { Box, Typography } from '@mui/material';
 
+import { isMcpToolkitType } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { ChatParticipantType } from '@/common/constants';
 import { useSelectedProjectId } from '@/hooks/useSelectedProject';
 
@@ -35,6 +37,7 @@ const ExpandedPerticapantsList = memo(props => {
   } = props;
 
   const selectedProjectId = useSelectedProjectId();
+  const isMcpVisible = useIsMcpVisible();
 
   const styles = expandedPerticapantsListStyles();
 
@@ -71,10 +74,12 @@ const ExpandedPerticapantsList = memo(props => {
           key = 'mcp';
 
         if (!acc[key]) acc[key] = [];
-        acc[key].push(p);
+        if (isMcpVisible || !isMcpToolkitType(p.entity_settings?.toolkit_type)) {
+          acc[key].push(p);
+        }
         return acc;
       }, {}),
-    [participants],
+    [isMcpVisible, participants],
   );
 
   return (
@@ -125,7 +130,8 @@ const ExpandedPerticapantsList = memo(props => {
 
       {ENTITY_SECTIONS.map(section => {
         const group = groupedByType[section.type];
-        if (!group?.length) return null;
+        if (!group || group.participants?.length === 0) return null;
+        if (section.type === 'mcp' && !isMcpVisible) return null;
 
         return (
           <ParticipantSection

--- a/src/[fsd]/features/chat/ui/chat-button/PlusChatButton.jsx
+++ b/src/[fsd]/features/chat/ui/chat-button/PlusChatButton.jsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material';
 
 import { useApplicationSubmenu } from '@/[fsd]/features/chat/lib/hooks';
-import { useAvailableInternalTools } from '@/[fsd]/shared/lib/hooks';
+import { useAvailableInternalTools, useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { Switch, Text } from '@/[fsd]/shared/ui';
 import FlowIcon from '@/assets/flow-icon.svg?react';
 import MCPIcon from '@/assets/mcp-icon.svg?react';
@@ -82,6 +82,7 @@ const PlusChatButton = forwardRef(props => {
   } = props;
 
   const theme = useTheme();
+  const isMcpVisible = useIsMcpVisible();
   const availableTools = useAvailableInternalTools();
   const buttonRef = useRef(null);
   const hoverTimeoutRef = useRef(null);
@@ -121,9 +122,9 @@ const PlusChatButton = forwardRef(props => {
       [SUBMENU_KEYS.AGENTS]: agents,
       [SUBMENU_KEYS.PIPELINES]: pipelines,
       [SUBMENU_KEYS.TOOLKITS]: toolkits,
-      [SUBMENU_KEYS.MCPS]: mcps,
+      ...(isMcpVisible && { [SUBMENU_KEYS.MCPS]: mcps }),
     }),
-    [agents, pipelines, toolkits, mcps],
+    [agents, pipelines, toolkits, mcps, isMcpVisible],
   );
 
   const handleClickAway = useCallback(
@@ -225,16 +226,18 @@ const PlusChatButton = forwardRef(props => {
         showToggle: true,
         showPublicLabel: false,
       },
-      [SUBMENU_KEYS.MCPS]: {
-        searchPlaceholder: 'Search MCPs...',
-        showCreateNew: !!onCreateToolkit,
-        createNewLabel: 'Create New MCP',
-        onCreateNew: handleCreateMCP,
-        emptyMessage: 'No MCPs available',
-        noResultsMessage: 'No MCPs found',
-        showToggle: true,
-        showPublicLabel: false,
-      },
+      ...(isMcpVisible && {
+        [SUBMENU_KEYS.MCPS]: {
+          searchPlaceholder: 'Search MCPs...',
+          showCreateNew: !!onCreateToolkit,
+          createNewLabel: 'Create New MCP',
+          onCreateNew: handleCreateMCP,
+          emptyMessage: 'No MCPs available',
+          noResultsMessage: 'No MCPs found',
+          showToggle: true,
+          showPublicLabel: false,
+        },
+      }),
     }),
     [
       onCreateAgent,
@@ -244,6 +247,7 @@ const PlusChatButton = forwardRef(props => {
       handleCreatePipeline,
       handleCreateToolkit,
       handleCreateMCP,
+      isMcpVisible,
     ],
   );
 
@@ -275,8 +279,10 @@ const PlusChatButton = forwardRef(props => {
     }
 
     if (SEARCHABLE_KEYS.includes(hoveredItem)) {
+      if (hoveredItem === SUBMENU_KEYS.MCPS && !isMcpVisible) return null;
       const data = submenuMap[hoveredItem];
       const config = submenuConfigs[hoveredItem];
+      if (!data || !config) return null;
       return (
         <PlusChatSubmenu
           items={data.items}
@@ -290,6 +296,7 @@ const PlusChatButton = forwardRef(props => {
     }
   }, [
     hoveredItem,
+    isMcpVisible,
     availableTools,
     internal_tools,
     disableInternalTools,
@@ -346,21 +353,23 @@ const PlusChatButton = forwardRef(props => {
                 limits={limits}
               />
 
-              {EXPANDABLE_ITEMS.map(({ key, label, Icon }) => (
-                <MenuItem
-                  key={key}
-                  sx={styles.menuItem}
-                  onMouseEnter={e => handleItemHover(key, e)}
-                  onMouseLeave={handleItemLeave}
-                >
-                  <Box
-                    component={Icon}
-                    sx={styles.menuIcon}
-                  />
-                  <Typography sx={styles.menuLabel}>{label}</Typography>
-                  <ArrowRightIcon sx={styles.chevron} />
-                </MenuItem>
-              ))}
+              {EXPANDABLE_ITEMS.filter(item => item.key !== SUBMENU_KEYS.MCPS || isMcpVisible).map(
+                ({ key, label, Icon }) => (
+                  <MenuItem
+                    key={key}
+                    sx={styles.menuItem}
+                    onMouseEnter={e => handleItemHover(key, e)}
+                    onMouseLeave={handleItemLeave}
+                  >
+                    <Box
+                      component={Icon}
+                      sx={styles.menuIcon}
+                    />
+                    <Typography sx={styles.menuLabel}>{label}</Typography>
+                    <ArrowRightIcon sx={styles.chevron} />
+                  </MenuItem>
+                ),
+              )}
 
               <MenuItem
                 sx={styles.menuItem}

--- a/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
+++ b/src/[fsd]/features/chat/ui/slash-suggestion-list/SlashSuggestionList.jsx
@@ -2,6 +2,8 @@ import { memo, useEffect, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { useToolkitsDetailsQuery } from '@/api/toolkits';
 import NewParticipantList from '@/pages/NewChat/Recommendations/NewParticipantList';
 
@@ -25,6 +27,7 @@ const SlashSuggestionList = memo(props => {
     onConfirmActiveRef,
   } = props;
 
+  const isMcpVisible = useIsMcpVisible();
   const toolkitValidationInfo = useSelector(state => state.chat.toolkitValidationInfo);
 
   // Only show toolkits that are added as conversation participants (AC1)
@@ -33,13 +36,14 @@ const SlashSuggestionList = memo(props => {
   const filteredParticipants = useMemo(() => {
     if (!participantToolkits?.length) return [];
     return participantToolkits.filter(p => {
+      if (!isMcpVisible && isMcpToolkit(p)) return false;
       const key = `${p.project_id}_${p.id}`;
       const validationInfo = toolkitValidationInfo?.[key];
       if (validationInfo?.length) return false;
       if (toolkitQuery && !p.name.toLowerCase().includes(toolkitQuery.toLowerCase())) return false;
       return true;
     });
-  }, [participantToolkits, toolkitValidationInfo, toolkitQuery]);
+  }, [participantToolkits, toolkitValidationInfo, toolkitQuery, isMcpVisible]);
 
   const { data: toolkitDetails, isFetching: isToolsFetching } = useToolkitsDetailsQuery(
     { projectId: selectedToolkit?.project_id, toolkitId: selectedToolkit?.id },
@@ -48,7 +52,7 @@ const SlashSuggestionList = memo(props => {
 
   const availableTools = useMemo(() => {
     if (!toolkitDetails?.settings) return [];
-    const isMcp = toolkitDetails.type === 'mcp' || toolkitDetails.type?.startsWith('mcp_');
+    const isMcp = isMcpToolkit(toolkitDetails);
     if (isMcp) {
       return (toolkitDetails.settings.available_mcp_tools || []).map(item => ({
         name: item.value || item.label,
@@ -149,7 +153,7 @@ const SlashSuggestionList = memo(props => {
           existingParticipantUids={[]}
           onClose={onClose}
           total={participantToolkits.length}
-          title="Mention Toolkit or MCP"
+          title={isMcpVisible ? 'Mention Toolkit or MCP' : 'Mention Toolkit'}
           activeIndex={activeIndex}
         />
       </>

--- a/src/[fsd]/features/pipelines/flow-editor/ui/select/ToolSelect.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/select/ToolSelect.jsx
@@ -3,6 +3,8 @@ import { memo, useCallback, useMemo } from 'react';
 import { useFormikContext } from 'formik';
 
 import { useGetToolkitNameFromSchema } from '@/[fsd]/features/pipelines/flow-editor/lib/hooks';
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
 import EntityIcon from '@/components/EntityIcon';
 import { useGetToolkitIconMeta } from '@/hooks/application/useLibraryToolkits';
@@ -20,6 +22,7 @@ const ToolSelect = memo(props => {
   } = props;
   const { getToolkitNameFromSchema } = useGetToolkitNameFromSchema();
   const getToolkitIconMeta = useGetToolkitIconMeta();
+  const isMcpVisible = useIsMcpVisible();
 
   const {
     values: { version_details },
@@ -29,6 +32,7 @@ const ToolSelect = memo(props => {
     () =>
       (version_details?.tools || [])
         .filter(filterTypes)
+        .filter(tool => isMcpVisible || !isMcpToolkit(tool))
         .map(tool => ({
           label:
             tool.type === ToolTypes.application.value
@@ -58,7 +62,7 @@ const ToolSelect = memo(props => {
           originalTool: tool,
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
-    [filterTypes, getToolkitIconMeta, getToolkitNameFromSchema, version_details?.tools],
+    [filterTypes, getToolkitIconMeta, getToolkitNameFromSchema, version_details?.tools, isMcpVisible],
   );
 
   const onChangeTool = useCallback(

--- a/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
+++ b/src/[fsd]/features/toolkits/ui/form/ToolBase/ToolBase.jsx
@@ -9,9 +9,9 @@ import { SharepointOAuthStatus } from '@/[fsd]/features/sharepoint/ui';
 import { ToolBaseHelpers } from '@/[fsd]/features/toolkits/lib/helpers';
 import { ToolkitForm } from '@/[fsd]/features/toolkits/ui';
 import { AccordionConstants } from '@/[fsd]/shared/lib/constants';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { useSystemSenderName } from '@/[fsd]/shared/lib/hooks/useEnvironmentSettingByKey.hooks';
 import BasicAccordion from '@/[fsd]/shared/ui/accordion/BasicAccordion';
-import { useGetPlatformSettingsQuery } from '@/api/platformSettings';
 import {
   convertToValidEliteaTitle,
   getEliteATitleValidationError,
@@ -73,8 +73,7 @@ const ToolBase = memo(props => {
   const { sections, sectionProps } = useToolkitConfigurationProperties({ toolType: editToolDetail?.type });
 
   // Get platform settings to check if MCP exposure is enabled
-  const { data: platformSettings } = useGetPlatformSettingsQuery();
-  const isMcpExposureEnabled = platformSettings?.mcp_exposure_enabled !== false;
+  const isMcpExposureEnabled = useIsMcpVisible();
 
   // Check if we need to show disabled configuration fields for old toolkits
   useEffect(() => {

--- a/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
+++ b/src/[fsd]/features/toolkits/ui/list/ToolkitsList.jsx
@@ -9,6 +9,8 @@ import { AuthorInformation } from '@/[fsd]/entities/author/ui';
 import { EmptyStatePage } from '@/[fsd]/entities/empty-state-page';
 import { useLoadToolkits } from '@/[fsd]/features/toolkits/lib/hooks';
 import { ToolkitTypesPanel, ToolkitsEmptyListPlaceHolder } from '@/[fsd]/features/toolkits/ui/list';
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { ContentType, PUBLIC_PROJECT_ID, ViewMode } from '@/common/constants';
 import { buildErrorMessage, uniqueArrayByProp } from '@/common/utils';
 import CardList from '@/components/CardList';
@@ -38,6 +40,7 @@ const ToolkitsList = memo(props => {
   const dispatch = useDispatch();
   const { query } = useSelector(state => state.search);
   const selectedProjectId = useSelectedProjectId();
+  const isMcpVisible = useIsMcpVisible();
 
   const { renderCard } = useCardList(
     selectedProjectId != PUBLIC_PROJECT_ID ? ViewMode.Owner : ViewMode.Public,
@@ -141,15 +144,17 @@ const ToolkitsList = memo(props => {
     };
 
     const items = uniqueArrayByProp(
-      (data || []).map(item => ({
-        ...item,
-        name: getToolkitItemName(item),
-      })),
+      (data || [])
+        .filter(item => isMcpVisible || !isMcpToolkit(item))
+        .map(item => ({
+          ...item,
+          name: getToolkitItemName(item),
+        })),
       'id',
     );
 
     return items;
-  }, [data]);
+  }, [data, isMcpVisible]);
 
   const loadMore = useCallback(() => {
     const existsMore = totalCount && uniqueDataList.length < totalCount && (page + 1) * pageSize < totalCount;

--- a/src/[fsd]/shared/lib/helpers/index.js
+++ b/src/[fsd]/shared/lib/helpers/index.js
@@ -21,3 +21,5 @@ export {
   MermaidHelpers,
   CodeMirrorLinterHelpers,
 };
+
+export { isMcpToolkitType, isMcpToolkit } from './mcp.helpers';

--- a/src/[fsd]/shared/lib/helpers/mcp.helpers.js
+++ b/src/[fsd]/shared/lib/helpers/mcp.helpers.js
@@ -1,0 +1,14 @@
+import { McpAuthConstants } from '@/[fsd]/features/mcp/lib/constants';
+
+/**
+ * Returns true if the given type string identifies an MCP toolkit.
+ * Covers both remote MCPs ('mcp') and pre-built MCPs ('mcp_*').
+ */
+export const isMcpToolkitType = type =>
+  type === 'mcp' || Boolean(type?.startsWith(McpAuthConstants.MCP_PREBUILD_PREFIX));
+
+/**
+ * Returns true if the given toolkit item is an MCP toolkit.
+ * Checks item.type and item.meta.mcp (used by pipeline nodes).
+ */
+export const isMcpToolkit = item => isMcpToolkitType(item?.type) || item?.meta?.mcp === true;

--- a/src/[fsd]/shared/lib/hooks/index.js
+++ b/src/[fsd]/shared/lib/hooks/index.js
@@ -16,3 +16,4 @@ export * from './useShowRunHistoryFromUrl.hooks';
 export * from './useDeleteConfirmationDisabled.hooks';
 export * from './useMentionHighlights.hooks';
 export * from './useLanguageLinter.hooks';
+export * from './useMcpVisibility.hooks';

--- a/src/[fsd]/shared/lib/hooks/useAvailableInternalTools.hooks.js
+++ b/src/[fsd]/shared/lib/hooks/useAvailableInternalTools.hooks.js
@@ -3,6 +3,8 @@ import { useMemo } from 'react';
 import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
 import { InternalToolsConstants } from '@/[fsd]/shared/lib/constants';
 
+import { useIsMcpVisible } from './useMcpVisibility.hooks';
+
 /**
  * Hook that returns the list of available internal tools based on toolkit availability.
  * Filters out tools that require specific toolkit types that are not available.
@@ -19,11 +21,17 @@ import { InternalToolsConstants } from '@/[fsd]/shared/lib/constants';
 export const useAvailableInternalTools = (options = {}) => {
   const { includeAgentOnly = false } = options;
   const { toolkitSchemas } = useGetCurrentToolkitSchemas();
+  const isMcpVisible = useIsMcpVisible();
 
   const availableTools = useMemo(() => {
     return InternalToolsConstants.INTERNAL_TOOLS_LIST.filter(tool => {
       // Filter out agent-only tools if not in agent context
       if (tool.agentOnly && !includeAgentOnly) {
+        return false;
+      }
+
+      // Hide the internal MCP tool when MCP is disabled or hidden in UI
+      if (tool.name === 'internal_mcp' && !isMcpVisible) {
         return false;
       }
 
@@ -34,7 +42,7 @@ export const useAvailableInternalTools = (options = {}) => {
       // Check if the required toolkit type exists in schemas
       return Boolean(toolkitSchemas?.[tool.requiredToolkitType]);
     });
-  }, [toolkitSchemas, includeAgentOnly]);
+  }, [toolkitSchemas, includeAgentOnly, isMcpVisible]);
 
   return availableTools;
 };

--- a/src/[fsd]/shared/lib/hooks/useMcpVisibility.hooks.js
+++ b/src/[fsd]/shared/lib/hooks/useMcpVisibility.hooks.js
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers/mcp.helpers';
+import { useGetPlatformSettingsQuery } from '@/api/platformSettings';
+
+export const useIsMcpVisible = () => {
+  const { data: platformSettings } = useGetPlatformSettingsQuery();
+  return platformSettings?.mcp_exposure_enabled !== false && platformSettings?.mcp_in_menu_enabled !== false;
+};
+
+/**
+ * Returns a stable filter predicate: item => isMcpVisible || !isMcpToolkit(item).
+ * Use this to filter toolkit arrays — replaces the repeated inline pattern.
+ */
+export const useMcpFilter = () => {
+  const isMcpVisible = useIsMcpVisible();
+  return useCallback(item => isMcpVisible || !isMcpToolkit(item), [isMcpVisible]);
+};

--- a/src/[fsd]/widgets/sidebar-root/ui/SidebarBody.jsx
+++ b/src/[fsd]/widgets/sidebar-root/ui/SidebarBody.jsx
@@ -7,12 +7,12 @@ import { Box, Divider, IconButton, Tooltip, Typography, useTheme } from '@mui/ma
 
 import StyledTooltip from '@/ComponentsLib/Tooltip';
 import { SIDEBAR_TOUR_TARGET_IDS } from '@/[fsd]/features/interactive-tours/lib/constants';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { useSystemSenderName } from '@/[fsd]/shared/lib/hooks/useEnvironmentSettingByKey.hooks';
 import { SidebarConstants, SocketConstants } from '@/[fsd]/widgets/sidebar-root/lib/constants';
 import { useSocketIcon } from '@/[fsd]/widgets/sidebar-root/lib/hooks';
 import { Buttons, SidebarMenuItem } from '@/[fsd]/widgets/sidebar-root/ui';
 import { useGetSupportAssistantConfigQuery } from '@/[fsd]/widgets/support-assistant';
-import { useGetPlatformSettingsQuery } from '@/api/platformSettings';
 import AppsIcon from '@/assets/applications-icon.svg?react';
 import ArtifactsIcon from '@/assets/artifacts-icon.svg?react';
 import BriefcaseIcon from '@/assets/briefcase-icon.svg?react';
@@ -48,7 +48,7 @@ const SidebarBody = memo(props => {
   const { isBlockNav, isStreaming, setIsResetApiState, resetApiState } = useNavBlocker();
   const { isSocketIconVisible, socketStatus } = useSocketIcon();
   const { personal_project_id } = useSelector(state => state.user);
-  const { data: platformSettings } = useGetPlatformSettingsQuery();
+  const isMcpVisible = useIsMcpVisible();
 
   useGetSupportAssistantConfigQuery();
 
@@ -191,8 +191,7 @@ const SidebarBody = memo(props => {
     ];
     const filteredSections = allSections.map(section => {
       return section.filter(i => {
-        // Hide MCPs menu item when mcp_in_menu is disabled at platform level
-        if (i.value === 'mcps' && platformSettings?.mcp_in_menu_enabled === false) {
+        if (i.value === 'mcps' && !isMcpVisible) {
           return false;
         }
         const perms = i.publicPermission ? publicPermissionsSet : permissionsSet;
@@ -203,7 +202,7 @@ const SidebarBody = memo(props => {
       });
     });
     return filteredSections.filter(section => section.length > 0);
-  }, [permissionsSet, publicPermissionsSet, platformSettings?.mcp_in_menu_enabled]);
+  }, [permissionsSet, publicPermissionsSet, isMcpVisible]);
 
   const customRenderProject = useCallback(
     option => {

--- a/src/hooks/toolkit/useToolkitSearch.js
+++ b/src/hooks/toolkit/useToolkitSearch.js
@@ -4,9 +4,10 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { useTheme } from '@mui/material';
 
+import { McpAuthConstants } from '@/[fsd]/features/mcp/lib/constants';
 import { McpConstants } from '@/[fsd]/features/toolkits/lib/constants';
 import { useGetCurrentToolkitSchemas } from '@/[fsd]/features/toolkits/lib/hooks';
-import { useGroupedCategories } from '@/[fsd]/shared/lib/hooks';
+import { useGroupedCategories, useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { getToolIcon } from '@/common/toolkitUtils';
 import RouteDefinitions from '@/routes.js';
 
@@ -20,6 +21,7 @@ export const useToolkitSearch = ({
   const navigate = useNavigate();
   const { toolkitType } = useParams();
   const [searchParams] = useSearchParams();
+  const isMcpVisible = useIsMcpVisible();
 
   // Get toolkit schemas from backend for category extraction
   const { toolkitSchemas } = useGetCurrentToolkitSchemas();
@@ -49,14 +51,16 @@ export const useToolkitSearch = ({
     [isMCP, toolkitSchemas],
   );
 
-  // Process children to add icons and categories
+  // Process children to add icons and categories, filtering out pre-built MCPs when MCP is hidden
   const processedChildren = useMemo(
     () =>
-      toolMenuItems?.map(child => ({
-        ...child,
-        icon: child.icon || getToolIcon(child.key, theme),
-      })) || [],
-    [toolMenuItems, theme],
+      (toolMenuItems || [])
+        .filter(child => isMcpVisible || !child?.key.startsWith(McpAuthConstants.MCP_PREBUILD_PREFIX))
+        .map(child => ({
+          ...child,
+          icon: child.icon || getToolIcon(child?.key, theme),
+        })),
+    [toolMenuItems, theme, isMcpVisible],
   );
 
   // Handle toolkit selection

--- a/src/hooks/useDropdownData.jsx
+++ b/src/hooks/useDropdownData.jsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useTheme } from '@mui/material';
 
+import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { useToolkitsListQuery } from '@/api/toolkits';
 import { PUBLIC_PROJECT_ID } from '@/common/constants';
 import { getToolIconByType } from '@/common/toolkitUtils';
@@ -20,6 +22,7 @@ const emptyTagIds = []; // Stable reference to prevent infinite re-renders
 export const useDropdownData = ({ agentQuery, pipelineQuery, toolkitQuery, mcpQuery, skip = false }) => {
   const projectId = useSelectedProjectId();
   const theme = useTheme();
+  const isMcpVisible = useIsMcpVisible();
   const [isLoadingMoreToolkit, setIsLoadingMoreToolkit] = useState(false);
   const [isLoadingMoreMCP, setIsLoadingMoreMCP] = useState(false);
 
@@ -241,10 +244,12 @@ export const useDropdownData = ({ agentQuery, pipelineQuery, toolkitQuery, mcpQu
 
   // Transform toolkits data for dropdown display (combine regular + public)
   const toolkitMenuItems = useMemo(() => {
-    const regularToolkits = (toolkitsData?.rows || []).map(item => ({
-      ...item,
-      project_id: projectId,
-    }));
+    const regularToolkits = (toolkitsData?.rows || [])
+      .filter(item => isMcpVisible || !isMcpToolkit(item))
+      .map(item => ({
+        ...item,
+        project_id: projectId,
+      }));
 
     return regularToolkits.map(toolkit => {
       // Get the preferred title following the hierarchy used in ToolkitsList
@@ -276,7 +281,7 @@ export const useDropdownData = ({ agentQuery, pipelineQuery, toolkitQuery, mcpQu
         ),
       };
     });
-  }, [toolkitsData?.rows, projectId, theme, entityIconSx, entityImageStyle]);
+  }, [toolkitsData?.rows, projectId, theme, entityIconSx, entityImageStyle, isMcpVisible]);
 
   // Transform MCPs data for dropdown display (combine regular + public)
   const mcpMenuItems = useMemo(() => {

--- a/src/pages/Applications/Components/Tools/ToolMenu.jsx
+++ b/src/pages/Applications/Components/Tools/ToolMenu.jsx
@@ -9,6 +9,7 @@ import { Box } from '@mui/material';
 import Tooltip from '@/ComponentsLib/Tooltip';
 import { useTrackEvent } from '@/GA';
 import { GA_EVENT_NAMES, GA_EVENT_PARAMS } from '@/[fsd]/shared/lib/constants/analytic.constants';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import BaseBtn, { BUTTON_VARIANTS } from '@/[fsd]/shared/ui/button/BaseBtn';
 import { useApplicationListQuery } from '@/api/applications';
 import { useLazyToolkitsDetailsQuery } from '@/api/toolkits';
@@ -89,6 +90,8 @@ const ToolMenu = memo(props => {
   // Determine if the current entity is unsaved (newly created but not yet persisted)
   // An entity is considered unsaved if it doesn't have an ID or version_details.id
   const isEntityUnsaved = !values?.id || !values?.version_details?.id;
+
+  const isMcpVisible = useIsMcpVisible();
 
   // Use the hook to filter out already-added items
   const { filterToolkits, filterAgents, filterPipelines } = useFilterAddedItems();
@@ -578,27 +581,29 @@ const ToolMenu = memo(props => {
             </BaseBtn>
           </Box>
         </Tooltip>
-        {/* Toolkit Button */}
-        <Tooltip
-          title={
-            isEntityUnsaved
-              ? `Save the ${values?.version_details?.agent_type === 'pipeline' ? 'pipeline' : 'agent'} first, then add mcps`
-              : ''
-          }
-          placement="top"
-        >
-          <Box component="span">
-            <BaseBtn
-              variant={BUTTON_VARIANTS.iconLabel}
-              startIcon={<PlusIcon />}
-              disableRipple
-              disabled={isEntityUnsaved}
-              onClick={isEntityUnsaved ? undefined : handleMCPButtonClick}
-            >
-              MCP
-            </BaseBtn>
-          </Box>
-        </Tooltip>
+        {/* MCP Button */}
+        {isMcpVisible && (
+          <Tooltip
+            title={
+              isEntityUnsaved
+                ? `Save the ${values?.version_details?.agent_type === 'pipeline' ? 'pipeline' : 'agent'} first, then add mcps`
+                : ''
+            }
+            placement="top"
+          >
+            <Box component="span">
+              <BaseBtn
+                variant={BUTTON_VARIANTS.iconLabel}
+                startIcon={<PlusIcon />}
+                disableRipple
+                disabled={isEntityUnsaved}
+                onClick={isEntityUnsaved ? undefined : handleMCPButtonClick}
+              >
+                MCP
+              </BaseBtn>
+            </Box>
+          </Tooltip>
+        )}
         {/* Agent Button */}
         <Tooltip
           title={
@@ -665,24 +670,26 @@ const ToolMenu = memo(props => {
       />
 
       {/* MCP Dropdown */}
-      <UnifiedDropdown
-        anchorEl={mcpAnchor}
-        open={Boolean(mcpAnchor)}
-        onClose={handleMCPMenuClose}
-        items={allMCPItems}
-        searchValue={mcpSearch}
-        onSearchChange={handleMCPSearchChange}
-        searchPlaceholder="Search mcps..."
-        onCreateNew={handleCreateNewToolkit(true)}
-        createNewLabel="Create new"
-        showCreateNew={true}
-        isLoading={isFetchingMCPs}
-        emptyMessage="No mcps available"
-        noResultsMessage="No mcps found"
-        onScroll={handleMCPScroll}
-        autoFocus={true}
-        showDivider={true}
-      />
+      {isMcpVisible && (
+        <UnifiedDropdown
+          anchorEl={mcpAnchor}
+          open={Boolean(mcpAnchor)}
+          onClose={handleMCPMenuClose}
+          items={allMCPItems}
+          searchValue={mcpSearch}
+          onSearchChange={handleMCPSearchChange}
+          searchPlaceholder="Search mcps..."
+          onCreateNew={handleCreateNewToolkit(true)}
+          createNewLabel="Create new"
+          showCreateNew={true}
+          isLoading={isFetchingMCPs}
+          emptyMessage="No mcps available"
+          noResultsMessage="No mcps found"
+          onScroll={handleMCPScroll}
+          autoFocus={true}
+          showDivider={true}
+        />
+      )}
 
       {/* Agent Dropdown */}
       <UnifiedDropdown

--- a/src/pages/Toolkits/ToolkitTypeSelector.jsx
+++ b/src/pages/Toolkits/ToolkitTypeSelector.jsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import { Link, Typography } from '@mui/material';
 
 import { useGetToolkitNameFromSchema } from '@/[fsd]/features/pipelines/flow-editor/lib/hooks';
+import { useIsMcpVisible } from '@/[fsd]/shared/lib/hooks';
 import { Category } from '@/[fsd]/shared/ui';
 import { useLazyListModelsQuery } from '@/api/configurations';
 import getToolInitialValueBySchema from '@/common/getToolInitialValueBySchema.js';
@@ -146,6 +147,8 @@ const ToolkitTypeSelector = memo(
       ],
     );
 
+    const isMcpVisible = useIsMcpVisible();
+
     const { toolMenuItems, isFetchingToolkitTypes } = useToolMenuItems({ onAddTool, isMCP, isApplication });
     const searchProps = useToolkitSearch({ toolMenuItems, isMCP, isApplication, disableNavigation });
 
@@ -197,6 +200,10 @@ const ToolkitTypeSelector = memo(
       ),
       [],
     );
+
+    if (isMCP && !isMcpVisible) {
+      return null;
+    }
 
     return (
       <>


### PR DESCRIPTION
# Solution: MCP Configuration — Master Toggle Behavior, Global Scope, and Sidebar Visibility Rename
**Issue:** [EliteaAI/elitea_issues#5260](https://github.com/EliteaAI/elitea_issues/issues/5260)

## Summary of Changes

Two toggles in Admin Portal → Configuration → Guardrails → MCP Configuration need to change:

1. **Enable MCP** — Upgrade to a true master switch affecting all MCP UI entry points globally (not just the SSE endpoints and toolkit checkbox as today).
2. **Show MCPs in Sidebar** → Rename to **Show MCPs in UI** — Extend scope from sidebar only to all MCP UI entry points (sidebar, Agent Tools, Pipeline Tools, Toolkit creation, Chat options, Chat Participants).

### Toggle Precedence Logic
- `mcp_exposure_enabled = false` (master switch OFF) → hide all MCP UI entry points + MCP API returns 403
- `mcp_exposure_enabled = true` + `mcp_in_menu_enabled = false` (UI toggle OFF) → hide all MCP UI entry points, MCP API still functional

Combined visibility: **`isMcpVisible = mcp_exposure_enabled !== false && mcp_in_menu_enabled !== false`**

### MCP Toolkit Identification
- **Remote / custom MCPs**: `type === 'mcp'`
- **Pre-built MCPs**: `type` starts with `MCP_PREBUILD_PREFIX` (`'mcp_'`) — e.g. `mcp_github`, `mcp_jira`
- **Pipeline node MCPs**: detected via `meta.mcp === true`

All three cases are handled by the shared `isMcpToolkit` / `isMcpToolkitType` helpers.

---

## Data Flow

1. Admin sets toggles in Admin Portal → `PUT /api/v2/admin/plugin_config_values/administration/guardrails`
2. Backend fires `bootstrap_runtime_update` event → writes updated YAML to `/data/configs/elitea_core.yml` → calls `descriptor.load_config()` → calls `descriptor.module.reconfig()`
3. `elitea_core/module.py` `reconfig()` refreshes cached `self.mcp_exposure_enabled` / `self.mcp_in_menu_enabled`
4. Platform Settings API (`GET /api/v2/elitea_core/platform_settings/prompt_lib`) returns both to the UI
5. `EliteaUI` reads via `useGetPlatformSettingsQuery()` from `@/api/platformSettings`

---

## Entry Points Coverage After Changes

| Entry Point | `mcp_exposure_enabled = false` | `mcp_in_menu_enabled = false` |
|---|---|---|
| SSE/HTTP MCP API endpoints | Blocked (403) — preserved | Allowed — unchanged |
| MCP DCR / OAuth / sync-tools API endpoints | Blocked (403) | Allowed |
| MCP chat injection (`inject_mcp_toolkits`) | Skipped | Allowed |
| Sidebar MCPs menu item | Hidden | Hidden |
| "Make available by MCP" checkbox in Toolkit form | Hidden | Hidden |
| "Elitea MCP Tools" in Agent Tools (internal tools) | Hidden | Hidden |
| "Elitea MCP Tools" in Chat options (config button) | Hidden | Hidden |
| MCP section in Chat Participants panel | Hidden | Hidden |
| Pre-configured MCPs in Agent Tools list | Hidden | Hidden |
| MCP button in Agent/Application tool menu | Hidden | Hidden |
| MCPs in Chat slash-mention suggestions | Hidden | Hidden |
| MCPs in slash-mention participant toolkits | Hidden | Hidden |
| Pre-configured MCPs in toolkit dropdown (Participants) | Hidden | Hidden |
| Pre-configured MCPs in toolkit list (ToolkitsList) | Hidden | Hidden |
| Pre-configured MCPs in new chat toolkit menu | Hidden | Hidden |
| MCP toolkits in Pipeline ToolSelect | Hidden | Hidden |

---

## Repository Changes

### Repository 1: `elitea_core`

#### File: `elitea_core/admin_schema.json`

**Change 1:** Update `mcp_enabled` description (line ~102):

```json
// BEFORE
"description": "Master switch for MCP (Model Context Protocol) exposure. When disabled, the MCP checkbox is hidden in toolkit UI and all MCP SSE endpoints return 403.",

// AFTER
"description": "Master switch for MCP (Model Context Protocol). When disabled, removes all MCP-related functionality across the entire application including API endpoints and all UI entry points.",
```

**Change 2:** Rename `mcp_in_menu` title and update description (lines ~110–111):

```json
// BEFORE
"title": "Show MCPs in Sidebar",
"description": "Controls whether the MCPs menu item is visible in sidebar navigation.",

// AFTER
"title": "Show MCPs in UI",
"description": "When disabled, hides all MCP entry points across the UI (sidebar, Agent Tools, Pipeline Tools, Toolkit creation, Chat options, Chat Participants) while keeping MCP API functionality intact.",
```

---

#### File: `elitea_core/module.py`

**Change:** Add MCP cache refresh inside the existing `reconfig()` method so that admin toggle changes take effect immediately (live-reload via `bootstrap_runtime_update`) without requiring a container restart.

```python
# BEFORE
def reconfig(self):
    """Re-config"""
    self._configure_elitea_ui()
    self._apply_scheduler_runtime_config()

# AFTER
def reconfig(self):
    """Re-config"""
    self._configure_elitea_ui()
    self._apply_scheduler_runtime_config()
    # Refresh cached MCP exposure settings so admin toggle changes take
    # effect immediately without requiring a container restart.
    mcp_config = self.descriptor.config.get('mcp_exposure', {})
    self.mcp_exposure_enabled = mcp_config.get('enabled', True)
    self.mcp_in_menu_enabled = mcp_config.get('in_menu', True)
    log.info(f"MCP config reloaded: exposure={self.mcp_exposure_enabled}, in_menu={self.mcp_in_menu_enabled}")
```

**Why this works:** When admin saves a toggle change, `bootstrap_runtime_update` fires → pylon bootstrap writes the new YAML to disk AND calls `descriptor.module.reconfig()`. Without this fix, `reconfig()` never updated the cached MCP values, so `is_mcp_exposure_enabled()` / `is_mcp_in_menu_enabled()` always returned the stale startup values.

---

#### File: `elitea_core/api/v2/mcp_dcr_proxy.py`

Gate the DCR proxy endpoint on `is_mcp_exposure_enabled()`:

```python
from ...utils.mcp_config import is_mcp_exposure_enabled

def post(self, project_id: int, **kwargs):
    if not is_mcp_exposure_enabled():
        return {"error": "MCP exposure is disabled on this deployment"}, 403
    # ... rest of method
```

---

#### File: `elitea_core/api/v2/mcp_oauth_proxy.py`

Gate the OAuth proxy endpoint on `is_mcp_exposure_enabled()` (same pattern as above).

---

#### File: `elitea_core/api/v2/mcp_sync_tools.py`

Gate already present — preserved unchanged.

---

#### File: `elitea_core/utils/internal_tools.py`

Skip MCP toolkit injection when master switch is off:

```python
def inject_mcp_toolkits(user_id, internal_tools=None):
    if not is_mcp_exposure_enabled():
        log.debug("MCP exposure is disabled, skipping MCP injection")
        return []
    # ... rest of function
```

---

### Repository 2: `EliteaUI`

#### Shared Helpers and Hooks

##### File (new): `src/[fsd]/shared/lib/helpers/mcp.helpers.js`

Pure predicate functions used by all filter sites. `MCP_PREBUILD_PREFIX` is imported from the existing `McpAuthConstants` to avoid duplication.

```js
import { McpAuthConstants } from '@/[fsd]/features/mcp/lib/constants';

/**
 * Returns true if the given type string identifies an MCP toolkit.
 * Covers both remote MCPs ('mcp') and pre-built MCPs ('mcp_*').
 */
export const isMcpToolkitType = type =>
  type === 'mcp' || Boolean(type?.startsWith(McpAuthConstants.MCP_PREBUILD_PREFIX));

/**
 * Returns true if the given toolkit item is an MCP toolkit.
 * Checks item.type and item.meta.mcp (used by pipeline nodes).
 */
export const isMcpToolkit = item =>
  isMcpToolkitType(item?.type) || item?.meta?.mcp === true;
```

---

##### File: `src/[fsd]/shared/lib/helpers/index.js`

Add named exports at the end:

```js
export { isMcpToolkitType, isMcpToolkit } from './mcp.helpers';
```

---

##### File: `src/[fsd]/shared/lib/hooks/useMcpVisibility.hooks.js`

Add `useMcpFilter` hook alongside `useIsMcpVisible`:

```js
import { useCallback } from 'react';
import { useGetPlatformSettingsQuery } from '@/api/platformSettings';
import { isMcpToolkit } from '@/[fsd]/shared/lib/helpers/mcp.helpers';

export const useIsMcpVisible = () => {
  const { data: platformSettings } = useGetPlatformSettingsQuery();
  return (
    platformSettings?.mcp_exposure_enabled !== false &&
    platformSettings?.mcp_in_menu_enabled !== false
  );
};

/**
 * Returns a stable filter predicate: item => isMcpVisible || !isMcpToolkit(item).
 * Use this to filter toolkit arrays — replaces the repeated inline pattern.
 */
export const useMcpFilter = () => {
  const isMcpVisible = useIsMcpVisible();
  return useCallback(item => isMcpVisible || !isMcpToolkit(item), [isMcpVisible]);
};
```

Both hooks are already re-exported via `src/[fsd]/shared/lib/hooks/index.js`.

---

#### Component-level Changes

The table below shows the import additions and filter replacements in each component.

| File | Added import | Filter change |
|---|---|---|
| `SidebarBody.jsx` | `useIsMcpVisible` | `mcp_in_menu_enabled === false` → `!isMcpVisible` |
| `ToolBase/ToolBase.jsx` | `useIsMcpVisible` | inline derivation → `useIsMcpVisible()` |
| `useAvailableInternalTools.hooks.js` | `useIsMcpVisible` | filter `tool.name === 'internal_mcp' && !isMcpVisible` |
| `ApplicationTools.jsx` | `isMcpToolkit` | `!tool.meta?.mcp && type !== 'mcp' && !type.startsWith('mcp_')` → `!isMcpToolkit(tool)` |
| `ToolMenu.jsx` | `useIsMcpVisible` | wrap MCP button + dropdown in `{isMcpVisible && ...}` |
| `SlashSuggestionList.jsx` | `isMcpToolkit` | `p.type === 'mcp' \|\| p.type.startsWith('mcp_')` → `isMcpToolkit(p)` (×2, incl. `isMcp` local var) |
| `useSlashMention.hooks.js` | `isMcpToolkitType` | `toolkitType !== 'mcp' && !startsWith('mcp_')` → `!isMcpToolkitType(toolkitType)` |
| `Participants.jsx` | `isMcpToolkitType` | `startsWith('mcp_')` patterns → `isMcpToolkitType(...)` (×2); MCP section wrapped in `{isMcpVisible && ...}` |
| `useDropdownData.jsx` | `isMcpToolkit` | `!item.type?.startsWith('mcp_')` → `!isMcpToolkit(item)` |
| `ToolkitsList.jsx` | `isMcpToolkit` | `!item.type?.startsWith('mcp_')` → `!isMcpToolkit(item)` |
| `ToolkitTypeSelector.jsx` | `useIsMcpVisible` | `if (isMCP && !isMcpVisible) return null` |
| `ToolSelect.jsx` (pipeline) | `isMcpToolkit` | `!tool.meta?.mcp` → `!isMcpToolkit(tool)` |

---

---

## Additional Fix: Plugin Hot-Reload Support

After the initial implementation, a second bug was identified: clicking **Reload** in the Admin Portal (plugin hot-reload, not full container restart) did not apply config changes. Three separate root causes were found and fixed.

### Root cause 1 — `RuntimeError: Tool is already registered: elitea_config`

**File:** `elitea_core/module.py` (inside `init()`)

Pylon's hot-reload creates a new `Module` instance and calls `init()` on it. The `register_tool('elitea_config', ...)` call in `init()` raised `RuntimeError` because the tool was already registered by the previous module instance.

**Fix:** Unregister before registering, silently ignoring the case where it is not yet registered on first startup.

```python
# BEFORE
self.descriptor.register_tool('elitea_config', self.descriptor.config)

# AFTER
# Unregister first to handle hot-reload (pylon does not always call deinit on old module)
try:
    self.descriptor.unregister_tool('elitea_config')
except RuntimeError:
    pass  # Not yet registered on first startup
self.descriptor.register_tool('elitea_config', self.descriptor.config)
```

---

### Root cause 2 — `InvalidRequestError: Table 'elitea_core_descriptor' is already defined`

**File:** `elitea_core/db/models/providers.py`

Pylon's hot-reload clears `plugins.elitea_core.*` from `sys.modules` and reimports them. SQLAlchemy's `MetaData` already holds the table definition from the previous import and raises an error when the same table is defined again.

**Fix:** Add `extend_existing: True` to `__table_args__`.

```python
# BEFORE
class ProviderDescriptor(this.db.Base):
    __tablename__ = f"{this.module_name}_descriptor"

    provider = Column(Text, primary_key=True)
    descriptor = Column(LargeBinary, unique=False, default=b"")

# AFTER
class ProviderDescriptor(this.db.Base):
    __tablename__ = f"{this.module_name}_descriptor"
    __table_args__ = {"extend_existing": True}

    provider = Column(Text, primary_key=True)
    descriptor = Column(LargeBinary, unique=False, default=b"")
```

---

### Root cause 3 — API returns stale `mcp_in_menu_enabled: true` after reload

**File:** `elitea_core/utils/mcp_config.py`

Even after a successful reload (with the above two fixes applied), the Platform Settings API still returned the old value.

**Root cause:** Pylon's `This` class caches a `ModuleThis` instance per plugin. That `ModuleThis` stores `self.descriptor` at construction time:

```python
# pylon/core/tools/module/this.py
class ModuleThis:
    def __init__(self, context, spaces, module_name):
        self.descriptor = self.context.module_manager.descriptors[self.module_name]
        ...

    @property
    def module(self):
        return self.descriptor.module  # <-- uses the cached, stale descriptor
```

After hot-reload:
- `context.module_manager.descriptors["elitea_core"]` → new descriptor (with updated module)
- `cached_ModuleThis.descriptor` → old descriptor (stale reference, never updated)
- `this.module` → `old_descriptor.module` → old Module instance with `mcp_in_menu_enabled = True`

`this.context` and `this.context.module_manager` are not stale — only the pre-cached `ModuleThis.descriptor` is.

**Fix:** Bypass the stale cached descriptor by looking up the current one directly from the module manager.

```python
# BEFORE
def is_mcp_exposure_enabled() -> bool:
    return getattr(this.module, 'mcp_exposure_enabled', True)

def is_mcp_in_menu_enabled() -> bool:
    return getattr(this.module, 'mcp_in_menu_enabled', True)

# AFTER
def _current_module():
    # this.module resolves via a cached ModuleThis whose .descriptor is set at construction time.
    # After a hot-reload, that cached descriptor still points to the old module instance.
    # Bypass the cache by looking up the current descriptor directly from the module manager.
    try:
        descriptor = this.context.module_manager.descriptors[this.module_name]
        return descriptor.module
    except Exception:  # pylint: disable=W0703
        return None

def is_mcp_exposure_enabled() -> bool:
    return getattr(_current_module(), 'mcp_exposure_enabled', True)

def is_mcp_in_menu_enabled() -> bool:
    return getattr(_current_module(), 'mcp_in_menu_enabled', True)
```

---

## Notes

- The `reconfig()` fix handles the **Save** path (config updated without reload): `bootstrap_runtime_update` event → `reconfig()` → attributes updated on the live module instance → `_current_module()` returns that same instance → API returns correct value.
- The `_current_module()` fix handles the **Reload** path (plugin hot-reloaded): a new module instance is created with fresh attributes → `_current_module()` fetches it from the current descriptor → API returns correct value.
- The `visible_when` condition in `admin_schema.json` (line ~116) already hides the `mcp_in_menu` toggle when `mcp_enabled` is false — preserved.
- Existing pipeline nodes with `type === 'mcp'` still render correctly; the filter only removes them from the `ToolSelect` add-new-tool dropdown.
- `useMcpFilter()` is available for future filter sites that work on toolkit item arrays. Components that also need the boolean for JSX gating should keep `useIsMcpVisible()`.
