### PR TITLE
fix: [EL-5242] prevent 404 on last bucket deletion and show empty state

### DIFF
--- a/src/pages/Artifacts/Artifacts.jsx
+++ b/src/pages/Artifacts/Artifacts.jsx
@@ -22,6 +22,7 @@ import { actions } from '@/slices/artifact';
 
 import Buckets from './Components/Buckets';
 import ArtifactTable from './component/ArtifactTable';
+import ArtifactTableNoFiles from './component/ArtifactTableNoFiles';
 import DuplicateDialogContent from './component/DuplicateDialogContent';
 import UploadPathDialog from './component/UploadPathDialog';
 import UploadingStatus from './component/UploadingStatus';
@@ -94,12 +95,14 @@ const Artifacts = memo(() => {
 
   // Bucket data will be provided by Buckets component via callback
   const [allBuckets, setAllBuckets] = useState([]);
+  const [isBucketsFetching, setIsBucketsFetching] = useState(false);
   const [refetchBuckets, setRefetchBuckets] = useState(() => () => {});
 
   // Callback to receive bucket data from Buckets component
-  const onBucketsDataChange = useCallback((buckets, refetchFunction) => {
+  const onBucketsDataChange = useCallback(({ buckets, refetch, isFetching }) => {
     setAllBuckets(buckets);
-    setRefetchBuckets(() => refetchFunction);
+    setRefetchBuckets(() => refetch);
+    setIsBucketsFetching(isFetching ?? false);
   }, []);
 
   const { data: configurationsResponse = {}, isSuccess } = useGetConfigurationsListQuery(
@@ -469,6 +472,7 @@ const Artifacts = memo(() => {
         allBuckets.length > 0 &&
         !queryParams.selectedBucket &&
         !isHandlingNavigationState &&
+        !isBucketsFetching &&
         queryParams.configurationTitle
       ) {
         let bucketToSelect = null;
@@ -508,6 +512,7 @@ const Artifacts = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       allBuckets,
+      isBucketsFetching,
       isHandlingNavigationState,
       queryParams.configurationTitle,
       queryParams.projectId,
@@ -686,7 +691,7 @@ const Artifacts = memo(() => {
                   onUnsavedChangesUpdate={onUnsavedChangesUpdate}
                 />
               </Box>
-            ) : (
+            ) : queryParams.selectedBucket ? (
               <Box sx={styles.contentBox}>
                 <ArtifactTable
                   bucket={queryParams.selectedBucket?.name}
@@ -699,6 +704,10 @@ const Artifacts = memo(() => {
                   onPrefixChange={handlePrefixChange}
                   onUploadRequest={handleTableUploadRequest}
                 />
+              </Box>
+            ) : (
+              <Box sx={styles.contentBox}>
+                <ArtifactTableNoFiles message="No buckets created yet" />
               </Box>
             )}
           </Box>

--- a/src/pages/Artifacts/Components/Buckets.jsx
+++ b/src/pages/Artifacts/Components/Buckets.jsx
@@ -56,6 +56,7 @@ const Buckets = memo(props => {
     isError,
     error,
     isLoading: isLoadingBuckets,
+    isFetching: isBucketsRefreshing,
     refetch,
   } = useBucketListQuery(
     {
@@ -104,16 +105,13 @@ const Buckets = memo(props => {
   // Provide bucket data to parent component
   useEffect(() => {
     if (onBucketsDataChange) {
-      onBucketsDataChange(buckets, refetch);
+      onBucketsDataChange({
+        buckets,
+        refetch,
+        isFetching: isBucketsRefreshing || isLoadingBuckets,
+      });
     }
-    // eslint-disable-next-line no-console
-    console.info('[Buckets] query state:', {
-      isLoadingBuckets,
-      isError,
-      bucketsCount: buckets?.length || 0,
-      dataPresent: !!data,
-    });
-  }, [buckets, refetch, onBucketsDataChange, isLoadingBuckets, isError, data]);
+  }, [buckets, refetch, onBucketsDataChange, isLoadingBuckets, isBucketsRefreshing]);
 
   // Handle bucket edit navigation
   const handleEdit = useCallback(
@@ -194,7 +192,6 @@ const Buckets = memo(props => {
         }
       }
 
-      // Clear the deleting bucket tracker
       setDeletingBucket(null);
     }
   }, [isDeleteSuccess, deletingBucket, selectedBucket, buckets, onSelectBucket]);


### PR DESCRIPTION

# fix: [EL-5242] prevent 404 on last bucket deletion and show empty state
related to https://github.com/EliteaAI/elitea_issues/issues/5242

<img width="1151" height="828" alt="image" src="https://github.com/user-attachments/assets/9aab5199-758d-4bf4-b183-121e13ca805a" />

<img width="1410" height="722" alt="image" src="https://github.com/user-attachments/assets/44b8966a-6960-44d6-8d5a-a9756c8e2b2f" />


## Problem

When the only (last) bucket was deleted from the Artifacts page, the UI immediately sent a GET request to the
just-deleted bucket:

```
GET /artifacts/s3/<deleted-bucket>?project_id=36&format=json → 404 Not Found
```

The DELETE itself returned `200 OK {"message": "Deleted"}` correctly.

Additionally, after all buckets were removed the right panel showed a blank area instead of an empty state.

## Root Cause

A race condition between the delete-success handler and the parent auto-select effect in `Artifacts.jsx`:

1. `deleteBucket` succeeds → RTK Query invalidates `TAG_BUCKETS` and starts a refetch, but the cached bucket
   list still contains the deleted bucket.
2. The success effect schedules `onSelectBucket(null)` in a 100 ms timeout, clearing `selectedBucket` and the
   URL `?bucket=` param.
3. Before the refetch completes, the auto-select effect in `Artifacts.jsx` sees:
   - `allBuckets.length > 0` (stale cache)
   - `selectedBucket = null` (just cleared)
   - no `bucket` param in URL → re-selects the deleted bucket → `ArtifactTable` fires the 404 request.

## Fix

### `Buckets.jsx`

- Extract `isFetching` (aliased `isBucketsRefreshing`) from `useBucketListQuery`.
- Change `onBucketsDataChange` from positional args to a named object
  `{ buckets, refetch, isFetching }` — self-describing and easier to extend.
- Pass `isFetching: isBucketsRefreshing || isLoadingBuckets` so the parent knows
  whether any bucket-list network request is in-flight (`isLoading` covers the
  initial load; `isFetching` covers every subsequent re-fetch after cache
  invalidation).
- Remove `isError` and `data` from the effect dependency array — both are already
  captured via the `buckets` memo, so keeping them caused unnecessary extra calls
  to `onBucketsDataChange`.

### `Artifacts.jsx`

- Add `isBucketsFetching` state, populated from the new callback field.
- Guard the auto-select effect with `!isBucketsFetching`.
- Render `ArtifactTableNoFiles` ("No buckets created yet") in the right panel when
  `selectedBucket` is `null`, replacing the previous blank area.

When the deletion triggers a `TAG_BUCKETS` refetch, `isFetching = true` immediately
(even though `isLoading` stays `false` because cached data still exists in the RTK
Query cache). This sets `isBucketsFetching = true` in the parent before the 100 ms
timeout fires `onSelectBucket(null)`, so the auto-select condition is false throughout
the unsafe window. By the time the refetch completes with an empty list,
`allBuckets.length === 0`, so auto-select simply has nothing to select.

## Files Changed

- `src/pages/Artifacts/Components/Buckets.jsx`
- `src/pages/Artifacts/Artifacts.jsx`
