### PR TITLE
fix: [EL-5265] scope pipeline trigger restriction to the saved version

### DIFF
--- a/src/[fsd]/features/pipelines/flow-editor/ui/settings/TriggerTypeSelector.jsx
+++ b/src/[fsd]/features/pipelines/flow-editor/ui/settings/TriggerTypeSelector.jsx
@@ -1,12 +1,12 @@
-import { memo, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useFormikContext } from 'formik';
+import YAML from 'js-yaml';
 
 import LinkIcon from '@mui/icons-material/Link';
 import { Box, IconButton } from '@mui/material';
 
 import Tooltip from '@/ComponentsLib/Tooltip';
-import { FlowEditorContext } from '@/[fsd]/app/providers';
 import { PipelineNodeTypes } from '@/[fsd]/features/pipelines/flow-editor/lib/constants/flowEditor.constants';
 import { InfoLabelWithTooltip } from '@/[fsd]/shared/ui/label';
 import { SingleSelect } from '@/[fsd]/shared/ui/select';
@@ -48,27 +48,35 @@ const TriggerTypeSelector = memo(props => {
   const { toastSuccess, toastError } = useToast();
   const selectedProject = useSelectedProject();
   const { values } = useFormikContext();
-  const { yamlJsonObject } = useContext(FlowEditorContext);
 
   const versionId = values?.version_details?.id;
   const projectId = selectedProject?.id;
+  const versionInstructions = values?.version_details?.instructions;
 
-  // Check if pipeline has interactive nodes or interrupts that require Chat Message trigger
+  // Check if the saved version content has nodes/interrupts that require Chat Message trigger.
+  // We parse `version_details.instructions` (the saved YAML for this exact versionId) instead of
+  // the editor's working copy so the restriction tracks the version we're configuring the trigger
+  // for, not whatever pipeline is loaded in the flow editor or the user's unsaved edits.
   const hasInteractiveElements = useMemo(() => {
-    if (!yamlJsonObject) return false;
+    if (!versionInstructions) return false;
 
-    // Check for HITL or Printer nodes
-    const hasInteractiveNodes = yamlJsonObject.nodes?.some(node =>
-      INTERACTIVE_NODE_TYPES.includes(node.type),
-    );
+    let parsed;
+    try {
+      parsed = YAML.load(versionInstructions);
+    } catch {
+      return false;
+    }
+    if (!parsed) return false;
 
-    // Check for interrupt_before or interrupt_after
+    const hasInteractiveNodes =
+      Array.isArray(parsed.nodes) && parsed.nodes.some(node => INTERACTIVE_NODE_TYPES.includes(node?.type));
+
     const hasInterrupts =
-      (Array.isArray(yamlJsonObject.interrupt_before) && yamlJsonObject.interrupt_before.length > 0) ||
-      (Array.isArray(yamlJsonObject.interrupt_after) && yamlJsonObject.interrupt_after.length > 0);
+      (Array.isArray(parsed.interrupt_before) && parsed.interrupt_before.length > 0) ||
+      (Array.isArray(parsed.interrupt_after) && parsed.interrupt_after.length > 0);
 
     return hasInteractiveNodes || hasInterrupts;
-  }, [yamlJsonObject]);
+  }, [versionInstructions]);
 
   // Filter trigger options based on pipeline content
   const availableTriggerOptions = useMemo(() => {


### PR DESCRIPTION
## Summary

Fixes EliteaAI/elitea_issues#5265 — non-default pipeline versions lost their saved Schedule/Webhook trigger and were reset to Chat Message after reopening the pipeline.

The trigger UI derived its "interactive elements" check from the flow editor's working copy (`yamlJsonObject`), which always reflects the application's default version (the backend resolves `applicationDetails` to `Application.get_default_version()` with a `base` fallback). As a result, configuring a Schedule/Webhook on a non-default version was overwritten back to `chat_message` on reopen because the default version's HITL/Printer/interrupt content drove the restriction for every version.

The check now reads from the saved YAML of the exact `versionId` being configured (`values.version_details.instructions`), so each version's trigger options track its own content.

## Changes

- `EliteaUI/src/[fsd]/features/pipelines/flow-editor/ui/settings/TriggerTypeSelector.jsx`
  - Drop dependency on `FlowEditorContext` / `yamlJsonObject`.
  - Parse `values.version_details.instructions` to detect HITL/Printer nodes and `interrupt_before/after`.

## Test plan

- [x] Open a pipeline with multiple versions where one has Printer/HITL/interrupt and the others don't.
- [x] On the version with interactive elements → only **Chat Message** is selectable.
- [x] On a version without them → **Schedule** and **Webhook** are selectable, regardless of the default version.
- [x] Configure a Schedule on a non-default version, save, close & reopen → schedule is preserved.
- [x] Switching versions in the UI updates the trigger options to match the version being viewed.
