### PR TITLE
fix: [EL-5305] add safety timeout to AI Assistant code-node streaming

### DIFF
--- a/src/[fsd]/features/pipelines/ai-assistant/lib/hooks/useAIContentGenerationStreaming.hooks.js
+++ b/src/[fsd]/features/pipelines/ai-assistant/lib/hooks/useAIContentGenerationStreaming.hooks.js
@@ -79,6 +79,12 @@ export const useAIContentGenerationStreaming = ({
   const chunkBufferRef = useRef([]);
   const rafPendingRef = useRef(false);
   const finalizeTimerRef = useRef(null);
+  const safetyTimerRef = useRef(null);
+
+  // Backstop: if no completion event arrives (events dropped, network drop,
+  // backend silently aborted), unblock the UI so the user is not stuck on
+  // "Thinking..." forever.
+  const SAFETY_TIMEOUT_MS = 60_000;
 
   useEffect(() => {
     toastErrorRef.current = toastError;
@@ -115,6 +121,8 @@ export const useAIContentGenerationStreaming = ({
     activeStreamIdRef.current = null;
     clearTimeout(finalizeTimerRef.current);
     finalizeTimerRef.current = null;
+    clearTimeout(safetyTimerRef.current);
+    safetyTimerRef.current = null;
 
     // Flush any remaining chunks and check for errors
     const remaining = chunkBufferRef.current.join('');
@@ -205,6 +213,8 @@ export const useAIContentGenerationStreaming = ({
       unsubscribe();
       clearTimeout(finalizeTimerRef.current);
       finalizeTimerRef.current = null;
+      clearTimeout(safetyTimerRef.current);
+      safetyTimerRef.current = null;
     };
   }, [subscribe, unsubscribe]);
 
@@ -222,6 +232,8 @@ export const useAIContentGenerationStreaming = ({
     chunkBufferRef.current = [];
     clearTimeout(finalizeTimerRef.current);
     finalizeTimerRef.current = null;
+    clearTimeout(safetyTimerRef.current);
+    safetyTimerRef.current = null;
   }, [projectId, stopLlmTask]);
 
   const generateContent = useCallback(
@@ -255,6 +267,16 @@ export const useAIContentGenerationStreaming = ({
         genTokenRef.current += 1;
         const myToken = genTokenRef.current;
         setIsGenerating(true);
+
+        clearTimeout(safetyTimerRef.current);
+        safetyTimerRef.current = setTimeout(() => {
+          if (activeStreamIdRef.current === streamId) {
+            toastErrorRef.current?.('AI assistant timed out: no response received. Please try again.');
+            setHasError(true);
+            finalize();
+          }
+        }, SAFETY_TIMEOUT_MS);
+
         const payload = {
           projectId,
           sid: socket.id,
@@ -289,6 +311,7 @@ export const useAIContentGenerationStreaming = ({
       socket?.id,
       resetContent,
       cancel,
+      finalize,
       fieldName,
       stateVariablesInfo,
       availableNodesInfo,


### PR DESCRIPTION
Refs: EliteaAI/elitea_issues#5305

## Summary

Defense-in-depth backstop for the bug where the AI Assistant in pipeline code-nodes shows "in progress" forever and never displays the LLM reply.

## Why this is needed

Previously the hook only cleared `isGenerating` in response to specific socket events (`AgentResponse`, `Error`, `LlmError`, `finish_reason` on chunks). If those events never arrived — backend silently dropped, network blip, **stream_id mismatch (the actual root cause being fixed in elitea_core)** — the spinner stayed forever with no signal to the user.

This PR adds a 60s safety timeout. If no completion event arrives, it toasts an error and finalizes the stream so the UI is unblocked and the user knows to retry.

This is a backstop, not the root-cause fix — the actual stream_id mismatch is fixed in EliteaAI/elitea_core#126. Keeping the timeout protects against future regressions of the same shape.

## Changes

- `useAIContentGenerationStreaming.hooks.js`: add `safetyTimerRef` and `SAFETY_TIMEOUT_MS = 60_000`.
- Set the timer when `generateContent` starts a new stream; clear it in `finalize`, `cancel`, and the unmount cleanup.
- On fire: toast `"AI assistant timed out: no response received. Please try again."`, set `hasError`, call `finalize`.

## Test plan

- [x] With a working backend (post-merge of companion PR), submit `Return {"test": True}` — reply streams normally and timer is cleared on `agent_response`
- [x] With BE intentionally producing no response, after 60s the user sees a clear error toast and the spinner stops