### PR TITLE
fix: [EL-5302] Removed "sss" Text in Chat Interface

### DIFF
--- a/src/[fsd]/features/chat/ui/chat-box/UserMessage.jsx
+++ b/src/[fsd]/features/chat/ui/chat-box/UserMessage.jsx
@@ -117,7 +117,7 @@ const UserMessage = React.forwardRef((props, ref) => {
                     variant="bodySmall"
                     sx={styles.sentToName(isSentToDummyParticipant)}
                   >
-                    {participantName} sss
+                    {participantName}
                   </Typography>
                 </StyledTooltip>
               </>


### PR DESCRIPTION
https://github.com/EliteaAI/elitea_issues/issues/5302

- Removed "sss" Text in Chat Interface

**BEFORE**
<img width="546" height="371" alt="image" src="https://github.com/user-attachments/assets/ca197384-65a1-4231-ba5a-0fab3677c277" />
**AFTER**
<img width="503" height="317" alt="image" src="https://github.com/user-attachments/assets/825f7609-f03f-41b7-879a-690a83fd218e" />

